### PR TITLE
GO-6842 Fix race on close: wait for write conn to be released

### DIFF
--- a/internal/driver/manager.go
+++ b/internal/driver/manager.go
@@ -283,11 +283,14 @@ func (c *ConnManager) setupConn(conn *sqlite.Conn) (err error) {
 func (c *ConnManager) Close() (err error) {
 	close(c.closed)
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	for _, conn := range c.readConn {
 		err = errors.Join(err, conn.Close())
 	}
-	err = errors.Join(err, c.writeConn.Close())
-	c.mu.Unlock()
+	// Wait for the write connection to be returned to the channel.
+	// This ensures no active writer is using it before we close.
+	writeConn := <-c.writeCh
+	err = errors.Join(err, writeConn.Close())
 	return err
 }
 


### PR DESCRIPTION
## Summary
- `ConnManager.Close()` was closing the write connection directly via `c.writeConn.Close()` without waiting for an active writer to release it
- This caused `concurrent map iteration and map write` crash: `SetInterrupt` iterates `sqlite.Conn.stmts` while `Finalize` (from Close) deletes from it
- Fix: drain the write connection from the channel (`<-c.writeCh`), ensuring any in-flight write finishes before closing

## Test plan
- [x] All existing tests pass with `-race` flag
- [x] `TestDb_Close/race` passes consistently