### PR TITLE
btree: exclusive DB-file lock for in-process mode (reject cross-process open)

### DIFF
--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -52,6 +52,23 @@ func openRegistryKey(path string) (string, error) {
 	return abs, nil
 }
 
+// registryKeyForOpenFile derives the openDBs key from an ALREADY-OPEN file
+// handle, preferring file identity (dev,ino) and falling back to the given
+// canonical/abs path when no inode is available (Windows/wasm or a VFS handle).
+// Using the open fd's Stat is correct even for a just-created file (the inode
+// now exists), unlike pre-open path stat. Shared by Open's registration and by
+// the pager's in-process exclusive-lock error path so both agree on the key.
+func registryKeyForOpenFile(f fileHandle, fallback string) string {
+	if f != nil {
+		if fi, err := f.Stat(); err == nil {
+			if key, ok := fileIdentityKey(fi); ok {
+				return key
+			}
+		}
+	}
+	return fallback
+}
+
 // Options configures the database.
 type Options struct {
 	PageSize  uint32 // Page size in bytes (default: 4096)
@@ -528,12 +545,7 @@ func Open(path string, opts Options) (*DB, error) {
 	// (os_unix.c:1282-1349). Falls back to the lexical canonical path when no
 	// inode is available (Windows/wasm, or a VFS-injected FileInfo).
 	if !opts.InMemory {
-		registryKey = canonicalPath
-		if fi, statErr := p.file.Stat(); statErr == nil {
-			if key, ok := fileIdentityKey(fi); ok {
-				registryKey = key
-			}
-		}
+		registryKey = registryKeyForOpenFile(p.file, canonicalPath)
 		if _, loaded := openDBs.LoadOrStore(registryKey, true); loaded {
 			_ = p.close()
 			// Clear so the deferred cleanup does not delete the entry that the

--- a/internal/btree/dbfile_lock_other.go
+++ b/internal/btree/dbfile_lock_other.go
@@ -1,12 +1,15 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package btree
 
-// Single-process stubs. On non-unix targets (wasm, Windows) any-store runs
-// with InProcess=true forced (db.go:201-204 via hasMmapShm=false), so these
-// lock primitives are dead code at runtime — but the pager open/close paths
-// reference them unconditionally, so they must still compile.
+// Single-process stubs for targets without a usable cross-process file lock
+// (wasm/js). These platforms run with InProcess=true forced (db.go via
+// hasMmapShm=false) and have no second-process notion, so all DB-file lock
+// primitives — including acquireExclusiveDBLock — are no-ops. They must still
+// compile because the pager open/close paths reference them unconditionally.
+// (Windows has its own real exclusive lock in dbfile_lock_windows.go.)
 
 func acquireSharedDBLock(_ fileHandle) error               { return nil }
 func tryUpgradeDBLockExclusive(_ fileHandle) (bool, error) { return true, nil }
 func downgradeDBLockToShared(_ fileHandle) error           { return nil }
+func acquireExclusiveDBLock(_ fileHandle) error            { return nil }

--- a/internal/btree/dbfile_lock_unix.go
+++ b/internal/btree/dbfile_lock_unix.go
@@ -35,6 +35,18 @@ func acquireSharedDBLock(fd fileHandle) error {
 	return flockNB(fd, syscall.LOCK_SH)
 }
 
+// acquireExclusiveDBLock takes a non-blocking EXCLUSIVE flock on fd, held for
+// the pager's lifetime (released when the fd is closed). Returns ErrBusy if any
+// other open file description — in this process or another — already holds a
+// lock on the file. Used by in-process mode (heap-backed SHM is process-local,
+// so the DB is single-handle): a second opener is rejected instead of silently
+// corrupting via a separate heap SHM. flock (per-description) is used rather
+// than fcntl so a failed second open in the same process, when it closes its
+// fd, does not release the first handle's lock.
+func acquireExclusiveDBLock(fd fileHandle) error {
+	return flockNB(fd, syscall.LOCK_EX)
+}
+
 // tryUpgradeDBLockExclusive attempts to upgrade the caller's shared flock
 // to exclusive. Returns (true, nil) if the upgrade succeeded (caller is
 // the only holder, safe to unlink shm / truncate WAL). Returns (false, nil)

--- a/internal/btree/dbfile_lock_windows.go
+++ b/internal/btree/dbfile_lock_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package btree
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// On Windows, mmap-backed WAL-index SHM is unavailable, so any-store forces
+// InProcess=true for file-backed databases (db.go via hasMmapShm=false). The
+// multi-process SHARED-lock protocol is therefore never exercised on Windows:
+// acquireSharedDBLock / tryUpgradeDBLockExclusive / downgradeDBLockToShared are
+// no-op stubs that must compile but never run.
+//
+// acquireExclusiveDBLock IS used: in-process mode is single-process only (heap
+// SHM is process-local), so on open it takes a non-blocking, whole-file
+// EXCLUSIVE lock via LockFileEx. A second process opening the same database is
+// rejected (mapped to ErrBusy -> ErrInProcessLocked by the caller) instead of
+// silently corrupting through a separate heap SHM. The lock is released when the
+// file handle is closed (CloseHandle releases all of a handle's locks).
+
+func acquireSharedDBLock(_ fileHandle) error               { return nil }
+func tryUpgradeDBLockExclusive(_ fileHandle) (bool, error) { return true, nil }
+func downgradeDBLockToShared(_ fileHandle) error           { return nil }
+
+func acquireExclusiveDBLock(fd fileHandle) error {
+	if fd == nil {
+		return fmt.Errorf("btree: dbfile lock: nil fd")
+	}
+	h := windows.Handle(fd.Fd())
+	// Lock the entire 64-bit file range, non-blocking + exclusive.
+	err := windows.LockFileEx(
+		h,
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		0xFFFFFFFF, // bytesLow
+		0xFFFFFFFF, // bytesHigh
+		&windows.Overlapped{},
+	)
+	if err != nil {
+		// Another handle (this or another process) holds an overlapping lock.
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+			return ErrBusy
+		}
+		return fmt.Errorf("btree: LockFileEx: %w", err)
+	}
+	return nil
+}

--- a/internal/btree/errors.go
+++ b/internal/btree/errors.go
@@ -74,6 +74,12 @@ var (
 	// ErrDatabaseOpen indicates the database file is already open in this process.
 	ErrDatabaseOpen = errors.New("btree: database already open in this process")
 
+	// ErrInProcessLocked indicates the database file is held by a DIFFERENT
+	// process. In-process mode uses heap-backed (process-local) WAL-index shared
+	// memory, so it is single-process only; on open it takes an exclusive
+	// whole-file lock and reports this error if another process already holds it.
+	ErrInProcessLocked = errors.New("btree: database is open by another process (in-process mode is single-process only)")
+
 	// ErrPageSlabNotInitialized indicates UsePageSlab was set but the global
 	// page slab was not initialized via ConfigPageCache.
 	ErrPageSlabNotInitialized = errors.New("btree: page slab not initialized (call ConfigPageCache first)")

--- a/internal/btree/inprocess_lock_test.go
+++ b/internal/btree/inprocess_lock_test.go
@@ -1,0 +1,98 @@
+//go:build unix
+
+package btree
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func inProcessOpts() Options {
+	opts := DefaultOptions()
+	opts.InProcess = true
+	return opts
+}
+
+// TestInProcess_CrossProcessLockRejected is the canonical regression: a
+// file-backed in-process DB uses heap-backed (process-local) SHM and is NOT
+// multi-process safe, so a second process opening the same file must be rejected
+// with ErrInProcessLocked — not silently allowed to corrupt via a separate heap
+// SHM. We simulate "another process" with an independent fd holding an exclusive
+// flock (flock treats separate file descriptions as separate holders, even in
+// the same process). Pre-fix, in-process mode skipped DB-file locking entirely,
+// so this Open SUCCEEDED (the bug); with the fix it returns ErrInProcessLocked.
+func TestInProcess_CrossProcessLockRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ip.db")
+
+	// Materialize a real DB, then close it (releases its lock + openDBs entry).
+	db, err := testOpen(t, path, inProcessOpts())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// "Another process" grabs the exclusive lock on the file.
+	peer, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer peer.Close()
+	require.NoError(t, syscall.Flock(int(peer.Fd()), syscall.LOCK_EX|syscall.LOCK_NB),
+		"peer should acquire exclusive lock on the closed DB")
+
+	// Opening in-process now must fail with the clear cross-process error.
+	_, err = testOpen(t, path, inProcessOpts())
+	require.ErrorIs(t, err, ErrInProcessLocked)
+
+	// And it must NOT be misreported as the same-process error.
+	require.NotErrorIs(t, err, ErrDatabaseOpen)
+}
+
+// TestInProcess_SameProcessDoubleOpenRejected: a second open of the same
+// in-process DB within this process is rejected with the established
+// ErrDatabaseOpen (the openDBs guard), distinct from the cross-process error.
+func TestInProcess_SameProcessDoubleOpenRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ip.db")
+
+	db1, err := testOpen(t, path, inProcessOpts())
+	require.NoError(t, err)
+	defer db1.Close()
+
+	_, err = testOpen(t, path, inProcessOpts())
+	require.ErrorIs(t, err, ErrDatabaseOpen)
+	require.NotErrorIs(t, err, ErrInProcessLocked)
+}
+
+// TestInProcess_LockReleasedOnClose: the exclusive lock is held only for the
+// pager's lifetime, so after Close a fresh open (or a peer) can acquire it.
+func TestInProcess_LockReleasedOnClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ip.db")
+
+	db1, err := testOpen(t, path, inProcessOpts())
+	require.NoError(t, err)
+	require.NoError(t, db1.Close())
+
+	db2, err := testOpen(t, path, inProcessOpts())
+	require.NoError(t, err, "reopen after close must succeed (lock released)")
+	require.NoError(t, db2.Close())
+}
+
+// TestInProcess_PeerCanOpenAfterClose: once the in-process holder closes, a peer
+// (another fd) can take the exclusive lock — proving the lock is not leaked.
+func TestInProcess_PeerCanOpenAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ip.db")
+
+	db, err := testOpen(t, path, inProcessOpts())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	peer, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer peer.Close()
+	require.NoError(t, syscall.Flock(int(peer.Fd()), syscall.LOCK_EX|syscall.LOCK_NB),
+		"peer must acquire the lock after the in-process holder closed")
+}

--- a/internal/btree/inprocess_lock_test.go
+++ b/internal/btree/inprocess_lock_test.go
@@ -96,3 +96,61 @@ func TestInProcess_PeerCanOpenAfterClose(t *testing.T) {
 	require.NoError(t, syscall.Flock(int(peer.Fd()), syscall.LOCK_EX|syscall.LOCK_NB),
 		"peer must acquire the lock after the in-process holder closed")
 }
+
+// --- Mixed mode (in-process vs multi-process mmap) ---------------------------
+//
+// anystore never opens the same file in both modes (Config exposes no InProcess;
+// mode is platform-derived: unix->mmap, Windows->in-process), so this is not a
+// user-reachable scenario. But if it ever happened — an mmap-mode process and an
+// in-process process on one file — it would be UNSAFE (one coordinates via the
+// mmap'd -shm, the other via heap SHM, with no shared coordination). The DB-file
+// locks must therefore be mutually exclusive: the second opener of either mode is
+// rejected rather than allowed to dual-open. (Before the exclusive-lock fix the
+// in-process side took no lock, so this dual-opened and corrupted.)
+
+// TestInProcess_RejectedWhilePeerHoldsShared: a multi-process (mmap) opener holds
+// a SHARED lock; an in-process open must be rejected with ErrInProcessLocked
+// (its exclusive lock cannot coexist with the peer's shared lock).
+func TestInProcess_RejectedWhilePeerHoldsShared(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mixed.db")
+
+	// Materialize a real DB, then close it.
+	db, err := testOpen(t, path, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Peer holds SHARED, as a multi-process mmap-mode opener would.
+	peer, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer peer.Close()
+	require.NoError(t, syscall.Flock(int(peer.Fd()), syscall.LOCK_SH|syscall.LOCK_NB))
+
+	_, err = testOpen(t, path, inProcessOpts())
+	require.ErrorIs(t, err, ErrInProcessLocked,
+		"in-process open must be rejected while an mmap-mode peer holds the shared lock")
+}
+
+// TestInProcess_MmapRejectedWhilePeerHoldsExclusive: an in-process opener holds an
+// EXCLUSIVE lock; a multi-process (mmap) open must be rejected (no dual-open).
+// The mmap path surfaces a generic busy-after-retries error rather than
+// ErrInProcessLocked, so we assert only that it is rejected — the safety property
+// is "no concurrent open across modes", not the specific message.
+func TestInProcess_MmapRejectedWhilePeerHoldsExclusive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mixed.db")
+
+	db, err := testOpen(t, path, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Peer holds EXCLUSIVE, as an in-process opener would.
+	peer, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer peer.Close()
+	require.NoError(t, syscall.Flock(int(peer.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+
+	got, err := testOpen(t, path, DefaultOptions()) // InProcess=false (mmap mode)
+	require.Error(t, err, "mmap open must be rejected while an in-process peer holds the exclusive lock")
+	require.Nil(t, got, "no DB handle must be returned on a rejected open")
+}

--- a/internal/btree/pager.go
+++ b/internal/btree/pager.go
@@ -417,14 +417,19 @@ func (p *pager) open() (err error) {
 	// match SQLite's lazy initialization in unixFetch (os_unix.c:5727).
 	p.dbMmap = newDBMmap(f, p.mmapSize)
 
-	// Acquire a shared flock on the DB file. Held for the lifetime of
-	// this pager. Any closer attempting to upgrade to exclusive will
-	// BUSY-retry while we hold this — serializing shm unlink against
-	// new-opener races. Matches SQLite's sqlite3PagerSharedLock + the
-	// wal.c:2508 EXCLUSIVE-for-close invariant.
+	// Acquire a DB-file flock, held for the lifetime of this pager and released
+	// when p.file is closed.
 	//
-	// Only applies to multi-process mode; in-process skips it (in-memory
-	// already returned above).
+	// Multi-process mmap mode takes a SHARED lock: concurrent processes are
+	// allowed and coordinated through the mmap'd -shm; any closer upgrading to
+	// exclusive BUSY-retries while we hold shared, serializing shm unlink against
+	// new-opener races (SQLite's sqlite3PagerSharedLock + wal.c:2508 invariant).
+	//
+	// In-process mode uses heap-backed, process-local SHM and is therefore
+	// single-process only, so it takes an EXCLUSIVE lock instead — a second
+	// opener (another process, or another handle in this process) is rejected
+	// with a clear error rather than silently corrupting via a separate heap SHM.
+	// (In-memory already returned above, so here p.inProcess implies file-backed.)
 	if !p.inProcess {
 		for attempt := 0; attempt < 100; attempt++ {
 			lockErr := acquireSharedDBLock(f)
@@ -442,6 +447,26 @@ func (p *pager) open() (err error) {
 				return fmt.Errorf("btree: DB-file lock still busy after retries (peer mid-close?)")
 			}
 			time.Sleep(10 * time.Millisecond)
+		}
+	} else {
+		if lockErr := acquireExclusiveDBLock(f); lockErr != nil {
+			if errors.Is(lockErr, ErrBusy) {
+				// Derive the registry key BEFORE closing f (inode identity needs
+				// the open fd). A same-process second open is already tracked in
+				// openDBs (the first handle registered after its own open) -> use
+				// the established ErrDatabaseOpen; a lock held by a DIFFERENT
+				// process is reported as ErrInProcessLocked.
+				key := registryKeyForOpenFile(f, p.path)
+				_ = f.Close()
+				p.file = nil
+				if _, here := openDBs.Load(key); here {
+					return ErrDatabaseOpen
+				}
+				return ErrInProcessLocked
+			}
+			_ = f.Close()
+			p.file = nil
+			return fmt.Errorf("btree: acquire DB-file exclusive lock: %w", lockErr)
 		}
 	}
 


### PR DESCRIPTION
## What
In-process mode (`Options.InProcess`) now takes a lifetime **exclusive** whole-file lock on open; a second opener of the same file is rejected instead of silently dual-opening.

## Why
In-process mode uses heap-backed, process-local WAL-index SHM, so it is **not multi-process safe** — two processes each get a separate heap SHM and corrupt each other. The pager previously **skipped DB-file locking entirely** in this mode. It is the default for file-backed DBs on platforms without mmap SHM (**Windows**), so a second Windows process could silently corrupt the database.

## Behavior
- Cross-process open → new exported `ErrInProcessLocked`.
- Same-process second open → existing `ErrDatabaseOpen` (unchanged; the lock failure consults the `openDBs` registry to distinguish).
- Multi-process mmap mode unchanged (shared lock — concurrent processes are intended).
- In-memory unaffected (returns before the lock section).
- Mixed mmap/in-process opens are mutually exclusive (either order rejected; previously they dual-opened → corruption).

## Platforms
- unix: `flock(LOCK_EX)`
- windows: `LockFileEx(EXCLUSIVE|FAIL_IMMEDIATELY)` — **cross-compile-checked only, not runtime-tested**; needs CI/Windows validation.
- wasm/other: no-op (single-process).

## Tests
`inprocess_lock_test.go` (unix): cross-process → `ErrInProcessLocked` (verified RED on pre-fix code), same-process → `ErrDatabaseOpen`, lock released on close, peer can open after close, and both mixed-mode directions. `go build ./...` and `GOOS=windows go build` pass.
