### PR TITLE
Stalled connections detector in ConnManager

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package anystore
 
 import (
 	"runtime"
+	"time"
 )
 
 var defaultSQLiteOptions = map[string]string{
@@ -31,6 +32,12 @@ type Config struct {
 	// SyncPoolElementMaxSize defines maximum size of buffer that can be returned to the syncpool
 	// default value id 2MiB
 	SyncPoolElementMaxSize int
+
+	// StalledConnectionsDetectorEnabled enables the collection of stack traces and duration of acquired connections
+	// You can then use StalledConnections method of the ConnManager
+	StalledConnectionsDetectorEnabled bool
+	// StalledConnectionsPanicOnClose enables panic on Close in case of any connection is not released after this timeout
+	StalledConnectionsPanicOnClose time.Duration
 }
 
 func (c *Config) setDefaults() {

--- a/db.go
+++ b/db.go
@@ -113,6 +113,8 @@ func Open(ctx context.Context, path string, config *Config) (DB, error) {
 		ds.filterReg,
 		ds.sortReg,
 		2, // sqlite user_version
+		config.StalledConnectionsDetectorEnabled,
+		config.StalledConnectionsPanicOnClose,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/driver/manager.go
+++ b/internal/driver/manager.go
@@ -30,6 +30,8 @@ func NewConnManager(
 	preAllocatedPageCacheSize int,
 	fr *registry.FilterRegistry, sr *registry.SortRegistry,
 	version int,
+	enableStalledConnDetector bool,
+	stalledConnDetectorCloseTimeout time.Duration,
 ) (*ConnManager, error) {
 	_, statErr := os.Stat(path)
 	var newDb bool
@@ -93,12 +95,14 @@ func NewConnManager(
 	}
 
 	cm := &ConnManager{
-		readCh:                 make(chan *Conn, len(readConn)),
-		writeCh:                make(chan *Conn, len(writeConn)),
-		closed:                 make(chan struct{}),
-		readConn:               readConn,
-		writeConn:              writeConn,
-		stalledConnStackTraces: make(map[uintptr][]uintptr),
+		readCh:                          make(chan *Conn, len(readConn)),
+		writeCh:                         make(chan *Conn, len(writeConn)),
+		closed:                          make(chan struct{}),
+		readConn:                        readConn,
+		writeConn:                       writeConn,
+		stalledConnStackTraces:          make(map[uintptr][]uintptr),
+		stalledConnDetectorEnabled:      enableStalledConnDetector,
+		stalledConnDetectorCloseTimeout: stalledConnDetectorCloseTimeout,
 	}
 	for _, conn := range writeConn {
 		cm.writeCh <- conn

--- a/internal/driver/manager.go
+++ b/internal/driver/manager.go
@@ -226,10 +226,7 @@ func (c *ConnManager) Close() (err error) {
 
 	var conn *Conn
 	for range c.readConn {
-		select {
-		case conn = <-c.readCh:
-			break
-		}
+		conn = <-c.readCh
 		err = errors.Join(err, conn.Close())
 	}
 

--- a/internal/driver/manager_test.go
+++ b/internal/driver/manager_test.go
@@ -22,7 +22,7 @@ func TestNewConnManager(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	})
 	t.Run("open-close", func(t *testing.T) {
-		cm, err := NewConnManager(filepath.Join(tmpDir, "1.db"), nil, 1, 2, 10, fr, sr, 1)
+		cm, err := NewConnManager(filepath.Join(tmpDir, "1.db"), nil, 1, 2, 10, fr, sr, 1, false, 0)
 		require.NoError(t, err)
 		require.NoError(t, cm.Close())
 	})
@@ -30,14 +30,14 @@ func TestNewConnManager(t *testing.T) {
 		conn, err := sqlite.OpenConn(filepath.Join(tmpDir, "empty.db"), sqlite.OpenCreate|sqlite.OpenWAL|sqlite.OpenURI|sqlite.OpenReadWrite)
 		require.NoError(t, err)
 		_ = conn.Close()
-		_, err = NewConnManager(filepath.Join(tmpDir, "empty.db"), nil, 1, 2, 10, fr, sr, 1)
+		_, err = NewConnManager(filepath.Join(tmpDir, "empty.db"), nil, 1, 2, 10, fr, sr, 1, false, 0)
 		require.ErrorIs(t, err, ErrIncompatibleVersion)
 	})
 	t.Run("old version", func(t *testing.T) {
-		cm, err := NewConnManager(filepath.Join(tmpDir, "old.db"), nil, 1, 2, 10, fr, sr, 1)
+		cm, err := NewConnManager(filepath.Join(tmpDir, "old.db"), nil, 1, 2, 10, fr, sr, 1, false, 0)
 		require.NoError(t, err)
 		require.NoError(t, cm.Close())
-		_, err = NewConnManager(filepath.Join(tmpDir, "old.db"), nil, 1, 2, 10, fr, sr, 2)
+		_, err = NewConnManager(filepath.Join(tmpDir, "old.db"), nil, 1, 2, 10, fr, sr, 2, false, 0)
 		require.ErrorIs(t, err, ErrIncompatibleVersion)
 	})
 }

--- a/internal/driver/stalled.go
+++ b/internal/driver/stalled.go
@@ -1,0 +1,58 @@
+package driver
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// StalledConnections returns a list of stalled connections
+// works only if stalledConnDetectorEnabled is true
+func (c *ConnManager) StalledConnections(threshold time.Duration) (stalledTraces []string) {
+	if !c.stalledConnDetectorEnabled {
+		return
+	}
+	c.stalledConnStackMutex.Lock()
+	defer c.stalledConnStackMutex.Unlock()
+	for _, stack := range c.stalledConnStackTraces {
+		if time.Since(time.Unix(int64(stack[0]), 0)) > threshold {
+			duration, stackTrace := unpackStackWithFrames(stack)
+			if duration > threshold {
+				stalledTraces = append(stalledTraces, stackTrace)
+			}
+		}
+	}
+	return
+}
+
+// packStack returns a slice of uintptrs representing the current stack, 0-element used to store the current timestamp
+func packStack() []uintptr {
+	// Allocate space for up to 32(-1) stack frames; adjust as needed.
+	pcs := make([]uintptr, 32)
+	// use first element to store current timestamp
+	pcs[0] = uintptr(time.Now().Unix()) // on 32 bit systems it will not work after 2106, but who cares about 32 bit systems after 2106
+	// Skip the first two callers: runtime.Callers and captureStack.
+	n := runtime.Callers(2, pcs[1:31])
+	return pcs[:n]
+}
+
+func unpackStackWithFrames(stack []uintptr) (time.Duration, string) {
+	var (
+		s        strings.Builder
+		duration time.Duration
+	)
+	if stack[0] > 0 {
+		// first element is timestamp
+		duration = time.Since(time.Unix(int64(stack[0]), 0))
+	}
+	frames := runtime.CallersFrames(stack[1:])
+	for {
+		frame, more := frames.Next()
+		s.WriteString(fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line))
+		if !more {
+			break
+		}
+	}
+	return duration, s.String()
+}

--- a/internal/driver/stalled.go
+++ b/internal/driver/stalled.go
@@ -2,9 +2,11 @@ package driver
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"time"
+	"unsafe"
 )
 
 // StalledConnections returns a list of stalled connections
@@ -24,6 +26,43 @@ func (c *ConnManager) StalledConnections(threshold time.Duration) (stalledTraces
 		}
 	}
 	return
+}
+
+func (c *ConnManager) stalledAcquireConn(conn *Conn) {
+	if !c.stalledConnDetectorEnabled {
+		return
+	}
+	stack := packStack()
+	c.stalledConnStackMutex.Lock()
+	defer c.stalledConnStackMutex.Unlock()
+	c.stalledConnStackTraces[uintptr(unsafe.Pointer(conn))] = stack
+}
+
+func (c *ConnManager) stalledReleaseConn(conn *Conn) {
+	if !c.stalledConnDetectorEnabled {
+		return
+	}
+	c.stalledConnStackMutex.Lock()
+	defer c.stalledConnStackMutex.Unlock()
+	delete(c.stalledConnStackTraces, uintptr(unsafe.Pointer(conn)))
+}
+
+func (c *ConnManager) stalledCloseWatcher(allClosed chan struct{}) {
+	select {
+	case <-allClosed:
+		return
+	case <-time.After(c.stalledConnDetectorCloseTimeout):
+		_, _ = fmt.Fprintf(os.Stderr, "any-store: close failed because of stalled connections\n")
+		c.stalledConnStackMutex.Lock()
+		defer c.stalledConnStackMutex.Unlock()
+		for _, vals := range c.stalledConnStackTraces {
+			duration, stackTrace := unpackStackWithFrames(vals)
+			_, _ = fmt.Fprintf(os.Stderr, "any-store: stalled connection for %s:\n%s\n\n", duration.String(), stackTrace)
+		}
+		if len(c.stalledConnStackTraces) > 0 {
+			panic("any-store: stalled connections")
+		}
+	}
 }
 
 // packStack returns a slice of uintptrs representing the current stack, 0-element used to store the current timestamp


### PR DESCRIPTION
- collect stacktraces and timestamps
- added option for timeout on close. I went for Panic here because if we return the error we will have some leaked connections
- add method to get the current stalled connections with duration threshold

Todo: 
- decide how to pass options to ConnManager. Probably via db Config
- maybe it's better to go build flags approach to make the code cleaner