### PR TITLE
chore(cli): bump any-store/v2 to v2.0.0-alpha.10

### DIFF
--- a/cmd/any-store-cli2/go.mod
+++ b/cmd/any-store-cli2/go.mod
@@ -3,7 +3,7 @@ module github.com/anyproto/any-store/cmd/any-store-cli2/v2
 go 1.25.0
 
 require (
-	github.com/anyproto/any-store/v2 v2.0.0-alpha.6
+	github.com/anyproto/any-store/v2 v2.0.0-alpha.10
 	github.com/fatih/color v1.18.0
 	github.com/peterh/liner v1.2.2
 	github.com/robertkrimen/otto v0.5.1

--- a/cmd/any-store-cli2/go.sum
+++ b/cmd/any-store-cli2/go.sum
@@ -1,5 +1,5 @@
-github.com/anyproto/any-store/v2 v2.0.0-alpha.6 h1:29/uLX9/U2313nLHRpXv4uPABX7deKjiE/wbNsfq0hE=
-github.com/anyproto/any-store/v2 v2.0.0-alpha.6/go.mod h1:ZWYzw07hxnCN9sPovwb0GIAKmk9QBrOLGQ/TLa4D0+8=
+github.com/anyproto/any-store/v2 v2.0.0-alpha.10 h1:Uu9kGfyQ1XZK+VxbIOlMvzM3k9tSehixyG9VeDJ07Og=
+github.com/anyproto/any-store/v2 v2.0.0-alpha.10/go.mod h1:ZWYzw07hxnCN9sPovwb0GIAKmk9QBrOLGQ/TLa4D0+8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

Bumps the CLI's `github.com/anyproto/any-store/v2` dependency from `v2.0.0-alpha.6` → `v2.0.0-alpha.10`, picking up the cross-process index/sketch staleness fixes merged in #112:

- Reconcile in-memory index set on schema-cookie bump (peer DDL — CREATE/DROP/recreate)
- Two-pointer CoW for the per-index selectivity sketch (writer-owned live + `atomic.Pointer` reader snapshot)
- Discard rolled-back sketch deltas at write-tx begin (no advisory-drift accumulation across rolled-back txs)
- Collection Drop deletes index namespaces from on-disk metadata

## Test plan

- [x] `go build ./...` in `cmd/any-store-cli2/` clean.
- [x] `go test ./...` passes.

Tag a `cmd/any-store-cli2/v2.0.0-alpha.10` after merge (matching prior cadence: `cmd/any-store-cli2/v2.0.0-alpha.4`, `…/v2.0.0-alpha.6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)