### PR TITLE
GO-5220 sqlite pre allocate page cache

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var defaultSQLiteOptions = map[string]string{
-	"cache_size": "100000",
+	"cache_size": "-2000", // negative value for kilobytes instead of pages
 }
 
 // Config provides the configuration options for the database.
@@ -22,10 +22,10 @@ type Config struct {
 	// corresponding to SQLite pragmas or other connection settings.
 	SQLiteConnectionOptions map[string]string
 
-	// PageCachePreallocateSize is the size of the page cache to preallocate.
-	// It is global, inited once and shared by all connections.
+	// SQLiteGlobalPageCachePreallocateSizeBytes is the size of the global page cache to preallocate.
+	// Initialised on the first call to NewConnManager and shared by all connections.
 	// default value is 10M
-	SQLitePageCachePreallocateSize int
+	SQLiteGlobalPageCachePreallocateSizeBytes int
 
 	// SyncPoolElementMaxSize defines maximum size of buffer that can be returned to the syncpool
 	// default value id 2MiB
@@ -46,8 +46,8 @@ func (c *Config) setDefaults() {
 		c.SyncPoolElementMaxSize = 2 << 20
 	}
 
-	if c.SQLitePageCachePreallocateSize <= 0 {
-		c.SQLitePageCachePreallocateSize = 10 << 20
+	if c.SQLiteGlobalPageCachePreallocateSizeBytes <= 0 {
+		c.SQLiteGlobalPageCachePreallocateSizeBytes = 10 << 20
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	// corresponding to SQLite pragmas or other connection settings.
 	SQLiteConnectionOptions map[string]string
 
+	// PageCachePreallocateSize is the size of the page cache to preallocate.
+	// It is global, inited once and shared by all connections.
+	// default value is 10M
+	SQLitePageCachePreallocateSize int
+
 	// SyncPoolElementMaxSize defines maximum size of buffer that can be returned to the syncpool
 	// default value id 2MiB
 	SyncPoolElementMaxSize int
@@ -39,6 +44,10 @@ func (c *Config) setDefaults() {
 	}
 	if c.SyncPoolElementMaxSize <= 0 {
 		c.SyncPoolElementMaxSize = 2 << 20
+	}
+
+	if c.SQLitePageCachePreallocateSize <= 0 {
+		c.SQLitePageCachePreallocateSize = 10 << 20
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	// SQLiteGlobalPageCachePreallocateSizeBytes is the size of the global page cache to preallocate.
 	// Initialised on the first call to NewConnManager and shared by all connections.
 	// default value is 10M
+	// set negative to disable preallocation
 	SQLiteGlobalPageCachePreallocateSizeBytes int
 
 	// SyncPoolElementMaxSize defines maximum size of buffer that can be returned to the syncpool
@@ -46,7 +47,7 @@ func (c *Config) setDefaults() {
 		c.SyncPoolElementMaxSize = 2 << 20
 	}
 
-	if c.SQLiteGlobalPageCachePreallocateSizeBytes <= 0 {
+	if c.SQLiteGlobalPageCachePreallocateSizeBytes == 0 {
 		c.SQLiteGlobalPageCachePreallocateSizeBytes = 10 << 20
 	}
 }

--- a/db.go
+++ b/db.go
@@ -109,10 +109,10 @@ func Open(ctx context.Context, path string, config *Config) (DB, error) {
 		config.pragma(),
 		1,
 		config.ReadConnections,
+		config.SQLitePageCachePreallocateSize,
 		ds.filterReg,
 		ds.sortReg,
 		2, // sqlite user_version
-		config.SQLitePageCachePreallocateSize,
 	); err != nil {
 		return nil, err
 	}

--- a/db.go
+++ b/db.go
@@ -112,6 +112,7 @@ func Open(ctx context.Context, path string, config *Config) (DB, error) {
 		ds.filterReg,
 		ds.sortReg,
 		2, // sqlite user_version
+		config.SQLitePageCachePreallocateSize,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/driver/sqlite.go
+++ b/internal/driver/sqlite.go
@@ -1,0 +1,68 @@
+package driver
+
+import (
+	"fmt"
+	"math"
+	"unsafe"
+
+	"modernc.org/libc"
+	"modernc.org/libc/sys/types"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+func sqlitePreallocatePageCache(tls *libc.TLS, pageCacheSize int) error {
+	if pageCacheSize > math.MaxInt32 {
+		return fmt.Errorf("sqlite: page cache size is too large")
+	}
+	p := libc.Xmalloc(tls, types.Size_t(pageCacheSize))
+	if p == 0 {
+		return fmt.Errorf("sqlite: cannot allocate memory")
+	}
+
+	headerSizeMem := libc.Xmalloc(tls, 4)
+	if headerSizeMem == 0 {
+		return fmt.Errorf("sqlite: cannot allocate memory for header size")
+	}
+	defer libc.Xfree(tls, headerSizeMem)
+
+	*(*int32)(unsafe.Pointer(headerSizeMem)) = 0
+
+	// Create a va_list containing the pointer to headerSize.
+	// Unlike SQLITE_CONFIG_SMALL_MALLOC (which takes an int value),
+	// SQLITE_CONFIG_PCACHE_HDRSZ expects a pointer to an int.
+	args := libc.NewVaList(headerSizeMem)
+	if args == 0 {
+		return fmt.Errorf("sqlite: get page cache header size: cannot allocate memory")
+	}
+	defer libc.Xfree(tls, args)
+
+	// Call sqlite3_config with SQLITE_CONFIG_PCACHE_HDRSZ.
+	rc := sqlite3.Xsqlite3_config(
+		tls,
+		sqlite3.SQLITE_CONFIG_PCACHE_HDRSZ,
+		args,
+	)
+	if rc != sqlite3.SQLITE_OK {
+		p := sqlite3.Xsqlite3_errstr(tls, rc)
+		str := libc.GoString(p)
+		return fmt.Errorf("sqlite: failed to get SQLITE_CONFIG_PCACHE_HDRSZ: %v", str)
+	}
+
+	headerSize := *(*int32)(unsafe.Pointer(headerSizeMem))
+	var sqlitePageSize int32 = sqlite3.SQLITE_DEFAULT_PAGE_SIZE // or your chosen SQLite page size
+	var sz = sqlitePageSize + headerSize                        // 4104 bytes
+	var n int32 = int32(pageCacheSize) / sz                     // number of cache lines
+
+	list := libc.NewVaList(p, sz, n)
+	rc = sqlite3.Xsqlite3_config(
+		tls,
+		sqlite3.SQLITE_CONFIG_PAGECACHE,
+		list,
+	)
+	if rc != sqlite3.SQLITE_OK {
+		p := sqlite3.Xsqlite3_errstr(tls, rc)
+		str := libc.GoString(p)
+		return fmt.Errorf("sqlite: failed to configure SQLITE_CONFIG_PAGECACHE: %v", str)
+	}
+	return nil
+}


### PR DESCRIPTION
- pre-allocate sqlite page cache
- change the default cache-size (was 100k pages). For kibibytes need to use negative value