### PR TITLE
GO-3540: implement update operations

### DIFF
--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -221,7 +221,7 @@ func parseComp(key string, v *fastjson.Value) (f Filter, err error) {
 		Path: strings.Split(key, "."),
 	}
 	if v.Type() == fastjson.TypeObject {
-		if fk.Filter, err = ParseCompObj(v); err != nil {
+		if fk.Filter, err = parseCompObj(v); err != nil {
 			return nil, err
 		}
 	} else {
@@ -233,7 +233,7 @@ func parseComp(key string, v *fastjson.Value) (f Filter, err error) {
 	return fk, nil
 }
 
-func ParseCompObj(v *fastjson.Value) (Filter, error) {
+func parseCompObj(v *fastjson.Value) (Filter, error) {
 	hasCompOp, f, err := parseCompObjOp(v)
 	if err != nil {
 		return nil, err

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -227,7 +227,7 @@ func parseComp(key string, v *fastjson.Value) (f Filter, err error) {
 		Path: strings.Split(key, "."),
 	}
 	if v.Type() == fastjson.TypeObject {
-		if fk.Filter, err = parseCompObj(v); err != nil {
+		if fk.Filter, err = ParseCompObj(v); err != nil {
 			return nil, err
 		}
 	} else {
@@ -238,7 +238,7 @@ func parseComp(key string, v *fastjson.Value) (f Filter, err error) {
 	return fk, nil
 }
 
-func parseCompObj(v *fastjson.Value) (Filter, error) {
+func ParseCompObj(v *fastjson.Value) (Filter, error) {
 	hasCompOp, f, err := parseCompObjOp(v)
 	if err != nil {
 		return nil, err

--- a/query/modifier.go
+++ b/query/modifier.go
@@ -342,9 +342,6 @@ func (m modifierAddToSet) Modify(a *fastjson.Arena, v *fastjson.Value) (result *
 		if err != nil {
 			return nil, fmt.Errorf("failed to pop item, %w", err)
 		}
-		if len(arrayOfValues) == 0 {
-			return value, nil
-		}
 		arrayOfValues, modified = m.addElements(arrayOfValues, m.val)
 		return prepareNewArrayValue(a, arrayOfValues), nil
 	})

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -95,6 +95,12 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 				return
 			}
 			root = append(root, setMod...)
+		case bytes.Equal(key, opBytesPullAll):
+			var setMod modifierRoot
+			if setMod, err = parseMod(v, newPullAllModifier); err != nil {
+				return
+			}
+			root = append(root, setMod...)
 		default:
 			err = fmt.Errorf("unknown modifier '%s'", string(key))
 		}
@@ -177,6 +183,13 @@ func newPushModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 
 func newPullModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierPull{
+		fieldPath: strings.Split(string(key), "."),
+		val:       v,
+	}, nil
+}
+
+func newPullAllModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+	return modifierPullAll{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
 	}, nil

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -83,6 +83,18 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 				return
 			}
 			root = append(root, setMod...)
+		case bytes.Equal(key, opBytesPush):
+			var setMod modifierRoot
+			if setMod, err = parseMod(v, newPushModifier); err != nil {
+				return
+			}
+			root = append(root, setMod...)
+		case bytes.Equal(key, opBytesPull):
+			var setMod modifierRoot
+			if setMod, err = parseMod(v, newPullModifier); err != nil {
+				return
+			}
+			root = append(root, setMod...)
 		default:
 			err = fmt.Errorf("unknown modifier '%s'", string(key))
 		}
@@ -151,6 +163,20 @@ func newRenameModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 
 func newPopModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierPop{
+		fieldPath: strings.Split(string(key), "."),
+		val:       v,
+	}, nil
+}
+
+func newPushModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+	return modifierPush{
+		fieldPath: strings.Split(string(key), "."),
+		val:       v,
+	}, nil
+}
+
+func newPullModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+	return modifierPull{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
 	}, nil

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -72,37 +72,37 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesRename):
-			var setMod modifierRoot
+			var setMod ModifierChain
 			if setMod, err = parseMod(v, newRenameModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPop):
-			var setMod modifierRoot
+			var setMod ModifierChain
 			if setMod, err = parseMod(v, newPopModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPush):
-			var setMod modifierRoot
+			var setMod ModifierChain
 			if setMod, err = parseMod(v, newPushModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPull):
-			var setMod modifierRoot
+			var setMod ModifierChain
 			if setMod, err = parseMod(v, newPullModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPullAll):
-			var setMod modifierRoot
+			var setMod ModifierChain
 			if setMod, err = parseMod(v, newPullAllModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesAddToSet):
-			var setMod modifierRoot
+			var setMod ModifierChain
 			if setMod, err = parseMod(v, newAddToSetModifier); err != nil {
 				return
 			}
@@ -173,7 +173,7 @@ func newRenameModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	}
 	return modifierRename{
 		fieldPath: strings.Split(string(key), "."),
-		val:       string(stringBytes),
+		val:       strings.Split(string(stringBytes), "."),
 	}, nil
 }
 
@@ -181,6 +181,9 @@ func newPopModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	value, err := v.Int()
 	if err != nil {
 		return nil, fmt.Errorf("failed to pop item, %w", err)
+	}
+	if value != 1 && value != -1 {
+		return nil, fmt.Errorf("failed to pop item: wrong argument")
 	}
 	return modifierPop{
 		fieldPath: strings.Split(string(key), "."),

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -208,7 +208,7 @@ func newPullModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, err
 		equalBuf:  eb,
 	}
 	if v.Type() == fastjson.TypeObject {
-		pull.filter, err = ParseCompObj(v)
+		pull.filter, err = parseCompObj(v)
 		if err == nil {
 			return pull, nil
 		}

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -71,6 +71,12 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 				return
 			}
 			root = append(root, setMod...)
+		case bytes.Equal(key, opBytesRename):
+			var setMod modifierRoot
+			if setMod, err = parseMod(v, newRenameModifier); err != nil {
+				return
+			}
+			root = append(root, setMod...)
 		default:
 			err = fmt.Errorf("unknown modifier '%s'", string(key))
 		}
@@ -127,5 +133,12 @@ func newIncModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierInc{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v.GetFloat64(),
+	}, nil
+}
+
+func newRenameModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+	return modifierRename{
+		fieldPath: strings.Split(string(key), "."),
+		val:       v,
 	}, nil
 }

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -101,6 +101,12 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 				return
 			}
 			root = append(root, setMod...)
+		case bytes.Equal(key, opBytesAddToSet):
+			var setMod modifierRoot
+			if setMod, err = parseMod(v, newAddToSetModifier); err != nil {
+				return
+			}
+			root = append(root, setMod...)
 		default:
 			err = fmt.Errorf("unknown modifier '%s'", string(key))
 		}
@@ -190,6 +196,13 @@ func newPullModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 
 func newPullAllModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierPullAll{
+		fieldPath: strings.Split(string(key), "."),
+		val:       v,
+	}, nil
+}
+
+func newAddToSetModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+	return modifierAddToSet{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
 	}, nil

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -77,6 +77,12 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 				return
 			}
 			root = append(root, setMod...)
+		case bytes.Equal(key, opBytesPop):
+			var setMod modifierRoot
+			if setMod, err = parseMod(v, newPopModifier); err != nil {
+				return
+			}
+			root = append(root, setMod...)
 		default:
 			err = fmt.Errorf("unknown modifier '%s'", string(key))
 		}
@@ -138,6 +144,13 @@ func newIncModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 
 func newRenameModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierRename{
+		fieldPath: strings.Split(string(key), "."),
+		val:       v,
+	}, nil
+}
+
+func newPopModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+	return modifierPop{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
 	}, nil

--- a/query/modifier_parse.go
+++ b/query/modifier_parse.go
@@ -48,6 +48,7 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 		return nil, err
 	}
 	root := ModifierChain{}
+	eb := &equalBuf{}
 	obj.Visit(func(key []byte, v *fastjson.Value) {
 		if err != nil {
 			return
@@ -55,55 +56,55 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 		switch {
 		case bytes.Equal(key, opBytesSet):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newSetModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newSetModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesUnset):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newUnsetModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newUnsetModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesInc):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newIncModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newIncModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesRename):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newRenameModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newRenameModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPop):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newPopModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newPopModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPush):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newPushModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newPushModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPull):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newPullModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newPullModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesPullAll):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newPullAllModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newPullAllModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
 		case bytes.Equal(key, opBytesAddToSet):
 			var setMod ModifierChain
-			if setMod, err = parseMod(v, newAddToSetModifier); err != nil {
+			if setMod, err = parseMod(v, eb, newAddToSetModifier); err != nil {
 				return
 			}
 			root = append(root, setMod...)
@@ -120,7 +121,7 @@ func parseModRoot(v *fastjson.Value) (m Modifier, err error) {
 	return nil, fmt.Errorf("empty modifier")
 }
 
-func parseMod(v *fastjson.Value, create func(key []byte, val *fastjson.Value) (Modifier, error)) (root ModifierChain, err error) {
+func parseMod(v *fastjson.Value, eb *equalBuf, create func(key []byte, val *fastjson.Value, eb *equalBuf) (Modifier, error)) (root ModifierChain, err error) {
 	obj, err := v.Object()
 	if err != nil {
 		return nil, err
@@ -135,7 +136,7 @@ func parseMod(v *fastjson.Value, create func(key []byte, val *fastjson.Value) (M
 			return
 		}
 		var mod Modifier
-		if mod, err = create(key, v); err != nil {
+		if mod, err = create(key, v, eb); err != nil {
 			return
 		}
 		root = append(root, mod)
@@ -143,20 +144,21 @@ func parseMod(v *fastjson.Value, create func(key []byte, val *fastjson.Value) (M
 	return
 }
 
-func newSetModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newSetModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	return modifierSet{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
+		equalBuf:  eb,
 	}, nil
 }
 
-func newUnsetModifier(key []byte, _ *fastjson.Value) (Modifier, error) {
+func newUnsetModifier(key []byte, _ *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	return modifierUnset{
 		fieldPath: strings.Split(string(key), "."),
 	}, nil
 }
 
-func newIncModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newIncModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	if v.Type() != fastjson.TypeNumber {
 		return nil, fmt.Errorf("not numeric value for $inc in field '%s'", string(key))
 	}
@@ -166,7 +168,7 @@ func newIncModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	}, nil
 }
 
-func newRenameModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newRenameModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	stringBytes, err := v.StringBytes()
 	if err != nil {
 		return nil, fmt.Errorf("failed to rename field: %w", err)
@@ -174,10 +176,11 @@ func newRenameModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierRename{
 		fieldPath: strings.Split(string(key), "."),
 		val:       strings.Split(string(stringBytes), "."),
+		equalBuf:  eb,
 	}, nil
 }
 
-func newPopModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newPopModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	value, err := v.Int()
 	if err != nil {
 		return nil, fmt.Errorf("failed to pop item, %w", err)
@@ -191,17 +194,18 @@ func newPopModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	}, nil
 }
 
-func newPushModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newPushModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	return modifierPush{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
 	}, nil
 }
 
-func newPullModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newPullModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	var err error
 	pull := modifierPull{
 		fieldPath: strings.Split(string(key), "."),
+		equalBuf:  eb,
 	}
 	if v.Type() == fastjson.TypeObject {
 		pull.filter, err = ParseCompObj(v)
@@ -213,7 +217,7 @@ func newPullModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return pull, nil
 }
 
-func newPullAllModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newPullAllModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	removedValues, err := v.Array()
 	if err != nil {
 		return nil, fmt.Errorf("failed to pop item, %w", err)
@@ -221,12 +225,14 @@ func newPullAllModifier(key []byte, v *fastjson.Value) (Modifier, error) {
 	return modifierPullAll{
 		fieldPath:     strings.Split(string(key), "."),
 		removedValues: removedValues,
+		equalBuf:      eb,
 	}, nil
 }
 
-func newAddToSetModifier(key []byte, v *fastjson.Value) (Modifier, error) {
+func newAddToSetModifier(key []byte, v *fastjson.Value, eb *equalBuf) (Modifier, error) {
 	return modifierAddToSet{
 		fieldPath: strings.Split(string(key), "."),
 		val:       v,
+		equalBuf:  eb,
 	}, nil
 }

--- a/query/modifier_test.go
+++ b/query/modifier_test.go
@@ -265,7 +265,7 @@ func TestModifierRename_Modify(t *testing.T) {
 				`{"$rename":{"old":"old"}}`,
 				`{"old":"value"}`,
 				`{"old":"value"}`,
-				false,
+				true,
 			},
 			{
 				`{"$rename":{"old":"new"}}`,
@@ -277,6 +277,24 @@ func TestModifierRename_Modify(t *testing.T) {
 				`{"$rename":{"old":"new"}}`,
 				`{"old":"value", "new":"value1"}`,
 				`{"new":"value"}`,
+				true,
+			},
+			{
+				`{"$rename":{"old":"new.new1"}}`,
+				`{"old":"value"}`,
+				`{"new":{"new1":"value"}}`,
+				true,
+			},
+			{
+				`{"$rename":{"old":"new.new1"}}`,
+				`{"old":"value", "new":{"new1":"value"}}`,
+				`{"new":{"new1":"value"}}`,
+				false,
+			},
+			{
+				`{"$rename":{"old.old1":"new.new1"}}`,
+				`{"old": {"old1": "value"}}`,
+				`{"old":{},"new":{"new1":"value"}}`,
 				true,
 			},
 		}...)
@@ -539,6 +557,7 @@ func BenchmarkModifier(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
+			a.Reset()
 			_, _, err := modifier.Modify(a, d)
 			require.NoError(b, err)
 		}
@@ -555,6 +574,9 @@ func BenchmarkModifier(b *testing.B) {
 	})
 	b.Run("rename", func(b *testing.B) {
 		bench(b, `{"$rename":{"a":"b"}}`)
+	})
+	b.Run("rename - object", func(b *testing.B) {
+		bench(b, `{"$rename":{"a":"d.c"}}`)
 	})
 	b.Run("pull", func(b *testing.B) {
 		bench(b, `{"$pull":{"b":3}}`)

--- a/query/modifier_test.go
+++ b/query/modifier_test.go
@@ -251,3 +251,273 @@ func TestModifierInc_Modify(t *testing.T) {
 	})
 
 }
+
+func TestModifierRename_Modify(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		testModCases(t, []modifierCase{
+			{
+				`{"$rename":{"old":"new"}}`,
+				`{}`,
+				`{}`,
+				false,
+			},
+			{
+				`{"$rename":{"old":"old"}}`,
+				`{"old":"value"}`,
+				`{"old":"value"}`,
+				false,
+			},
+			{
+				`{"$rename":{"old":"new"}}`,
+				`{"old":"value"}`,
+				`{"new":"value"}`,
+				true,
+			},
+		}...)
+	})
+}
+
+func TestModifierPop_Modify(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		testModCases(t, []modifierCase{
+			{
+				`{"$pop":{"arr": -1}}`,
+				`{}`,
+				`{}`,
+				false,
+			},
+			{
+				`{"$pop":{"arr": -1}}`,
+				`{"arr": [1]}`,
+				`{"arr":[]}`,
+				true,
+			},
+			{
+				`{"$pop":{"arr": 1}}`,
+				`{"arr": [1]}`,
+				`{"arr":[]}`,
+				true,
+			},
+			{
+				`{"$pop":{"arr": -1}}`,
+				`{"arr": [1,2,3]}`,
+				`{"arr":[2,3]}`,
+				true,
+			},
+			{
+				`{"$pop":{"arr": 1}}`,
+				`{"arr": [1,2,3]}`,
+				`{"arr":[1,2]}`,
+				true,
+			},
+			{
+				`{"$pop":{"arr": 1}}`,
+				`{"arr": []}`,
+				`{"arr":[]}`,
+				false,
+			},
+		}...)
+	})
+	t.Run("error", func(t *testing.T) {
+		testModCasesErr(t, []modifierCaseError{
+			{
+				`{"$pop":{"arr":1}}`,
+				`{"arr":"2"}`,
+				`failed to pop item, value doesn't contain array; it contains string`,
+			},
+			{
+				`{"$pop":{"arr":""}}`,
+				`{"arr":[1,2]}`,
+				`failed to pop item, value doesn't contain number; it contains string`,
+			},
+			{
+				`{"$pop":{"arr":2}}`,
+				`{"arr":[1,2]}`,
+				`failed to pop item: wrong argument`,
+			},
+		}...)
+	})
+}
+
+func TestModifierPush_Modify(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		testModCases(t, []modifierCase{
+			{
+				`{"$push":{"arr": -1}}`,
+				`{}`,
+				`{}`,
+				false,
+			},
+			{
+				`{"$push":{"arr": 1}}`,
+				`{"arr": [1]}`,
+				`{"arr":[1,1]}`,
+				true,
+			},
+		}...)
+	})
+	t.Run("error", func(t *testing.T) {
+		testModCasesErr(t, []modifierCaseError{
+			{
+				`{"$push":{"arr":1}}`,
+				`{"arr":"2"}`,
+				`failed to pop item, value doesn't contain array; it contains string`,
+			},
+		}...)
+	})
+}
+
+func TestModifierPull_Modify(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		testModCases(t, []modifierCase{
+			{
+				`{"$pull":{"arr": 1}}`,
+				`{}`,
+				`{}`,
+				false,
+			},
+			{
+				`{"$pull":{"arr": 1}}`,
+				`{"arr": []}`,
+				`{"arr":[]}`,
+				false,
+			},
+			{
+				`{"$pull":{"arr": 1}}`,
+				`{"arr": [2, 3, 1, 4]}`,
+				`{"arr":[2,3,4]}`,
+				true,
+			},
+			{
+				`{"$pull":{"arr": 1}}`,
+				`{"arr": [2, 3, 4]}`,
+				`{"arr":[2,3,4]}`,
+				false,
+			},
+			{
+				`{"$pull":{"arr": {"id":"123","name":"one"}}}`,
+				`{"arr": [{"id":"123","name":"two"},{"id":"321","name":"one"},{"id":"123","name":"one"}]}`,
+				`{"arr":[{"id":"123","name":"two"},{"id":"321","name":"one"}]}`,
+				true,
+			},
+			{
+				`{"$pull":{"arr": {"$in":[2,6]}}}`,
+				`{"arr": [1,2,3,4,5,6,7]}`,
+				`{"arr":[1,3,4,5,7]}`,
+				true,
+			},
+			{
+				`{"$pull":{"arr": {"$gte":6}}}`,
+				`{"arr": [1,2,3,4,5,6,7]}`,
+				`{"arr":[1,2,3,4,5]}`,
+				true,
+			},
+			{
+				`{"$pull":{"arr": {"$gt":6}}}`,
+				`{"arr": [1,2,3,4,5,6,7]}`,
+				`{"arr":[1,2,3,4,5,6]}`,
+				true,
+			},
+			{
+				`{"$pull":{"arr": {"$lte":6}}}`,
+				`{"arr": [1,2,3,4,5,6,7]}`,
+				`{"arr":[7]}`,
+				true,
+			},
+			{
+				`{"$pull":{"arr": {"$lt":6}}}`,
+				`{"arr": [1,2,3,4,5,6,7]}`,
+				`{"arr":[6,7]}`,
+				true,
+			},
+		}...)
+	})
+	t.Run("error", func(t *testing.T) {
+		testModCasesErr(t, []modifierCaseError{
+			{
+				`{"$pull":{"arr":1}}`,
+				`{"arr":"2"}`,
+				`failed to pop item, value doesn't contain array; it contains string`,
+			},
+		}...)
+	})
+}
+
+func TestModifierPullAll_Modify(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		testModCases(t, []modifierCase{
+			{
+				`{"$pullAll":{"arr": [1]}}`,
+				`{}`,
+				`{}`,
+				false,
+			},
+			{
+				`{"$pullAll":{"arr": [1]}}`,
+				`{"arr": []}`,
+				`{"arr":[]}`,
+				false,
+			},
+			{
+				`{"$pullAll":{"arr": [1,2,3,4]}}`,
+				`{"arr": [1,2,3,4,5]}`,
+				`{"arr":[5]}`,
+				true,
+			},
+		}...)
+	})
+	t.Run("error", func(t *testing.T) {
+		testModCasesErr(t, []modifierCaseError{
+			{
+				`{"$pullAll":{"arr":1}}`,
+				`{"arr":"2"}`,
+				`failed to pop item, value doesn't contain array; it contains string`,
+			},
+			{
+				`{"$pullAll":{"arr":1}}`,
+				`{"arr":[1,2,3,4,5]}`,
+				`failed to pop item, value doesn't contain array; it contains number`,
+			},
+		}...)
+	})
+}
+
+func TestModifierAddToSet_Modify(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		testModCases(t, []modifierCase{
+			{
+				`{"$addToSet":{"arr": [1]}}`,
+				`{}`,
+				`{}`,
+				false,
+			},
+			{
+				`{"$addToSet":{"arr": [1]}}`,
+				`{"arr": []}`,
+				`{"arr":[[1]]}`,
+				true,
+			},
+			{
+				`{"$addToSet":{"arr": "test"}}`,
+				`{"arr": [1,2,3,4,5]}`,
+				`{"arr":[1,2,3,4,5,"test"]}`,
+				true,
+			},
+			{
+				`{"$addToSet":{"arr": 5}}`,
+				`{"arr": [1,2,3,4,5]}`,
+				`{"arr":[1,2,3,4,5]}`,
+				false,
+			},
+		}...)
+	})
+	t.Run("error", func(t *testing.T) {
+		testModCasesErr(t, []modifierCaseError{
+			{
+				`{"$addToSet":{"arr":1}}`,
+				`{"arr":"2"}`,
+				`failed to pop item, value doesn't contain array; it contains string`,
+			},
+		}...)
+	})
+}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3540/[anystore]-implement-update-operations

Implemented following update operations:

- $rename
- $pop
- $push
- $pull
- $pullAll
- $addToSet

Using mongo db reference https://www.mongodb.com/docs/manual/reference/operator/update/



