### PR TITLE
fix: avoid mutating shared defaultSQLiteOptions map in setDefaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,7 +76,7 @@ func (c *Config) setDefaults() {
 		c.ReadConnections = runtime.NumCPU()
 	}
 	if c.SQLiteConnectionOptions == nil {
-		c.SQLiteConnectionOptions = defaultSQLiteOptions
+		c.SQLiteConnectionOptions = make(map[string]string, len(defaultSQLiteOptions))
 	}
 	for k, v := range defaultSQLiteOptions {
 		c.SQLiteConnectionOptions[k] = v

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,24 @@
+package anystore
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_setDefaultsConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := &Config{}
+			c.setDefaults()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, "-2000", defaultSQLiteOptions["cache_size"])
+	assert.Len(t, defaultSQLiteOptions, 1)
+}


### PR DESCRIPTION
Closes #115.

When `Config.SQLiteConnectionOptions` is nil, `setDefaults` aliased the package-level `defaultSQLiteOptions` map and then wrote into it via the copy loop, so two concurrent `Open()` calls on the default path mutated the same global map and could trigger `fatal error: concurrent map writes`. Allocating a fresh map on the nil path (the same thing `pragma()` already does) keeps the global read-only. Added a race test that runs setDefaults from several goroutines and fails under `-race` without the change.