### PR TITLE
perf(btree): pool balance-path cell scratch to cut allocation churn

### DIFF
--- a/internal/btree/balance.go
+++ b/internal/btree/balance.go
@@ -386,11 +386,13 @@ func (bt *btree) balanceNonroot(parentPg *page, parentIdx int, isRoot bool, pare
 				poolFail(g)
 				return cerr
 			}
-			// collectInteriorCells self-recycles the pager's shared cellBuf
-			// (btree.go:1642), so non-overflow cell keys alias a buffer that the
-			// NEXT collectInteriorCells call (for the next gathered sibling) will
-			// overwrite. Clone every key into balance-owned memory before pooling
-			// so each sibling's keys survive the whole redistribution.
+			// The collectInteriorCells wrapper self-recycles its scratch buffer to
+			// the pager free-list, so non-overflow cell keys alias a buffer that the
+			// NEXT collectInteriorCells call (for the next gathered sibling) may
+			// reuse. Clone every key into balance-owned memory before pooling so each
+			// sibling's keys survive the whole redistribution. (rewriteParentAfter
+			// Balance avoids this clone by using collectInteriorCellsKeepBuf and
+			// holding the buffer across the rebuild instead.)
 			for j := range cells {
 				cells[j].key = bytes.Clone(cells[j].key)
 			}
@@ -806,27 +808,43 @@ func (bt *btree) rewriteParentAfterBalance(
 	// rebuildInteriorPage re-creates as needed — same contract as the existing
 	// interior split, btree.go:2023). After this the parent's old divider chains
 	// are gone; we rebuild from childPgnos + divKeys below.
-	parentCells, cerr := bt.collectInteriorCells(parentPg)
+	parentCells, parentBuf, cerr := bt.collectInteriorCellsKeepBuf(parentPg)
 	if cerr != nil {
 		// Caller (balanceNonroot) retains parentPg's pin; do not release it here,
 		// matching the ErrCorrupt path below. Propagate up the balance() do-loop
 		// (btree.c:9131-9242).
 		return cerr
 	}
+	// Hold the collected-cell scratch buffer for the whole rebuild so the parent's
+	// divider keys can be spliced by aliasing (oldDivs below) instead of cloning
+	// each one — the former per-divider bytes.Clone was the largest object
+	// producer of the index-build profile. parentBuf is read-only here (never
+	// appended to), so the aliases stay stable; the defer returns it to the
+	// free-list at every exit, after the parent rebuild(s) have consumed newCells.
+	// The promoted sepKey on the split path is independently cloned below, so it
+	// survives this recycle and the cascade up the tree.
+	defer bt.pager.recycleCellBuf(parentBuf)
 	nc := len(parentCells)
 	parentRightChild := parentPg.header.rightChild
 
-	// Old children (nc+1) and old divider keys (nc). Clone keys: collectInterior
-	// Cells self-recycles the shared cellBuf (btree.go:1642), so non-overflow
-	// keys would otherwise dangle once rebuildInteriorPage / the cascade re-takes
-	// the buffer.
+	// Old children (nc+1) and old divider keys (nc). oldDivs aliases parentBuf
+	// (non-overflow keys) / the freshly-read overflow keys — both valid until the
+	// deferred recycle above, which fires only after newCells is rebuilt.
 	oldChildren := make([]uint32, nc+1)
 	oldDivs := make([][]byte, nc)
 	for j := 0; j < nc; j++ {
 		oldChildren[j] = parentCells[j].leftChild
-		oldDivs[j] = bytes.Clone(parentCells[j].key)
+		oldDivs[j] = parentCells[j].key
 	}
 	oldChildren[nc] = parentRightChild
+
+	// parentCells (the descriptor slice) is fully consumed: every leftChild is
+	// copied into oldChildren and every key header aliased into oldDivs (the key
+	// BYTES live in parentBuf, recycled separately by the defer above). Return the
+	// slice to the pool now — before the divider splice and the cascade — so the
+	// next balanceNonroot up the tree can reuse it. recycleCellSlice clears the
+	// entries, which does not disturb oldDivs (it holds its own header copies).
+	bt.pager.recycleCellSlice(parentCells)
 
 	// Bounds: the gathered run children are [nxDiv, nxDiv+nOld); valid child
 	// slots are 0..nc. rightmostChildSlot == nxDiv+nOld-1.

--- a/internal/btree/balance_alloc_bench_test.go
+++ b/internal/btree/balance_alloc_bench_test.go
@@ -1,0 +1,71 @@
+package btree
+
+import (
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+)
+
+// numIVFCells approximates an IVF nlist for ~40k vectors (sqrt(n)-ish).
+const numIVFCells = 196
+
+// BenchmarkBalanceAlloc_IVFCellInterleaved reproduces the IVF-SQ :cell write
+// path allocation profile. The :cell key is cellID‖label and the build loop
+// iterates by label (build order), assigning each vector to its IVF cell — so
+// inserts are INTERLEAVED across many cell prefixes, not globally ascending.
+// That scatters inserts across many active rightmost-of-prefix leaves and drives
+// the GENERAL balanceNonroot sibling-gather path (collectLeafCells x3 per balance
+// + rewriteParentAfterBalance) — not the splitLeafRightmostAppend fast path a
+// single ascending stream would hit. Records are ~772 bytes (4 + 768 int8, fits
+// locally). Run with -benchmem / -memprofile to inspect the balance subtree.
+func BenchmarkBalanceAlloc_IVFCellInterleaved(b *testing.B) {
+	resetPageBufferPool()
+	dir := b.TempDir()
+	db, err := Open(filepath.Join(dir, "test.db"), Options{PageSize: 4096})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	tx, err := db.BeginWrite()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err = tx.CreateNamespace("cell"); err != nil {
+		b.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatal(err)
+	}
+
+	val := make([]byte, 772) // 4 + 768 int8, fits locally (no overflow)
+	tx, err = db.BeginWrite()
+	if err != nil {
+		b.Fatal(err)
+	}
+	ns, err := db.getNamespaceLocked("cell")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		// key = cellID‖label: round-robin the cell prefix so consecutive inserts
+		// land in different prefixes (interleaved), with the label ascending
+		// within each prefix — the real IVF-SQ :cell insert pattern.
+		cell := uint32(i % numIVFCells)
+		label := uint32(i / numIVFCells)
+		key := binary.BigEndian.AppendUint32(nil, cell)
+		key = binary.BigEndian.AppendUint32(key, label)
+		if err := tx.Put(ns, key, val); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.StopTimer()
+	if err := tx.Commit(); err != nil {
+		b.Fatal(err)
+	}
+}

--- a/internal/btree/btree.go
+++ b/internal/btree/btree.go
@@ -1575,11 +1575,13 @@ func (bt *btree) updateLeafCell(pg *page, idx int, key, value []byte, path []pat
 // This matches SQLite's balance_nonroot which never reads or frees overflow data during
 // rebalancing — overflow chains are only created/destroyed when cell content actually changes.
 //
-// Uses pager.cellBuf as reusable scratch space, modeled after SQLite's
-// Pager.pTmpSpace (pager.c). The buffer is "taken" from the pager on each call
-// and "returned" by the caller via pager.recycleCellBuf after the cells are
-// consumed. The take-and-nil pattern handles the merge path (two overlapping
-// calls) — the second call finds nil and allocates fresh.
+// Draws its scratch buffer and descriptor slice from the pager's bounded
+// free-lists (cellBufFree/cellSliceFree, SQLite Pager.pTmpSpace / apCell). The
+// buffer/slice are "taken" on each call and "returned" by the caller via
+// pager.recycleCellBuf/recycleCellSlice after the cells are consumed. The
+// free-list (rather than a single buffer) lets the balance path keep all NB
+// gathered siblings' buffers alive at once without falling back to make() — only
+// an empty free-list allocates fresh, and recycle folds that buffer back in.
 func (bt *btree) collectLeafCells(pg *page) ([]cellData, []byte, error) {
 	n := int(pg.header.cellCount)
 
@@ -1687,16 +1689,38 @@ func (bt *btree) cellFullKey(c *cellData) ([]byte, error) {
 	return fullKey, nil
 }
 
-// collectInteriorCells reads all cells from an interior page.
-// For cells with overflow keys, the full key is read from overflow pages
-// and the overflow chain is freed (since the caller will rebuild the page).
+// collectInteriorCellsKeepBuf reads all cells from an interior page and returns
+// the scratch content buffer to the caller INSTEAD of recycling it. Non-overflow
+// keys alias buf, so they stay valid for as long as the caller keeps buf alive;
+// the caller must return it via pager.recycleCellBuf when done.
 //
-// Uses pager.cellBuf as reusable scratch space (same buffer as collectLeafCells;
-// callers never interleave leaf and interior collection). Self-recycles the
-// buffer back to the pager at the end since interior collection never overlaps.
-func (bt *btree) collectInteriorCells(pg *page) ([]cellData, error) {
+// This is the lifetime contract the balance path needs: rewriteParentAfterBalance
+// splices the parent's existing divider keys into the rebuilt parent, and by
+// holding buf across the rebuild it can alias those keys directly instead of
+// cloning every one (the former per-divider bytes.Clone was the single largest
+// object producer of the index-build allocation profile). buf never grows past
+// the page content size (the total non-overflow key bytes are a subset of the
+// page content it was sized for), so the appends below never reallocate and the
+// returned aliases are stable.
+//
+// For cells with overflow keys the full key is read from overflow pages and the
+// overflow chain is freed (the caller will rebuild the page); such keys are
+// freshly allocated and do not alias buf.
+func (bt *btree) collectInteriorCellsKeepBuf(pg *page) ([]cellData, []byte, error) {
 	n := int(pg.header.cellCount)
-	cells := make([]cellData, n)
+	// Draw the descriptor slice from the pager free-list (SQLite apCell[]); this
+	// make() was the largest remaining byte producer of the interleaved index
+	// build. The caller returns it via pager.recycleCellSlice once it has read
+	// out everything it needs — rewriteParentAfterBalance does so right after
+	// splicing the dividers (it has copied each leftChild and aliased each key
+	// into oldDivs by then). The self-recycling collectInteriorCells wrapper and
+	// its callers leave it for GC, same as before (they keep the slice live).
+	cells := bt.pager.takeCellSlice(n)
+	if cells != nil {
+		cells = cells[:n]
+	} else {
+		cells = make([]cellData, n)
+	}
 	usable := bt.usablePageSize()
 	maxLocal := maxLocalPayload(usable)
 
@@ -1710,7 +1734,7 @@ func (bt *btree) collectInteriorCells(pg *page) ([]cellData, error) {
 		contentSize = 0
 	}
 
-	// Take pager's reusable buffer.
+	// Take a reusable buffer from the pager's free-list.
 	buf := bt.pager.takeCellBuf(contentSize)
 	if buf == nil {
 		buf = make([]byte, 0, contentSize)
@@ -1736,7 +1760,7 @@ func (bt *btree) collectInteriorCells(pg *page) ([]cellData, error) {
 				// chains during balance (btree.c:8473-8489); errors propagate up the
 				// balance() do-loop as SQLITE_CORRUPT/IO (btree.c:9131-9242).
 				bt.pager.recycleCellBuf(buf)
-				return nil, err
+				return nil, nil, err
 			}
 			_ = bt.pager.freeOverflowChain(overflowPg)
 			cells[i].key = fullKey
@@ -1750,7 +1774,20 @@ func (bt *btree) collectInteriorCells(pg *page) ([]cellData, error) {
 		_ = maxLocal
 	}
 
-	// Return buffer to pager for reuse.
+	return cells, buf, nil
+}
+
+// collectInteriorCells reads all cells from an interior page, self-recycling its
+// scratch buffer at the end. The returned keys alias the pager's shared scratch
+// buffer (now back in the free-list), so they remain valid only until the next
+// collect/take on this pager — the contract every non-balance caller relies on
+// (each rebuilds its page immediately, with no intervening collect). Callers that
+// must outlive that window use collectInteriorCellsKeepBuf instead.
+func (bt *btree) collectInteriorCells(pg *page) ([]cellData, error) {
+	cells, buf, err := bt.collectInteriorCellsKeepBuf(pg)
+	if err != nil {
+		return nil, err
+	}
 	bt.pager.recycleCellBuf(buf)
 	return cells, nil
 }

--- a/internal/btree/pager.go
+++ b/internal/btree/pager.go
@@ -147,18 +147,25 @@ type pager struct {
 	// Reusable slice for collecting dirty pages during commit
 	dirtyBuf []*page
 
-	// cellBuf is a reusable temp buffer for collectLeafCells / collectInteriorCells,
-	// matching SQLite's Pager.pTmpSpace (pager.c). Pre-allocated once at pager init
-	// and reused across defragment / balance / rebuild calls. Since writes are
-	// single-threaded, one buffer per pager is safe.
-	cellBuf []byte
+	// cellBufFree is a small bounded free-list of reusable temp buffers for
+	// collectLeafCells / collectInteriorCells, matching SQLite's scratch space
+	// (Pager.pTmpSpace / sqlite3ScratchMalloc, pager.c). A free-list rather than
+	// a single buffer because the balance path needs several alive AT ONCE: it
+	// gathers up to NB siblings and keeps each one's collected content buffer
+	// pinned while it redistributes (cellBufs in balanceNonroot). A single
+	// take-and-nil buffer forced the 2nd/3rd concurrent take to fall back to
+	// make() — the bulk of collectLeafCells' allocation churn during an
+	// append-heavy build. RAM stays controllable: at most cellScratchMax buffers
+	// are retained, each grows to at most the content size of one page, so the
+	// pool is bounded by ~cellScratchMax*pageSize (no sync.Pool, no unbounded
+	// growth). Since writes are single-threaded, the free-list needs no locking.
+	cellBufFree [][]byte
 
-	// cellSlice is a reusable []cellData for collectLeafCells, avoiding
-	// per-call allocation of the cells slice. Same take-and-nil pattern as
-	// cellBuf: taken by collectLeafCells, returned by callers via
-	// recycleCellSlice. Second concurrent call (merge path) finds nil and
-	// allocates fresh.
-	cellSlice []cellData
+	// cellSliceFree is the matching bounded free-list of reusable []cellData
+	// backing slices (SQLite apCell[]). Same rationale and bound as cellBufFree.
+	// recycleCellSlice clears entries before returning them so stale cellData
+	// headers do not pin old cellBuf backing arrays in the GC.
+	cellSliceFree [][]cellData
 
 	// dontWritePages tracks pages that were dirtied but whose content doesn't
 	// need to be persisted (e.g., freed leaf pages added to a freelist trunk).
@@ -288,14 +295,27 @@ func newPager(path string, pageSize uint32, cacheSize int, purgeable bool) *page
 	return p
 }
 
-// takeCellBuf returns the pager's reusable cell buffer if its capacity is >= minCap,
-// setting p.cellBuf to nil (take-and-nil pattern). Returns nil if no buffer is
-// available or it's too small. The caller owns the returned slice.
+// cellScratchMax bounds how many cell buffers / cellData slices the pager
+// retains in its scratch free-lists. The balance path's peak concurrent demand
+// is NB sibling buffers (nbMaxOut covers the gathered run plus output pages); a
+// couple of spares absorb the rewriteParentAfterBalance parent read overlapping
+// a cascade up the tree. Retained RAM is bounded by cellScratchMax*pageSize.
+const cellScratchMax = nbMaxOut + 3
+
+// takeCellBuf removes and returns a reusable cell buffer from the free-list
+// whose capacity is >= minCap. Returns nil if none qualifies (the caller then
+// allocates its own, which recycleCellBuf folds back into the pool). The caller
+// owns the returned slice until it recycles it.
 func (p *pager) takeCellBuf(minCap int) []byte {
-	if p.cellBuf != nil && cap(p.cellBuf) >= minCap {
-		buf := p.cellBuf[:0]
-		p.cellBuf = nil
-		return buf
+	for i := len(p.cellBufFree) - 1; i >= 0; i-- {
+		if cap(p.cellBufFree[i]) >= minCap {
+			buf := p.cellBufFree[i][:0]
+			last := len(p.cellBufFree) - 1
+			p.cellBufFree[i] = p.cellBufFree[last]
+			p.cellBufFree[last] = nil
+			p.cellBufFree = p.cellBufFree[:last]
+			return buf
+		}
 	}
 	return nil
 }
@@ -340,34 +360,81 @@ func (p *pager) readDBPage(pgno uint32, buf []byte) error {
 	return err
 }
 
-// recycleCellBuf returns a byte buffer to the pager for reuse. Keeps the larger
-// of the existing and returned buffers.
+// recycleCellBuf returns a byte buffer to the pager's free-list for reuse. If
+// the pool is full it keeps the larger buffers (replacing the smallest when the
+// incoming one is bigger), so the pool converges on page-content-sized buffers
+// and never grows past cellScratchMax entries.
 func (p *pager) recycleCellBuf(buf []byte) {
-	if cap(buf) > cap(p.cellBuf) {
-		p.cellBuf = buf[:0]
+	if cap(buf) == 0 {
+		return
+	}
+	if len(p.cellBufFree) < cellScratchMax {
+		p.cellBufFree = append(p.cellBufFree, buf[:0])
+		return
+	}
+	minI := 0
+	for i := 1; i < len(p.cellBufFree); i++ {
+		if cap(p.cellBufFree[i]) < cap(p.cellBufFree[minI]) {
+			minI = i
+		}
+	}
+	if cap(buf) > cap(p.cellBufFree[minI]) {
+		p.cellBufFree[minI] = buf[:0]
 	}
 }
 
-// takeCellSlice returns the pager's reusable cellData slice if its capacity
-// is >= minCap, setting p.cellSlice to nil (take-and-nil pattern). Returns nil
-// if no slice is available or it's too small.
+// takeCellSlice removes and returns a reusable cellData slice from the
+// free-list whose capacity is >= minCap. Returns nil if none qualifies (the
+// caller then allocates its own, which recycleCellSlice folds back into the
+// pool).
 func (p *pager) takeCellSlice(minCap int) []cellData {
-	if p.cellSlice != nil && cap(p.cellSlice) >= minCap {
-		s := p.cellSlice[:0]
-		p.cellSlice = nil
-		return s
+	for i := len(p.cellSliceFree) - 1; i >= 0; i-- {
+		if cap(p.cellSliceFree[i]) >= minCap {
+			s := p.cellSliceFree[i][:0]
+			last := len(p.cellSliceFree) - 1
+			p.cellSliceFree[i] = p.cellSliceFree[last]
+			p.cellSliceFree[last] = nil
+			p.cellSliceFree = p.cellSliceFree[:last]
+			return s
+		}
 	}
 	return nil
 }
 
-// recycleCellSlice returns a cellData slice to the pager for reuse. Keeps the
-// larger of the existing and returned slices. Clears all entries in the
-// returned slice to release references to cellBuf data, preventing stale
-// slice headers from pinning old buffers in the GC.
+// recycleCellSlice returns a cellData slice to the pager's free-list for reuse.
+// Clears all entries first to release references to cellBuf data, preventing
+// stale slice headers from pinning old buffers in the GC. When the pool is full
+// it keeps the larger slices, bounded at cellScratchMax entries.
 func (p *pager) recycleCellSlice(s []cellData) {
-	if cap(s) > cap(p.cellSlice) {
-		clear(s[:cap(s)])
-		p.cellSlice = s[:0]
+	if cap(s) == 0 {
+		return
+	}
+	clear(s[:cap(s)])
+	if len(p.cellSliceFree) < cellScratchMax {
+		p.cellSliceFree = append(p.cellSliceFree, s[:0])
+		return
+	}
+	minI := 0
+	for i := 1; i < len(p.cellSliceFree); i++ {
+		if cap(p.cellSliceFree[i]) < cap(p.cellSliceFree[minI]) {
+			minI = i
+		}
+	}
+	if cap(s) > cap(p.cellSliceFree[minI]) {
+		p.cellSliceFree[minI] = s[:0]
+	}
+}
+
+// initCellScratch (re-)seeds the cell-scratch free-list. It pre-allocates
+// nbSiblings page-content-sized buffers so the very first balance does not have
+// to make() its gathered-sibling buffers; the pool then self-tunes within the
+// cellScratchMax bound. Called from the pager init / re-open paths where the
+// usable page size is known. Replaces the former single-buffer pre-allocation.
+func (p *pager) initCellScratch() {
+	p.cellBufFree = p.cellBufFree[:0]
+	p.cellSliceFree = p.cellSliceFree[:0]
+	for i := 0; i < nbSiblings; i++ {
+		p.cellBufFree = append(p.cellBufFree, make([]byte, 0, p.usableSize_))
 	}
 }
 
@@ -570,7 +637,7 @@ func (p *pager) open() (err error) {
 	} else {
 		p.dbSize.Store(fileNPage)
 	}
-	p.cellBuf = make([]byte, 0, p.usableSize_)
+	p.initCellScratch()
 	p.writerCache = newPcache(int(p.pageSize), p.writerCache.maxPages, p.writerCache.purgeable)
 	p.writerCache.useSlab = p.useSlab
 	p.writerCache.xStress = p.pagerStress
@@ -716,7 +783,7 @@ func (p *pager) initNewDB() error {
 	}
 	// END ENCRYPTION
 	p.usableSize_ = int(p.pageSize) - int(p.header.ReservedSpace)
-	p.cellBuf = make([]byte, 0, p.usableSize_)
+	p.initCellScratch()
 
 	// Create page 1 with the database header and an empty leaf table page
 	buf := make([]byte, p.pageSize)


### PR DESCRIPTION
## What

Cuts heap-allocation churn on the btree balance (`balance_nonroot`) write path — the dominant allocator during index builds. On a realistic interleaved bulk index build it accounted for **~80% of allocated bytes** and **~94% of allocated objects**.

Three changes, all faithful to SQLite's btree-scoped bounded-scratch model (no on-disk format or page-assembly changes):

1. **`pager`** — replace the single take-and-nil cell-scratch buffer with a **bounded free-list** (`cellBufFree`/`cellSliceFree`, cap `cellScratchMax`). The balancer gathers up to `NB` siblings and needs all their content buffers alive at once; the old single buffer forced the 2nd/3rd concurrent `collectLeafCells` to `make()`. RAM stays controllable — at most `cellScratchMax * pageSize` retained, **no `sync.Pool`**.
2. **`collectInteriorCellsKeepBuf`** — returns its scratch buffer (no self-recycle) and draws the `[]cellData` descriptor slice from the pool. `collectInteriorCells` stays a thin self-recycling wrapper, so the 5 non-balance callers are untouched.
3. **`rewriteParentAfterBalance`** — aliases the parent divider keys directly into the held buffer instead of cloning every one (the per-divider `bytes.Clone` was the single largest object producer), and recycles the descriptor slice as soon as the dividers are spliced.

## Results

**Targeted micro-benchmark** (interleaved IVF `:cell` build, 400k inserts):

| metric | baseline | after | Δ |
|---|---:|---:|---:|
| balance-path alloc_space | 21,468 MB | 7,170 MB | **−66.6%** |
| allocs/op | 134 | 14 | **−90%** |
| B/op | 56,007 | 18,804 | −66% |
| ns/op | 11,948 | 6,036 | **−49%** |

**Full-app benchmark** (any-store-tests, 500k docs, back-to-back):

| build | baseline | after | Δ |
|---|---:|---:|---:|
| Index (a) | 2.472 s | 2.011 s | −18.6% |
| Index (email) unique | 2.299 s | 1.712 s | −25.5% |
| Index (tags) | 7.117 s | 5.529 s | −22.3% |

Secondary index builds **14–26% faster, identical DB sizes** (unchanged tree shape). Query/CRUD scenarios are flat (geomean +0.05%, B/op byte-identical) — no regression. The initial ascending bulk load is flat as expected (it takes the rightmost-append fast path, not the sibling-gather balancer).

## Testing

- Full `internal/btree` suite passes, incl. `-race` (balance/delete/merge/corrupt/integrity/pcache/slab + multiprocess WAL).
- Slab verified: `Slab`/`PageSlab`/`Pcache` tests under `-race`, `TestSlabHeapBound_MultiDB`, and external bench `84/0 at 500k docs with -slab 25600`.
- External `any-store-tests` suite (`storetest`) passes, including multiprocess/cross-process tests (real subprocesses running this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)