### PR TITLE
btree: fix cross-process reader corruption (Stats ErrCorrupt, WAL-restart snapshot isolation, stale hash segments)

### DIFF
--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -744,7 +744,7 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 		return nil, ErrClosed
 	}
 
-	hdr, maxFrame, slot, err := db.pager.beginReadHdr()
+	hdr, maxFrame, minFrame, slot, err := db.pager.beginReadHdr()
 	if err != nil {
 		db.mu.RUnlock()
 		<-db.readerSem
@@ -768,30 +768,53 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 
 	// Allocate reader cache from pool for per-connection page caching.
 	// Persistent cache: keep cached pages only if the DB snapshot hasn't
-	// changed. We check dataVersion (monotonic, never wraps) to detect
-	// writes. walMaxFrame alone suffers ABA after checkpoint restart.
-	// Matches SQLite pager.c:3246-3267 (pagerBeginReadTransaction —
-	// pager_reset only if change-counter changed).
+	// changed. The snapshot key is the FULL WAL-index header (not just
+	// mxFrame): aSalt is re-randomized on every WAL restart, so a peer
+	// process's checkpoint-restart cycle that happens to land on the same
+	// mxFrame still invalidates the cache. dataVersion (monotonic, never
+	// wraps) additionally covers in-process commits, whose synthesized
+	// header carries no salts. Matches SQLite's pChanged signal from
+	// walIndexReadHdr (raw header memcmp, wal.c:2611) driving pager_reset
+	// in pagerBeginReadTransaction (pager.c:3246-3267).
 	curDV := db.dataVersion.Load()
+	// Normalize the snapshot header once; the same value becomes both the
+	// cache validity key and tx.walHdr below.
+	snapHdr := hdr
+	if hdr.isInit == 0 {
+		snapHdr = WalIndexHdr{isInit: 1, mxFrame: maxFrame}
+	}
 	// Snapshot DB page count for this reader (hdr.nPage, fallback p.dbSize).
 	// Carried on the cache so reader bound checks accept pages a peer
-	// allocated after open. Set in lockstep with walMaxFrame.
+	// allocated after open. Set in lockstep with walHdr.
 	snapDbSize := db.pager.effectiveReaderDbSize(hdr)
 	var cache *pcache
 	select {
 	case cache = <-db.readerCaches:
-		if cache.dataVersion != curDV || cache.walMaxFrame != maxFrame {
+		if cache.dataVersion != curDV || cache.walHdr != snapHdr {
+			if debugTrace && cache.dataVersion == curDV && cache.walHdr.mxFrame == maxFrame {
+				trace("beginRead: reader cache ABA averted: mxFrame=%d cachedSalt=%x liveSalt=%x",
+					maxFrame, cache.walHdr.aSalt, snapHdr.aSalt)
+			}
 			cache.clear()
 			cache.dataVersion = curDV
+			cache.walHdr = snapHdr
 			cache.walMaxFrame = maxFrame
 		}
 		cache.dbSize = snapDbSize
+		// Refresh on every BeginRead, even when the cache is kept: a backfill
+		// between two same-header read txs raises the floor (harmless), and a
+		// slot-0 snapshot (minFrame == maxFrame+1) must not inherit a lower
+		// floor from an earlier slot-1..4 tx, or a peer's WAL restart could
+		// serve new-generation frames into it. See pcache.minFrame.
+		cache.minFrame = minFrame
 	default:
 		cache = newPcache(int(db.pager.pageSize), db.readerCacheSize, true)
 		cache.useSlab = db.pager.useSlab
 		cache.dataVersion = curDV
+		cache.walHdr = snapHdr
 		cache.walMaxFrame = maxFrame
 		cache.dbSize = snapDbSize
+		cache.minFrame = minFrame
 	}
 
 	tx := db.getReadTx()
@@ -803,11 +826,7 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 	// Dual-write during per-connection-hdr migration. Step 5 will remove
 	// walMaxFrame; until then, tests still read it directly.
 	tx.walMaxFrame = maxFrame
-	if hdr.isInit != 0 {
-		tx.walHdr = hdr
-	} else {
-		tx.walHdr = WalIndexHdr{isInit: 1, mxFrame: maxFrame}
-	}
+	tx.walHdr = snapHdr
 	tx.walSlot = slot
 	tx.diskFileChangeCounter = fcc
 	tx.diskSchemaCookie = sc
@@ -865,7 +884,7 @@ func (db *DB) BeginWrite() (*WriteTx, error) {
 
 	for attempt := 0; ; attempt++ {
 		var err error
-		readSnap, maxFrame, slot, err = db.pager.beginReadHdr()
+		readSnap, maxFrame, _, slot, err = db.pager.beginReadHdr()
 		if err != nil {
 			if errors.Is(err, ErrBusyRecovery) {
 				xBusy := db.pager.wal.busyHandler
@@ -1201,7 +1220,7 @@ func (db *DB) freeTreePagesDepth(pgno uint32, depth int) error {
 // goroutine. To resolve namespaces from the writer goroutine (seeing dirty
 // pages), use getNamespaceLocked directly.
 func (db *DB) GetNamespace(name string) (*Namespace, error) {
-	hdr, maxFrame, slot, err := db.pager.beginReadHdr()
+	hdr, maxFrame, minFrame, slot, err := db.pager.beginReadHdr()
 	if err != nil {
 		return nil, err
 	}
@@ -1210,6 +1229,7 @@ func (db *DB) GetNamespace(name string) (*Namespace, error) {
 	cache := newPcache(int(db.pager.pageSize), 200, true)
 	cache.useSlab = db.pager.useSlab
 	cache.dbSize = db.pager.effectiveReaderDbSize(hdr)
+	cache.minFrame = minFrame
 	defer cache.destroy()
 
 	return db.getNamespaceAt(name, maxFrame, cache)
@@ -1291,7 +1311,7 @@ func (db *DB) resolveNamespace(name string, bt *btree) (*Namespace, error) {
 
 // ListNamespaces returns the names of all namespaces.
 func (db *DB) ListNamespaces() ([]string, error) {
-	hdr, maxFrame, slot, err := db.pager.beginReadHdr()
+	hdr, maxFrame, minFrame, slot, err := db.pager.beginReadHdr()
 	if err != nil {
 		return nil, err
 	}
@@ -1300,6 +1320,7 @@ func (db *DB) ListNamespaces() ([]string, error) {
 	cache := newPcache(int(db.pager.pageSize), 200, true)
 	cache.useSlab = db.pager.useSlab
 	cache.dbSize = db.pager.effectiveReaderDbSize(hdr)
+	cache.minFrame = minFrame
 	defer cache.destroy()
 
 	bt := &btree{pager: db.pager, cache: cache, rootPage: 1, walMaxFrame: maxFrame, writable: false}
@@ -1391,6 +1412,10 @@ func (tx *ReadTx) txGetPage(pgno uint32) (*page, error) {
 // bound, exactly as readerDbSizeBound resolves.
 func (tx *ReadTx) txDescendChild(childPgno uint32) (*page, error) {
 	if childPgno == 0 || childPgno > tx.pager.readerDbSizeBound(tx.cache) {
+		if debugTrace {
+			trace("txDescendChild: CORRUPT childPgno=%d bound=%d walMaxFrame=%d hdr.nPage=%d",
+				childPgno, tx.pager.readerDbSizeBound(tx.cache), tx.walHdr.mxFrame, tx.walHdr.nPage)
+		}
 		return nil, ErrCorrupt
 	}
 	return tx.txGetPage(childPgno)

--- a/internal/btree/multiprocess_reader_test.go
+++ b/internal/btree/multiprocess_reader_test.go
@@ -1,0 +1,179 @@
+//go:build (linux || darwin) && (amd64 || arm64)
+
+package btree
+
+// Reproduces the "btree: database is corrupt" error reported when one OS
+// process writes large documents to a collection while a second process
+// (e.g. the CLI) periodically runs read-only full scans (collection.Stats).
+//
+// Writer process: commits a few ~100KB values per transaction in a loop with
+// a low auto-checkpoint threshold, so the WAL is frequently backfilled and
+// RESTARTed (frame numbers recycle).
+//
+// Reader process (this test's parent): loops BeginRead + full cursor scan +
+// NamespaceSize, holding a persistent reader page cache between transactions,
+// exactly like a long-lived CLI connection.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const mpReaderNumDocs = 3
+
+func TestMultiProcessReaderScanCorruption(t *testing.T) {
+	dbPath := os.Getenv("TEST_MPREADER_DB_PATH")
+	if dbPath != "" {
+		mpReaderWriterChild(t, dbPath)
+		return
+	}
+	if testing.Short() {
+		t.Skip("multi-process test skipped in -short mode")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	// Reader uses defaults comparable to the CLI: file-backed SHM,
+	// persistent per-connection cache.
+	opts := Options{
+		PageSize:  4096,
+		CacheSize: 2000,
+		InProcess: false,
+	}
+
+	db, err := testOpen(t, path, opts)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Seed the namespace so the child can GetNamespace it.
+	tx, err := db.BeginWrite()
+	require.NoError(t, err)
+	ns, err := tx.CreateNamespace("docs")
+	require.NoError(t, err)
+	for i := 0; i < mpReaderNumDocs; i++ {
+		key := binary.BigEndian.AppendUint32(nil, uint32(i))
+		val := bytes.Repeat([]byte{0}, 100*1024)
+		require.NoError(t, tx.Put(ns, key, val))
+	}
+	tx.MarkDataChanged()
+	require.NoError(t, tx.Commit())
+
+	// Spawn the writer child process.
+	cmd := exec.Command(os.Args[0],
+		"-test.run=^TestMultiProcessReaderScanCorruption$",
+		"-test.timeout=60s",
+	)
+	cmd.Env = append(os.Environ(), "TEST_MPREADER_DB_PATH="+path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+	childDone := make(chan error, 1)
+	go func() { childDone <- cmd.Wait() }()
+
+	// Reader loop: full scan + NamespaceSize per read tx, like Stats().
+	scans := 0
+	for done := false; !done; {
+		select {
+		case cErr := <-childDone:
+			require.NoError(t, cErr, "writer child failed")
+			done = true
+		default:
+		}
+
+		rtx, rErr := db.BeginRead()
+		require.NoError(t, rErr)
+		rns, nsErr := rtx.GetNamespace("docs")
+		if nsErr != nil {
+			rtx.Rollback()
+			t.Fatalf("scan %d: GetNamespace: %v", scans, nsErr)
+		}
+		if scanErr := mpReaderScan(rtx, rns); scanErr != nil {
+			rtx.Rollback()
+			t.Fatalf("scan %d (walMaxFrame=%d): %v", scans, rtx.WalMaxFrame(), scanErr)
+		}
+		require.NoError(t, rtx.Rollback())
+		scans++
+	}
+	t.Logf("completed %d scans without corruption", scans)
+}
+
+// mpReaderScan mirrors collection.Stats: full cursor scan reading every
+// value, then a NamespaceSize page sweep.
+func mpReaderScan(rtx *ReadTx, ns *Namespace) error {
+	cursor := rtx.NewCursor(ns)
+	defer cursor.Close()
+	if err := cursor.First(); err != nil {
+		return fmt.Errorf("cursor.First: %w", err)
+	}
+	docs := 0
+	for cursor.Valid() {
+		val, err := cursor.Value()
+		if err != nil {
+			return fmt.Errorf("cursor.Value doc %d: %w", docs, err)
+		}
+		// The writer fills each value with a single byte; a mixed-snapshot
+		// read of the overflow chain shows up as a non-uniform value.
+		for j := 1; j < len(val); j++ {
+			if val[j] != val[0] {
+				return fmt.Errorf("doc %d: torn value: byte %d = %d, byte 0 = %d (len %d)",
+					docs, j, val[j], val[0], len(val))
+			}
+		}
+		docs++
+		if err := cursor.Next(); err != nil {
+			return fmt.Errorf("cursor.Next doc %d: %w", docs, err)
+		}
+	}
+	if docs != mpReaderNumDocs {
+		return fmt.Errorf("expected %d docs, scanned %d", mpReaderNumDocs, docs)
+	}
+	if _, err := rtx.NamespaceSize(ns); err != nil {
+		return fmt.Errorf("NamespaceSize: %w", err)
+	}
+	return nil
+}
+
+// mpReaderWriterChild overwrites the same few large documents in a loop.
+// The low AutoCheckpointAfter forces frequent passive checkpoints followed
+// by best-effort WAL RESTARTs, so WAL frame numbers recycle while the
+// parent process is reading.
+func mpReaderWriterChild(t *testing.T, dbPath string) {
+	opts := Options{
+		PageSize:            4096,
+		CacheSize:           2000,
+		InProcess:           false,
+		AutoCheckpointAfter: 64,
+	}
+
+	db, err := testOpen(t, dbPath, opts)
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	iter := 0
+	for time.Now().Before(deadline) {
+		tx, err := db.BeginWrite()
+		require.NoError(t, err)
+		ns, err := tx.GetNamespace("docs")
+		require.NoError(t, err)
+		fill := byte(1 + iter%250)
+		for i := 0; i < mpReaderNumDocs; i++ {
+			key := binary.BigEndian.AppendUint32(nil, uint32(i))
+			val := bytes.Repeat([]byte{fill}, 100*1024)
+			require.NoError(t, tx.Put(ns, key, val))
+		}
+		tx.MarkDataChanged()
+		require.NoError(t, tx.Commit())
+		iter++
+	}
+	t.Logf("writer child: %d commits", iter)
+	require.NoError(t, db.Close())
+}

--- a/internal/btree/namespace_size.go
+++ b/internal/btree/namespace_size.go
@@ -143,7 +143,10 @@ func leafCellPayloadLen(data []byte, offset int) (keyLen, valLen int, err error)
 func (bt *btree) countOverflowChain(firstPgno uint32) (int, error) {
 	count := 0
 	pgno := firstPgno
-	dbSize := bt.pager.dbSize.Load()
+	// Snapshot bound, not pager.dbSize: a read-only process never refreshes
+	// pager.dbSize, so chains through pages a peer process allocated after we
+	// opened would be falsely rejected as corrupt. See readerDbSizeBound.
+	dbSize := bt.pager.readerDbSizeBound(bt.cache)
 	for pgno != 0 {
 		if pgno < 2 || pgno > dbSize {
 			return 0, ErrCorrupt

--- a/internal/btree/pager.go
+++ b/internal/btree/pager.go
@@ -669,7 +669,7 @@ func (p *pager) open() (err error) {
 	// occurred before checkpoint. Without this, commit() would serialize
 	// stale p.header fields back into page 1, corrupting the freelist.
 	if p.wal.index.maxFrame.Load() > 0 {
-		frame, err := p.wal.index.get(1, p.wal.index.maxFrame.Load())
+		frame, err := p.wal.index.get(1, p.wal.index.maxFrame.Load(), p.wal.index.liveMinFrame())
 		if err != nil {
 			return err
 		}
@@ -867,23 +867,23 @@ func (p *pager) initNewDB() error {
 // beginRead starts a read transaction, taking a WAL snapshot.
 // Returns the WAL max frame for snapshot isolation and the reader slot number.
 func (p *pager) beginRead() (maxFrame uint32, slot int, err error) {
-	_, maxFrame, slot, err = p.beginReadHdr()
+	_, maxFrame, _, slot, err = p.beginReadHdr()
 	return maxFrame, slot, err
 }
 
 // beginReadHdr is beginRead plus the exact WAL header snapshot used to claim
 // the reader slot. Callers that may escalate to a write transaction should use
 // this so BUSY_SNAPSHOT compares against the same snapshot the read lock used.
-func (p *pager) beginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err error) {
+func (p *pager) beginReadHdr() (hdr WalIndexHdr, maxFrame, minFrame uint32, slot int, err error) {
 	p.mu.RLock()
 	if pagerState(p.state.Load()) == pagerError {
 		p.mu.RUnlock()
-		return WalIndexHdr{}, 0, 0, ErrCorrupt
+		return WalIndexHdr{}, 0, 0, 0, ErrCorrupt
 	}
-	hdr, maxFrame, slot, err = p.wal.beginReadHdr()
+	hdr, maxFrame, minFrame, slot, err = p.wal.beginReadHdr()
 	if err != nil {
 		p.mu.RUnlock()
-		return WalIndexHdr{}, 0, 0, err
+		return WalIndexHdr{}, 0, 0, 0, err
 	}
 	// Update pager's walMaxFrame monotonically: never decrease, since a reader
 	// with an older snapshot must not overwrite a newer value set by the writer.
@@ -896,7 +896,7 @@ func (p *pager) beginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err 
 			break
 		}
 	}
-	return hdr, maxFrame, slot, nil
+	return hdr, maxFrame, minFrame, slot, nil
 }
 
 // endRead ends a read transaction for the given reader slot.
@@ -1000,7 +1000,9 @@ func (p *pager) getPageWriter(pgno, walMaxFrame uint32) (*page, error) {
 
 	// Try to read from WAL first
 	if walMaxFrame > 0 {
-		frame, err := p.wal.index.get(pgno, walMaxFrame)
+		// Writer path: the write lock excludes a concurrent restart, so the
+		// live checkpoint frontier is a valid minFrame.
+		frame, err := p.wal.index.get(pgno, walMaxFrame, p.wal.index.liveMinFrame())
 		if err != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain: fail the
 			// read (matching C's walFindFrame SQLITE_CORRUPT_BKPT at
@@ -1080,7 +1082,7 @@ func (p *pager) getPageWriter(pgno, walMaxFrame uint32) (*page, error) {
 // falls back to allocPageBuffer in that case.
 // DRIFT: WAL frame read failure silently falls through to stale disk read See docs/btree/NOTES.md#drift-6-wal-frame-read-failure-falls-through-to-disk-read
 // DRIFT: short DB-file read on in-bounds page is hard error in Go, zero-pad OK in C See docs/btree/NOTES.md#drift-7-short-db-file-read-treated-as-hard-error
-func (p *pager) readTempPage(pgno, walMaxFrame, dbSizeBound uint32, codecBuf []byte, codecAEAD *aeadScratch) (*page, error) {
+func (p *pager) readTempPage(pgno, walMaxFrame, walMinFrame, dbSizeBound uint32, codecBuf []byte, codecAEAD *aeadScratch) (*page, error) {
 	pg := p.acquireTempPage()
 	pg.pgno = pgno
 	pg.pinCount = 1
@@ -1101,7 +1103,7 @@ func (p *pager) readTempPage(pgno, walMaxFrame, dbSizeBound uint32, codecBuf []b
 
 	// Try to read from WAL first.
 	if walMaxFrame > 0 {
-		frame, err := p.wal.index.get(pgno, walMaxFrame)
+		frame, err := p.wal.index.get(pgno, walMaxFrame, walMinFrame)
 		if err != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain: fail the read
 			// (C walFindFrame SQLITE_CORRUPT_BKPT, wal.c:3593) rather than
@@ -1188,7 +1190,7 @@ func (p *pager) getPageReader(pgno, walMaxFrame uint32, cache *pcache) (*page, e
 	// If no reader cache provided, read an uncached temporary page.
 	// Never fall back to writerCache — that would race with the writer goroutine.
 	if cache == nil {
-		return p.readTempPage(pgno, walMaxFrame, p.readerDbSizeBound(nil), nil, nil)
+		return p.readTempPage(pgno, walMaxFrame, p.wal.index.liveMinFrame(), p.readerDbSizeBound(nil), nil, nil)
 	}
 
 	// Check reader cache.
@@ -1210,7 +1212,7 @@ func (p *pager) getPageReader(pgno, walMaxFrame uint32, cache *pcache) (*page, e
 			cache.codecScratch = make([]byte, p.pageSize)
 		}
 		// END ENCRYPTION
-		return p.readTempPage(pgno, walMaxFrame, p.readerDbSizeBound(cache), cache.codecScratch, &cache.codecAEAD)
+		return p.readTempPage(pgno, walMaxFrame, p.readerMinFrame(cache), p.readerDbSizeBound(cache), cache.codecScratch, &cache.codecAEAD)
 	}
 
 	// Decide read-vs-zero up front, matching C getPageNormal
@@ -1228,7 +1230,7 @@ func (p *pager) getPageReader(pgno, walMaxFrame uint32, cache *pcache) (*page, e
 
 	// Try to read from WAL first.
 	if walMaxFrame > 0 {
-		frame, err := p.wal.index.get(pgno, walMaxFrame)
+		frame, err := p.wal.index.get(pgno, walMaxFrame, p.readerMinFrame(cache))
 		if err != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain: fail the read
 			// (C walFindFrame SQLITE_CORRUPT_BKPT, wal.c:3593) rather than
@@ -1344,7 +1346,7 @@ func (p *pager) readRawPage(pgno, walMaxFrame uint32) ([]byte, error) {
 	}
 	buf := make([]byte, p.pageSize)
 	if walMaxFrame > 0 && p.wal != nil {
-		frame, err := p.wal.index.get(pgno, walMaxFrame)
+		frame, err := p.wal.index.get(pgno, walMaxFrame, p.wal.index.liveMinFrame())
 		if err != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain: fail the read
 			// (C walFindFrame SQLITE_CORRUPT_BKPT, wal.c:3593) rather than
@@ -1948,6 +1950,19 @@ func (p *pager) readerDbSizeBound(cache *pcache) uint32 {
 	return p.dbSize.Load()
 }
 
+// readerMinFrame returns the WAL lookup floor for a read path: the snapshot
+// minFrame carried on the reader cache (captured at BeginRead, like SQLite's
+// pWal->minFrame), or the live checkpoint frontier when there is no reader
+// cache (writer / uncached paths, where the write lock or exclusivity rules
+// out a concurrent WAL restart). An unset cache value (0) degrades to the
+// live frontier.
+func (p *pager) readerMinFrame(cache *pcache) uint32 {
+	if cache != nil && cache.minFrame != 0 {
+		return cache.minFrame
+	}
+	return p.wal.index.liveMinFrame()
+}
+
 // refreshHeaderFromPage1 refreshes p.header and p.dbSize from the latest
 // page 1 bytes, consulting WAL first (via SHM hash tables in multi-process
 // mode) and falling back to the database file. Called from beginWrite when
@@ -1986,7 +2001,7 @@ func (p *pager) refreshHeaderFromPage1() error {
 	// can be propagated to the caller rather than swallowed.
 	var walErr error
 	if effectiveMaxFrame > 0 {
-		frame, err := p.wal.index.get(1, effectiveMaxFrame)
+		frame, err := p.wal.index.get(1, effectiveMaxFrame, p.wal.index.liveMinFrame())
 		if err != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain is a hard error,
 			// not a "WAL has no page 1" miss: do not fall back to the DB file
@@ -2095,7 +2110,7 @@ func (p *pager) readHeaderCounters(walMaxFrame uint32) (fileChangeCount, schemaC
 	// frames. After an external state change, beginWrite rebuilds the local page
 	// map from the WAL so page-1 refreshes do not depend solely on SHM hashes.
 	if effectiveMaxFrame > 0 {
-		frame, gerr := p.wal.index.get(1, effectiveMaxFrame)
+		frame, gerr := p.wal.index.get(1, effectiveMaxFrame, p.wal.index.liveMinFrame())
 		if gerr != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain is a hard error,
 			// not a "WAL has no page 1" miss: fail rather than reading stale

--- a/internal/btree/pager_test.go
+++ b/internal/btree/pager_test.go
@@ -5720,7 +5720,7 @@ func TestWalBeginRead_AllSlotsBusy_Slot0AlsoLocked(t *testing.T) {
 	// retry and eventually surface ErrProtocol after ~10s of back-off,
 	// but that's a retry-exhaustion contract, not a slot-lock contract —
 	// test the inner conversion directly to keep the test fast and focused.
-	_, _, _, err := w.tryBeginReadInProcessHdr()
+	_, _, _, _, err := w.tryBeginReadInProcessHdr()
 	assert.ErrorIs(t, err, errWALRetry)
 
 	for i := 0; i <= 4; i++ {
@@ -7815,7 +7815,7 @@ func TestPagerSlabIntegration(t *testing.T) {
 	defer p.endRead(slot3)
 
 	freeBeforeTemp := len(globalPageSlab.freeList)
-	tmpPg, err := p.readTempPage(pageNos[0], mf3, p.readerDbSizeBound(nil), nil, nil)
+	tmpPg, err := p.readTempPage(pageNos[0], mf3, p.wal.index.liveMinFrame(), p.readerDbSizeBound(nil), nil, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, tmpPg.data)
 	freeAfterTemp := len(globalPageSlab.freeList)
@@ -8432,7 +8432,7 @@ func TestBeginWriteHeaderRefreshError_DoubleIOFailure(t *testing.T) {
 	// Drive db2's beginWrite manually so we can inject the read failure on the
 	// stateChanged edge. Mirror DB.BeginWrite's beginReadHdr -> beginWrite flow.
 	p := db2.pager
-	readSnap, maxFrame, slot, err := p.beginReadHdr()
+	readSnap, maxFrame, _, slot, err := p.beginReadHdr()
 	require.NoError(t, err)
 	p.writerWalSlot = slot
 

--- a/internal/btree/pcache.go
+++ b/internal/btree/pcache.go
@@ -50,21 +50,36 @@ type pcache struct {
 	dirtyTail *page // oldest dirty page; spill victim search starts here
 	nDirty    int
 
-	// dataVersion and walMaxFrame together identify the DB snapshot for which
+	// dataVersion and walHdr together identify the DB snapshot for which
 	// this cache's pages are valid. On reuse from the pool, if EITHER value
 	// differs from the current transaction, the cache is cleared.
 	//
-	// walMaxFrame alone is insufficient because it can wrap after checkpoint
-	// restart (ABA problem). dataVersion alone is insufficient because of a
-	// TOCTOU race: the WAL mxFrame is updated inside pager.commit() but
-	// dataVersion is incremented afterward. A reader starting between these
-	// two points would see the new walMaxFrame but old dataVersion, matching
-	// a stale cache. Checking both eliminates both failure modes.
+	// walHdr is the full WAL-index header snapshot, not just mxFrame:
+	// mxFrame alone wraps after a checkpoint restart (ABA problem), and a
+	// PEER PROCESS's restart never bumps this process's dataVersion, so the
+	// salts (re-randomized on every restart) are the only signal that frame
+	// numbers were recycled cross-process. dataVersion alone is insufficient
+	// because of a TOCTOU race: the WAL mxFrame is updated inside
+	// pager.commit() but dataVersion is incremented afterward. A reader
+	// starting between these two points would see the new header but old
+	// dataVersion, matching a stale cache. Checking both eliminates both
+	// failure modes. (In-process mode synthesizes a salt-less header, where
+	// dataVersion covers every local commit by itself.)
 	//
 	// Matches SQLite pager.c:3246-3267 (pagerBeginReadTransaction — pager_reset
 	// only if change-counter changed) and pPager->iDataVersion (pager.c:1776).
 	dataVersion uint64
+	walHdr      WalIndexHdr
 	walMaxFrame uint32
+
+	// minFrame is the snapshot's WAL lookup floor (nBackfill+1 for slot 1-4
+	// readers, walMaxFrame+1 for slot-0 readers), captured at BeginRead like
+	// SQLite's pWal->minFrame (wal.c:3239) and refreshed on EVERY BeginRead
+	// (not just on clear): a reader re-entering on slot 0 must raise the
+	// floor so a peer's WAL restart cannot serve new-generation frames into
+	// this snapshot. 0 means "fall back to the live frontier" (writer /
+	// uncached paths via pager.readerMinFrame).
+	minFrame uint32
 
 	// dbSize is the database size in pages for the snapshot this cache serves
 	// (WalIndexHdr.nPage, captured cross-process at BeginRead). Reader page/

--- a/internal/btree/wal.go
+++ b/internal/btree/wal.go
@@ -743,17 +743,32 @@ func (wi *walIndex) getInTxRange(pgno, maxFrame, minFrame uint32) (uint32, error
 	return wi.shmHashGet(pgno, maxFrame, minFrame)
 }
 
-// get returns the frame containing the latest version of pgno that is
-// within the given maxFrame snapshot, or 0 if not in WAL.
-// The maxFrame parameter limits which frames are visible (for snapshot isolation).
+// liveMinFrame returns the CURRENT checkpoint frontier bound (nBackfill+1)
+// for WAL lookups. Valid only for callers that cannot race a WAL restart:
+// the writer (restart needs the write lock) and open/recovery paths. Reader
+// transactions must NOT use this — they capture minFrame once at beginRead
+// (like SQLite's pWal->minFrame, wal.c:3239) so a peer's restart cannot
+// make recycled frame numbers of the NEW WAL generation pass their old
+// snapshot's maxFrame bound.
+func (wi *walIndex) liveMinFrame() uint32 {
+	if wi.inProcess {
+		return wi.nBackfill.Load() + 1
+	}
+	return wi.shmNBackfill() + 1
+}
+
+// get returns the frame containing the latest version of pgno within
+// [minFrame, maxFrame], or 0 if not in WAL. maxFrame is the snapshot's
+// visibility ceiling; minFrame is the snapshot's checkpoint-frontier floor
+// (frames below it were already backfilled to the DB file). Both come from
+// the caller's snapshot — readers thread the beginRead-captured value,
+// writers pass liveMinFrame(). Matches SQLite walFindFrame (wal.c:3554-3582)
+// with pWal->minFrame supplied by walTryBeginRead.
 // DRIFT: WAL hash-probe full-chain (nCollide) CORRUPT signal dropped in get/shmHashGet See docs/btree/NOTES.md#drift-93-wal-hash-probe-full-chain-corruption-signal-dropped
 // DRIFT: in-process WAL lookup via Go map (O(1)) vs SQLite hash scan; cross-process still uses SHM See docs/btree/NOTES.md#old-drift-pagemap-same-process-lookup
-func (wi *walIndex) get(pgno, maxFrame uint32) (uint32, error) {
+func (wi *walIndex) get(pgno, maxFrame, minFrame uint32) (uint32, error) {
 	if wi.inProcess {
 		// In-process: no SHM to consult; pageMap is the sole source of truth.
-		// minFrame filters out frames already checkpointed back to the DB
-		// (SQLite wal.c:3571).
-		minFrame := wi.nBackfill.Load() + 1
 		wi.mu.RLock()
 		frames := wi.pageMap[pgno]
 		wi.mu.RUnlock()
@@ -765,11 +780,7 @@ func (wi *walIndex) get(pgno, maxFrame uint32) (uint32, error) {
 		return 0, nil
 	}
 	// Multi-process: SHM hash tables are the sole source of truth, matching
-	// SQLite's walFindFrame (wal.c:3554-3582). nBackfill lives in SHM
-	// (wal.c:3114, 3571) since a peer checkpoint may advance it without
-	// touching our process-local copy — use shmNBackfill() rather than
-	// the cached atomic.
-	minFrame := wi.shmNBackfill() + 1
+	// SQLite's walFindFrame (wal.c:3554-3582).
 	return wi.shmHashGet(pgno, maxFrame, minFrame)
 }
 
@@ -2544,14 +2555,25 @@ func (w *wal) readFramePgno(frame uint32) (uint32, error) {
 //   - Slots 1-4: used for readers that need WAL frames. Best slot is the one
 //     with the largest readmark <= current maxFrame.
 func (w *wal) beginRead() (maxFrame uint32, slot int, err error) {
-	_, maxFrame, slot, err = w.beginReadHdr()
+	_, maxFrame, _, slot, err = w.beginReadHdr()
 	return maxFrame, slot, err
 }
 
 // beginReadHdr is beginRead plus the exact WAL header snapshot used to claim
 // the reader slot. The caller can thread this hdr into BUSY_SNAPSHOT checks so
 // beginWrite compares against the same snapshot that beginRead actually used.
-func (w *wal) beginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err error) {
+//
+// minFrame is the snapshot's checkpoint-frontier floor for WAL lookups,
+// captured at slot-claim time exactly like SQLite's pWal->minFrame
+// (wal.c:3239). For slot-0 readers it is maxFrame+1 (an empty WAL range:
+// the WAL is fully backfilled, so the reader serves everything from the DB
+// file — C expresses this as the readLock==0 short-circuit in walFindFrame,
+// wal.c:3567). This must stay fixed for the life of the read transaction: a
+// peer's checkpoint-RESTART may recycle frame numbers, and a live
+// nBackfill-derived floor would let NEW-generation frames pass the OLD
+// snapshot's maxFrame bound (observed as torn overflow chains in the
+// cross-process reader test).
+func (w *wal) beginReadHdr() (hdr WalIndexHdr, maxFrame, minFrame uint32, slot int, err error) {
 	// Retry loop matching SQLite's WAL_RETRY protocol (wal.c:3022-3056,
 	// 3391-3393). After 5 retries we begin sleeping; from the 10th retry
 	// onward the delay grows quadratically up to ~10s total before
@@ -2569,9 +2591,9 @@ func (w *wal) beginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err er
 	// tryBeginRead.
 	const protocolLimit = 100
 	for cnt := 0; cnt <= protocolLimit; cnt++ {
-		hdr, maxFrame, slot, err = w.tryBeginReadHdr()
+		hdr, maxFrame, minFrame, slot, err = w.tryBeginReadHdr()
 		if !errors.Is(err, errWALRetry) {
-			return hdr, maxFrame, slot, err
+			return hdr, maxFrame, minFrame, slot, err
 		}
 		if cnt < 5 {
 			runtime.Gosched()
@@ -2584,7 +2606,7 @@ func (w *wal) beginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err er
 		}
 		time.Sleep(nDelay)
 	}
-	return WalIndexHdr{}, 0, 0, ErrProtocol
+	return WalIndexHdr{}, 0, 0, 0, ErrProtocol
 }
 
 // tryBeginRead attempts to acquire a reader slot and returns the current
@@ -2597,13 +2619,13 @@ func (w *wal) beginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err er
 // SQLite's walTryBeginRead slot-0 fast path (wal.c:3136-3157) and its
 // aReadMark[0]==0 invariant (wal.c:2159,361).
 func (w *wal) tryBeginRead() (maxFrame uint32, slot int, err error) {
-	_, maxFrame, slot, err = w.tryBeginReadHdr()
+	_, maxFrame, _, slot, err = w.tryBeginReadHdr()
 	return maxFrame, slot, err
 }
 
 // tryBeginReadHdr is tryBeginRead plus the exact WAL header snapshot used to
 // choose/validate the reader slot.
-func (w *wal) tryBeginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err error) {
+func (w *wal) tryBeginReadHdr() (hdr WalIndexHdr, maxFrame, minFrame uint32, slot int, err error) {
 	if w.inProcess || w.inMemory {
 		return w.tryBeginReadInProcessHdr()
 	}
@@ -2622,18 +2644,18 @@ func (w *wal) tryBeginReadHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err
 // post-lock re-check of aReadMark[mxI], wal.c:3239-3249). On retry the
 // nBackfill==mxFrame slot-0 fast path stays safe.
 func (w *wal) tryBeginReadInProcess() (maxFrame uint32, slot int, err error) {
-	_, maxFrame, slot, err = w.tryBeginReadInProcessHdr()
+	_, maxFrame, _, slot, err = w.tryBeginReadInProcessHdr()
 	return maxFrame, slot, err
 }
 
-func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err error) {
+func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame, minFrame uint32, slot int, err error) {
 	mxFrame := w.index.mxCommitFrame.LoadLocal()
 	nBackfill := w.index.nBackfill.Load()
 	hdr = WalIndexHdr{isInit: 1, mxFrame: mxFrame}
 
 	if mxFrame == 0 || nBackfill == mxFrame {
 		if err := w.index.lock(lockRead0, lockShared); err != nil {
-			return WalIndexHdr{}, 0, 0, err
+			return WalIndexHdr{}, 0, 0, 0, err
 		}
 		// Slot 0's read mark is a fixed sentinel that must stay 0 (set at
 		// wal.go:1900): it pins frame 0, i.e. "read nothing from the WAL".
@@ -2642,7 +2664,10 @@ func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot
 		// the invariant aReadMark[0]==0 (wal.c:2159,361). The returned maxFrame
 		// comes from the local mxFrame snapshot, and no reader/checkpointer scan
 		// consults slot 0 (all loops start at i=1), so no write is needed here.
-		return hdr, mxFrame, 0, nil
+		// minFrame = mxFrame+1: a slot-0 reader reads nothing from the WAL
+		// (C's readLock==0 short-circuit, wal.c:3567), which keeps it immune
+		// to a concurrent WAL restart recycling frame numbers.
+		return hdr, mxFrame, mxFrame + 1, 0, nil
 	}
 
 	bestSlot := -1
@@ -2672,9 +2697,9 @@ func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot
 			// nBackfill==mxFrame slot-0 fast path stays safe.
 			if w.index.mxCommitFrame.LoadLocal() != mxFrame || w.index.nBackfill.Load() != nBackfill {
 				_ = w.index.unlock(lockSlot, lockShared)
-				return WalIndexHdr{}, 0, 0, errWALRetry
+				return WalIndexHdr{}, 0, 0, 0, errWALRetry
 			}
-			return hdr, mxFrame, bestSlot, nil
+			return hdr, mxFrame, nBackfill + 1, bestSlot, nil
 		}
 	}
 
@@ -2682,7 +2707,7 @@ func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot
 		lockSlot := lockRead0 + i
 		if err := w.index.lock(lockSlot, lockShared); err == nil {
 			w.index.aReadMark[i].Store(mxFrame)
-			return hdr, mxFrame, i, nil
+			return hdr, mxFrame, nBackfill + 1, i, nil
 		}
 	}
 
@@ -2693,14 +2718,18 @@ func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot
 		// conversion. In InProcess mode this is rare (process-local
 		// locks rarely race) but kept symmetric.
 		if errors.Is(err, ErrBusy) {
-			return WalIndexHdr{}, 0, 0, errWALRetry
+			return WalIndexHdr{}, 0, 0, 0, errWALRetry
 		}
-		return WalIndexHdr{}, 0, 0, err
+		return WalIndexHdr{}, 0, 0, 0, err
 	}
 	// Slot 0 fallback: like the fast path above, do not write aReadMark[0].
 	// It is a fixed 0 sentinel (wal.go:1900); the returned maxFrame comes from
 	// the local mxFrame snapshot. Matches SQLite walTryBeginRead (wal.c:3136-3157).
-	return hdr, mxFrame, 0, nil
+	// minFrame = nBackfill+1 (NOT mxFrame+1): unlike the fast path, mxFrame >
+	// nBackfill here, so the WAL must still be consulted. Holding read-0
+	// shared blocks backfill (it takes read-0 exclusive), so nBackfill cannot
+	// advance — and therefore no restart can recycle frames — while we hold it.
+	return hdr, mxFrame, nBackfill + 1, 0, nil
 }
 
 // tryBeginReadMultiProcess handles the multi-process path, matching SQLite's
@@ -2717,17 +2746,20 @@ func (w *wal) tryBeginReadInProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot
 //  4. Re-validate after acquiring shared lock: compare live SHM header against local
 //     copy AND live readmark against saved value. If either changed → WAL_RETRY.
 //     Matches SQLite wal.c:3239-3249 (memcmp + AtomicLoad re-check).
-//  5. Sync nBackfill to process-local atomic for walIndex.get() minFrame filter.
-//     (docs/btree/NOTES.md §20, drift 3 — SQLite doesn't need this sync step because it reads
-//     nBackfill directly from SHM via pInfo pointer everywhere)
+//  5. Capture the snapshot minFrame (nBackfill+1) under the validated reader
+//     lock and return it to the caller — the read tx threads this fixed value
+//     into every WAL lookup, matching SQLite's pWal->minFrame (wal.c:3239).
+//     The slot-0 path returns maxFrame+1 instead (C: readLock==0 short-circuit
+//     in walFindFrame, wal.c:3567). nBackfill is also synced to the
+//     process-local atomic for live-frontier users (liveMinFrame).
 //
 // DRIFT: reader-slot tie-break selects lowest slot; SQLite selects highest on equal marks See docs/btree/NOTES.md#drift-102-reader-slot-tie-break-selects-lowest-not-highest
 func (w *wal) tryBeginReadMultiProcess() (maxFrame uint32, slot int, err error) {
-	_, maxFrame, slot, err = w.tryBeginReadMultiProcessHdr()
+	_, maxFrame, _, slot, err = w.tryBeginReadMultiProcessHdr()
 	return maxFrame, slot, err
 }
 
-func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame uint32, slot int, err error) {
+func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame, minFrame uint32, slot int, err error) {
 	// Step 1: Read SHM header into local copy (SQLite: walIndexReadHdr → walIndexTryHdr)
 	hdr, valid := w.index.readHeader()
 	if !valid {
@@ -2739,7 +2771,7 @@ func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame uint32, s
 		if err := w.index.lock(lockRecover, lockShared); err == nil {
 			_ = w.index.unlock(lockRecover, lockShared)
 		}
-		return WalIndexHdr{}, 0, 0, errWALRetry
+		return WalIndexHdr{}, 0, 0, 0, errWALRetry
 	}
 	mxFrame := hdr.mxFrame
 
@@ -2766,7 +2798,7 @@ func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame uint32, s
 			// mid-zeroing SHM) always differs and forces WAL_RETRY.
 			if liveHdr, ok := w.index.readHeader(); !ok || liveHdr != hdr {
 				_ = w.index.unlock(lockRead0, lockShared)
-				return WalIndexHdr{}, 0, 0, errWALRetry
+				return WalIndexHdr{}, 0, 0, 0, errWALRetry
 			}
 			// Do not write aReadMark[0]: slot 0's mark is a fixed 0 sentinel
 			// (wal.go:1900) meaning "read nothing from the WAL". SQLite's
@@ -2776,10 +2808,16 @@ func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame uint32, s
 			// the local hdr snapshot, and no reader/checkpointer scan reads slot
 			// 0 (all loops start at i=1), so neither the SHM mark nor the
 			// process-local mirror needs updating.
-			return hdr, mxFrame, 0, nil
+			// minFrame = mxFrame+1: a slot-0 reader reads nothing from the
+			// WAL (C's readLock==0 short-circuit in walFindFrame, wal.c:3567).
+			// This keeps the snapshot immune to a peer's WAL restart recycling
+			// frame numbers mid-transaction: restart only locks slots 1-4, so
+			// it can run while we hold slot 0, and new-generation frames must
+			// never pass this snapshot's [minFrame, maxFrame] filter.
+			return hdr, mxFrame, mxFrame + 1, 0, nil
 		}
 		if !errors.Is(err, ErrBusy) {
-			return WalIndexHdr{}, 0, 0, err
+			return WalIndexHdr{}, 0, 0, 0, err
 		}
 		// BUSY: fall through to slot 1..4 selection below.
 	}
@@ -2824,13 +2862,13 @@ func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame uint32, s
 		//   }
 		// any-store has no read-only-shm mode, so the conversion is
 		// unconditional.
-		return WalIndexHdr{}, 0, 0, errWALRetry
+		return WalIndexHdr{}, 0, 0, 0, errWALRetry
 	}
 
 	// Step 6: Acquire shared lock on the chosen slot (SQLite wal.c:3192)
 	lockSlot := lockRead0 + bestSlot
 	if err := w.index.lock(lockSlot, lockShared); err != nil {
-		return WalIndexHdr{}, 0, 0, errWALRetry
+		return WalIndexHdr{}, 0, 0, 0, errWALRetry
 	}
 
 	// Step 7: Re-validate after lock (SQLite wal.c:3239-3249)
@@ -2845,13 +2883,16 @@ func (w *wal) tryBeginReadMultiProcessHdr() (hdr WalIndexHdr, maxFrame uint32, s
 	// differs and forces WAL_RETRY.
 	if liveMark != bestMark || !liveValid || liveHdr != hdr {
 		_ = w.index.unlock(lockSlot, lockShared)
-		return WalIndexHdr{}, 0, 0, errWALRetry
+		return WalIndexHdr{}, 0, 0, 0, errWALRetry
 	}
 
-	// Sync nBackfill to process-local for walIndex.get() minFrame filter
+	// Sync nBackfill to process-local (live-frontier users: liveMinFrame).
 	w.index.nBackfill.Store(nBackfill)
 
-	return hdr, mxFrame, bestSlot, nil
+	// Snapshot minFrame, captured under the validated reader lock exactly
+	// like SQLite's pWal->minFrame = nBackfill+1 (wal.c:3239). The read tx
+	// carries this fixed value for all its WAL lookups.
+	return hdr, mxFrame, nBackfill + 1, bestSlot, nil
 }
 
 // endRead releases the reader lock for the given slot.

--- a/internal/btree/wal.go
+++ b/internal/btree/wal.go
@@ -1072,6 +1072,21 @@ func (wi *walIndex) shmHashWrite(pgno, frame uint32) error {
 		return err
 	}
 
+	// Lazily zero the segment's aPgno+aHash area when writing its FIRST
+	// entry, matching SQLite walIndexAppend (wal.c:1324-1330
+	// `if( idx==1 ){ memset((void*)&aPgno[1], 0, nByte); }`). A WAL reset
+	// (shmClearHash) only clears the segments the resetting connection has
+	// mapped; a WAL that previously grew further left stale entries from
+	// the prior generation in the higher segments, and those occupied slots
+	// overflow the bounded probe below (observed as ErrCorrupt on commit at
+	// frame 131039, the first frame of segment 32, after a reset of a
+	// ~140k-frame WAL). aHash is the tail of the region, so clearing from
+	// aPgno[0] to the region end covers both arrays in every segment.
+	if idx == 0 {
+		pgnoBase, _, _ := htSegmentInfo(seg)
+		clear(region[pgnoBase:])
+	}
+
 	// Write pgno to aPgno[idx] first (SQLite wal.c:1337). u32-aligned.
 	pgnoOff := htPgnoOffset(seg, idx)
 	atomic.StoreUint32((*uint32)(unsafe.Pointer(&region[pgnoOff])), pgno)
@@ -1101,6 +1116,9 @@ func (wi *walIndex) shmHashWrite(pgno, frame uint32) error {
 			return nil
 		}
 		if nCollide--; nCollide < 0 {
+			if debugTrace {
+				trace("shmHashWrite: CORRUPT full chain pgno=%d frame=%d seg=%d idx=%d", pgno, frame, seg, idx)
+			}
 			return ErrCorrupt
 		}
 		h = (h + 1) & (htNSlot - 1)
@@ -1181,6 +1199,9 @@ func (wi *walIndex) shmHashGet(pgno, maxFrame, minFrame uint32) (uint32, error) 
 			// Bound the probe AFTER the match check, like C (wal.c:3592-3595):
 			// walking past nCollide occupied slots = full/corrupt chain.
 			if nCollide--; nCollide == 0 {
+				if debugTrace {
+					trace("shmHashGet: CORRUPT over-probed chain pgno=%d seg=%d maxFrame=%d minFrame=%d", pgno, seg, maxFrame, minFrame)
+				}
 				return 0, ErrCorrupt
 			}
 			h = (h + 1) & (htNSlot - 1)
@@ -1196,8 +1217,14 @@ func (wi *walIndex) shmHashGet(pgno, maxFrame, minFrame uint32) (uint32, error) 
 
 // shmClearHash zeros out all hash table data in shm regions.
 // Called during WAL reset. Preserves the header area in region 0.
+//
+// Best-effort: only segments this connection has mapped are cleared (the
+// loop stops at the first unmapped region, which on mmap SHM may be before
+// the end of the shm file if a peer grew the WAL further). Segments missed
+// here are lazily zeroed by shmHashWrite when their first entry of the new
+// WAL generation is written, matching SQLite walIndexAppend (wal.c:1324-1330).
 func (wi *walIndex) shmClearHash() {
-	for seg := range shmMaxRegions {
+	for seg := 0; ; seg++ {
 		region, err := wi.shm.region(seg, false)
 		if err != nil {
 			break

--- a/internal/btree/wal_reader_retry_test.go
+++ b/internal/btree/wal_reader_retry_test.go
@@ -60,7 +60,7 @@ func TestTryBeginReadMultiProcessHdr_AllSlotsBusyReturnsRetry(t *testing.T) {
 		}
 	}()
 
-	_, _, _, err = w.tryBeginReadMultiProcessHdr()
+	_, _, _, _, err = w.tryBeginReadMultiProcessHdr()
 	if !errors.Is(err, errWALRetry) {
 		t.Fatalf("got err=%v (type %T), want errWALRetry — SQLite wal.c:3188 converts SQLITE_BUSY to WAL_RETRY here", err, err)
 	}

--- a/internal/btree/wal_test.go
+++ b/internal/btree/wal_test.go
@@ -2054,18 +2054,22 @@ func TestShmHashWrite_CollisionLimit_Corrupt(t *testing.T) {
 	region, err := wi.shm.region(0, true)
 	require.NoError(t, err)
 
-	// Target frame 1 => idx 0 => nCollide = idx+1 = 1. The probe may pass over
-	// at most one occupied slot; a second occupied slot is provably corrupt.
+	// Target frame 2 => idx 1 => nCollide = idx+1 = 2. The probe may pass over
+	// at most two occupied slots; a third occupied slot is provably corrupt.
+	// (Frame 1 / idx 0 cannot exercise the bound: the segment's first write
+	// lazily zeroes the whole table first, matching SQLite walIndexAppend
+	// wal.c:1324-1330.)
 	const pgno = uint32(12345)
-	const frame = uint32(1)
+	const frame = uint32(2)
 	h0 := int(pgno*htHash1) & (htNSlot - 1)
 
-	// Occupy the first TWO slots of pgno's probe chain with non-matching, valid
-	// entries so there is no empty slot within nCollide+1 probes. (No third
-	// slot is occupied, so a fix that mis-bounds the probe would still find a
-	// free slot — only the correctly-bounded check fires here.)
+	// Occupy the first THREE slots of pgno's probe chain with non-matching,
+	// valid entries so there is no empty slot within nCollide+1 probes. (No
+	// fourth slot is occupied, so a fix that mis-bounds the probe would still
+	// find a free slot — only the correctly-bounded check fires here.)
 	binary.LittleEndian.PutUint16(region[hashSlotOff(h0):], 7)
 	binary.LittleEndian.PutUint16(region[hashSlotOff((h0+1)&(htNSlot-1)):], 9)
+	binary.LittleEndian.PutUint16(region[hashSlotOff((h0+2)&(htNSlot-1)):], 11)
 
 	err = wi.shmHashWrite(pgno, frame)
 	require.ErrorIs(t, err, ErrCorrupt,
@@ -2086,14 +2090,57 @@ func TestShmHashWrite_CollisionLimit_PropagatesThroughSetBatch(t *testing.T) {
 
 	const pgno = uint32(54321)
 	h0 := int(pgno*htHash1) & (htNSlot - 1)
-	// frame 1 => idx 0 => nCollide = 1: two occupied slots => corrupt.
+	// frame 2 => idx 1 => nCollide = 2: three occupied slots => corrupt.
+	// (Frame 1 would lazily zero the segment first — see walIndexAppend's
+	// idx==1 memset, mirrored in shmHashWrite.)
 	binary.LittleEndian.PutUint16(region[hashSlotOff(h0):], 3)
 	binary.LittleEndian.PutUint16(region[hashSlotOff((h0+1)&(htNSlot-1)):], 5)
+	binary.LittleEndian.PutUint16(region[hashSlotOff((h0+2)&(htNSlot-1)):], 7)
 
 	p := &page{pgno: pgno}
-	err = wi.setBatch([]*page{p}, 1, true)
+	err = wi.setBatch([]*page{p}, 2, true)
 	require.ErrorIs(t, err, ErrCorrupt,
 		"setBatch must propagate shmHashWrite's ErrCorrupt so the commit aborts")
+}
+
+// TestShmHashWrite_FirstFrameLazilyClearsSegment verifies that writing the
+// FIRST entry of a hash segment zeroes the whole segment first, matching
+// SQLite walIndexAppend (wal.c:1324-1330 `if( idx==1 ) memset(...)`). This is
+// what makes stale entries from a previous WAL generation harmless: a WAL
+// reset only clears the segments the resetting connection has mapped, so a
+// regrowing WAL must be able to reclaim a junk-filled segment. Regression
+// test for the multi-process writer aborting with ErrCorrupt at the first
+// frame of segment 32 after a reset of a larger WAL.
+func TestShmHashWrite_FirstFrameLazilyClearsSegment(t *testing.T) {
+	wi, err := newWalIndex("", true)
+	require.NoError(t, err)
+	defer wi.close(false)
+
+	region, err := wi.shm.region(0, true)
+	require.NoError(t, err)
+
+	// Simulate a previous WAL generation: fill EVERY hash slot and a few
+	// aPgno entries with junk, as if the segment had been fully used and
+	// never cleared by reset.
+	for h := 0; h < htNSlot; h++ {
+		binary.LittleEndian.PutUint16(region[hashSlotOff(h):], uint16(h%htNPage)+1)
+	}
+	for i := 0; i < 16; i++ {
+		binary.LittleEndian.PutUint32(region[htPgnoOff0+i*4:], uint32(100000+i))
+	}
+
+	// Writing frame 1 (the segment's first entry of the new generation) must
+	// succeed — not ErrCorrupt — because the segment is zeroed first.
+	const pgno = uint32(777)
+	require.NoError(t, wi.shmHashWrite(pgno, 1),
+		"first frame of a segment must lazily clear stale entries, not trip the collision bound")
+
+	// The new entry is findable, and the junk is gone: a lookup for one of
+	// the junk page numbers misses cleanly.
+	frame := mustShmHashGet(t, wi, pgno, 1, 1)
+	require.Equal(t, uint32(1), frame)
+	miss := mustShmHashGet(t, wi, 100003, 1, 1)
+	require.Zero(t, miss, "stale pre-reset entries must not survive the segment's first write")
 }
 
 // TestShmHashGet_FullChain_Corrupt verifies the READ-side bound: a probe chain

--- a/internal/btree/wal_test.go
+++ b/internal/btree/wal_test.go
@@ -2142,7 +2142,7 @@ func TestShmHashGet_FullChain_Corrupt_PropagatesThroughGet(t *testing.T) {
 	}
 	binary.LittleEndian.PutUint32(region[htPgnoOff0:], 999999)
 
-	frame, err := wi.get(7, 100)
+	frame, err := wi.get(7, 100, wi.liveMinFrame())
 	require.ErrorIs(t, err, ErrCorrupt,
 		"walIndex.get must forward shmHashGet's ErrCorrupt to the pager")
 	require.Zero(t, frame)
@@ -2173,7 +2173,7 @@ func mustShmHashWrite(t *testing.T, wi *walIndex, pgno, frame uint32) {
 
 func mustWiGet(t *testing.T, wi *walIndex, pgno, maxFrame uint32) uint32 {
 	t.Helper()
-	v, err := wi.get(pgno, maxFrame)
+	v, err := wi.get(pgno, maxFrame, wi.liveMinFrame())
 	if err != nil {
 		t.Fatalf("walIndex.get(%d, %d): unexpected error: %v", pgno, maxFrame, err)
 	}
@@ -2269,7 +2269,7 @@ func TestWALReaderSlotReuseRevalidatesOnStaleMark(t *testing.T) {
 
 	// The reuse path must detect the changed state and signal retry rather than
 	// silently adopting the stale (now-unsafe) snapshot.
-	_, _, _, err := w.tryBeginReadInProcessHdr()
+	_, _, _, _, err := w.tryBeginReadInProcessHdr()
 	require.True(t, injected, "test must exercise the slot-reuse shared-lock path")
 	require.ErrorIs(t, err, errWALRetry,
 		"reuse branch must re-validate and retry when the checkpointer advanced "+
@@ -2279,7 +2279,7 @@ func TestWALReaderSlotReuseRevalidatesOnStaleMark(t *testing.T) {
 	// adopt the LIVE commit ceiling (20), never the stale snapshot (10). A
 	// snapshot that floored at the stale mark while nBackfill had already
 	// advanced to 10 is exactly the corruption window the re-validation closes.
-	hdr, maxFrame, slot, err := w.tryBeginReadInProcessHdr()
+	hdr, maxFrame, _, slot, err := w.tryBeginReadInProcessHdr()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(20), maxFrame, "retry must adopt the live commit ceiling, not the stale 10")
 	assert.Equal(t, uint32(20), hdr.mxFrame)
@@ -2312,7 +2312,7 @@ func TestWALReaderSlotReuseFastPathSafeAfterBackfill(t *testing.T) {
 	w.index.nBackfill.Store(10)
 	w.index.aReadMark[1].Store(10)
 
-	hdr, maxFrame, slot, err := w.tryBeginReadInProcessHdr()
+	hdr, maxFrame, _, slot, err := w.tryBeginReadInProcessHdr()
 	require.NoError(t, err)
 	assert.Equal(t, 0, slot, "fully-backfilled WAL must use the slot-0 fast path")
 	assert.Equal(t, uint32(10), maxFrame)
@@ -2337,7 +2337,7 @@ func TestWALReaderSlotReuseSucceedsWhenStateStable(t *testing.T) {
 	w.index.nBackfill.Store(3)
 	w.index.aReadMark[1].Store(10)
 
-	hdr, maxFrame, slot, err := w.tryBeginReadInProcessHdr()
+	hdr, maxFrame, _, slot, err := w.tryBeginReadInProcessHdr()
 	require.NoError(t, err)
 	require.False(t, errors.Is(err, errWALRetry))
 	assert.Equal(t, 1, slot, "stable state must reuse the existing slot 1")

--- a/stats_mp_test.go
+++ b/stats_mp_test.go
@@ -1,0 +1,150 @@
+package anystore
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/internal/btree"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatsMultiprocessReader reproduces the reported scenario: one OS
+// process writes a few large documents to a collection while a second
+// process (like the CLI) periodically calls collection.Stats(). The reader
+// must never see "btree: database is corrupt".
+//
+// The child process is the WRITER; the parent is the polling READER.
+func TestStatsMultiprocessReader(t *testing.T) {
+	if path := os.Getenv("STATS_MP_WRITER_PATH"); path != "" {
+		statsMpWriterChild(t, path)
+		return
+	}
+	if testing.Short() {
+		t.Skip("multi-process test skipped in -short mode")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats_mp.db")
+
+	// Reader opens with defaults, like the CLI does.
+	readerDB, err := Open(ctx, path, nil)
+	require.NoError(t, err)
+	defer readerDB.Close()
+	coll, err := readerDB.CreateCollection(ctx, "agent_debug_log")
+	require.NoError(t, err)
+
+	// Seed one doc so the collection btrees exist.
+	require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(`{"id":"seed","body":"x"}`)))
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStatsMultiprocessReader$", "-test.timeout=60s")
+	cmd.Env = append(os.Environ(), "STATS_MP_WRITER_PATH="+path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+	childDone := make(chan error, 1)
+	go func() { childDone <- cmd.Wait() }()
+
+	polls := 0
+	var lastDocCount int
+	for done := false; !done; {
+		select {
+		case cErr := <-childDone:
+			require.NoError(t, cErr, "writer child failed")
+			done = true
+		default:
+		}
+		stats, sErr := coll.Stats(ctx)
+		if sErr != nil {
+			statsMpDiagnose(t, readerDB.(*db), coll, polls, lastDocCount, sErr)
+		}
+		lastDocCount = stats.DocCount
+		polls++
+	}
+	t.Logf("completed %d Stats() polls without corruption, final DocCount=%d", polls, lastDocCount)
+}
+
+// statsMpDiagnose breaks the failed Stats poll into its sub-operations to
+// identify exactly which step fails, then retries to see whether the error
+// is transient (race window) or persistent (durable bad state).
+func statsMpDiagnose(t *testing.T, d *db, coll Collection, polls, lastDocCount int, origErr error) {
+	t.Helper()
+	c := coll.(*collection)
+	for attempt := 0; attempt < 3; attempt++ {
+		var steps []string
+		_ = d.doReadTx(ctx, func(tx *btree.ReadTx) error {
+			steps = append(steps, fmt.Sprintf("snapshot: walMaxFrame=%d dbSize=%d", tx.WalMaxFrame(), tx.DatabaseSize()))
+			cursor := tx.NewCursor(c.ns)
+			defer cursor.Close()
+			if err := cursor.First(); err != nil {
+				steps = append(steps, fmt.Sprintf("cursor.First: %v", err))
+				return nil
+			}
+			n := 0
+			for cursor.Valid() {
+				if _, err := cursor.Value(); err != nil {
+					steps = append(steps, fmt.Sprintf("cursor.Value(doc %d): %v", n, err))
+					return nil
+				}
+				n++
+				if err := cursor.Next(); err != nil {
+					steps = append(steps, fmt.Sprintf("cursor.Next(doc %d): %v", n, err))
+					return nil
+				}
+			}
+			steps = append(steps, fmt.Sprintf("scan ok: %d docs", n))
+			if _, err := tx.NamespaceSize(c.ns); err != nil {
+				steps = append(steps, fmt.Sprintf("NamespaceSize: %v", err))
+				return nil
+			}
+			steps = append(steps, "NamespaceSize ok")
+			return nil
+		})
+		t.Logf("diagnose attempt %d: %v", attempt, steps)
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("poll %d (lastDocCount=%d): Stats: %v", polls, lastDocCount, origErr)
+}
+
+// statsMpWriterChild writes a few large (~1MB, incompressible) documents per
+// transaction in a loop, like an application logging large payloads.
+func statsMpWriterChild(t *testing.T, path string) {
+	writerDB, err := Open(ctx, path, nil)
+	require.NoError(t, err)
+	coll, err := writerDB.OpenCollection(ctx, "agent_debug_log")
+	require.NoError(t, err)
+
+	rng := rand.New(rand.NewSource(1))
+	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789 "
+	bigBody := func() string {
+		var sb strings.Builder
+		sb.Grow(1 << 20)
+		for sb.Len() < 1<<20 {
+			sb.WriteByte(alphabet[rng.Intn(len(alphabet))])
+		}
+		return sb.String()
+	}
+
+	deadline := time.Now().Add(6 * time.Second)
+	iter := 0
+	for time.Now().Before(deadline) {
+		docs := make([]*anyenc.Value, 0, 3)
+		arena := &anyenc.Arena{}
+		for i := 0; i < 3; i++ {
+			obj := arena.NewObject()
+			obj.Set("id", arena.NewString(fmt.Sprintf("doc-%d-%d", iter, i)))
+			obj.Set("body", arena.NewString(bigBody()))
+			docs = append(docs, obj)
+		}
+		require.NoError(t, coll.Insert(ctx, docs...))
+		iter++
+	}
+	t.Logf("writer child: %d insert batches", iter)
+	require.NoError(t, writerDB.Close())
+}


### PR DESCRIPTION
## Summary

Fixes the reported bug: a CLI process polling `collection.Stats()` while another process writes large documents gets `btree: database is corrupt`. Root-caused to three independent cross-process bugs, each a drift from SQLite's WAL design; all fixes re-align with the corresponding `wal.c` mechanics.

1. **`NamespaceSize` overflow-chain bound** (the reported bug, deterministic): `countOverflowChain` validated page numbers against `pager.dbSize` — a process-local counter only the write path refreshes — instead of the reader-snapshot bound. Any overflow chain past the reader's open-time size was reported corrupt. Now uses `readerDbSizeBound(bt.cache)`.

2. **Reader snapshot isolation across WAL restarts** (intermittent, torn reads):
   - per-connection cache validity keyed on `(dataVersion, walMaxFrame)` suffers cross-process ABA after checkpoint-RESTART (frame numbers recycle, peer restarts never bump a reader's `dataVersion`). Now keyed on the **full WAL-index header** — `aSalt` re-randomizes on every restart (SQLite's header-memcmp → `pager_reset` signal).
   - `walIndex.get()` recomputed `minFrame = nBackfill+1` **live** per lookup, so a slot-0 reader coexisting with a peer's restart accepted new-generation frames into its old snapshot. `minFrame` is now captured once at `BeginRead` (slot-0 → `maxFrame+1`, i.e. WAL reads disabled), matching `pWal->minFrame` (wal.c:3239) and the `readLock==0` short-circuit in `walFindFrame` (wal.c:3567).

3. **Stale SHM hash segments after reset** (writer aborts at frame 131,039): `shmClearHash` only cleared the segments the resetting connection had mapped (capped at 32), so a regrown WAL hit leftover entries and overflowed the bounded collision probe. Adopted SQLite's lazy clear: zero a segment when writing its first entry (`walIndexAppend`, wal.c:1324-1330).

## Tests

- `TestStatsMultiprocessReader` (new, anystore-level): child process inserts ~1MB docs while the parent polls `Stats()`. Failed 100% on the first cross-process commit before; 8/8 green after.
- `TestMultiProcessReaderScanCorruption` (new, btree-level): low checkpoint threshold forces frequent RESTART cycles under a continuously scanning reader; caught both the torn-value race and the writer-side hash corruption. 10/10 green after.
- Full `./internal/btree` suite, root + query/anyenc/qplanner, and `-race` on the WAL/checkpoint/SHM tests: green.

## Benchmarks

`any-store-tests` benchmark, groups `id_queries` / `fullscan` / `crud` / `overflow`, 3 samples each side: **no degradation** — geomean −0.86%, every scenario statistically unchanged, allocations identical (the reader path now reads a cached `minFrame` instead of an SHM atomic per lookup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)