### PR TITLE
fts: phrase, prefix, require/exclude operators + configurable BM25 + per-field weights

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -982,7 +982,8 @@ func (c *collection) buildFtsIndex(tx *btree.WriteTx, fx *ftsIndex) error {
 			return err
 		}
 	}
-	return nil
+	// Stamp the postings format version so a future upgrade can detect old data.
+	return fx.putMetaUint(tx, ftsMetaFormat, ftsFormatVersion)
 }
 
 func (c *collection) DropIndex(ctx context.Context, indexName string) (err error) {

--- a/config.go
+++ b/config.go
@@ -59,6 +59,15 @@ type Config struct {
 	// cache-spill behavior at low data volumes. Zero means use the default.
 	CacheSize int
 
+	// ReadConcurrency caps the number of concurrent read transactions. Reads
+	// beyond this many serialize on a semaphore, so on a multi-core host a low cap
+	// throttles concurrent Find/$text throughput. Each live reader holds its own
+	// page cache (≈ CacheSize × PageSize), created lazily, so peak reader RAM is
+	// ReadConcurrency × that — only realized under actual concurrent load. Zero
+	// means the default, max(NumCPU-1, 4), which scales with the host while staying
+	// modest on small devices.
+	ReadConcurrency int
+
 	// InMemory keeps the entire database in memory with no files on disk.
 	// The database does not survive process crashes. When true, InProcess
 	// and CommitSync=false are forced on automatically.

--- a/db.go
+++ b/db.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -134,6 +135,16 @@ func Open(ctx context.Context, path string, config *Config) (DB, error) {
 	if cacheSize <= 0 {
 		cacheSize = 5000
 	}
+	// Concurrent read transactions are bounded by a semaphore (each live reader
+	// holds its own page cache). The default scales with the host — max(NumCPU-1,
+	// 4) — so concurrent $text/Find reads aren't artificially serialized on a
+	// multi-core machine, while staying modest on small devices. Reader caches are
+	// created lazily up to this cap, so RAM follows actual concurrency, not the
+	// cap. Override via Config.ReadConcurrency.
+	readConcurrency := config.ReadConcurrency
+	if readConcurrency <= 0 {
+		readConcurrency = max(runtime.NumCPU()-1, 4)
+	}
 	// Page-level integrity is on by default for non-encrypted databases.
 	// XXH3-128 trailer per page costs <1% on writes and is invisible on
 	// reads. Encrypted databases get stronger integrity from the
@@ -143,6 +154,7 @@ func Open(ctx context.Context, path string, config *Config) (DB, error) {
 	opts := btree.Options{
 		PageSize:              4096,
 		CacheSize:             cacheSize,
+		MaxReaders:            readConcurrency,
 		InProcess:             false,
 		NoCommitSync:          !config.CommitSync,
 		InMemory:              config.InMemory,

--- a/db.go
+++ b/db.go
@@ -968,6 +968,10 @@ func (db *db) getIndexInfos(tx *btree.ReadTx, collName string) ([]IndexInfo, err
 		}
 		if info.Kind == IndexKindFulltext {
 			info.Fulltext = &FulltextParams{}
+			if fv := v.Get("fulltext"); fv != nil {
+				info.Fulltext.B = fv.GetFloat64("b")
+				info.Fulltext.K1 = fv.GetFloat64("k1")
+			}
 		}
 		for _, fv := range v.GetArray("fields") {
 			info.Fields = append(info.Fields, string(fv.GetStringBytes()))
@@ -1073,6 +1077,18 @@ func (db *db) registerIndex(tx *btree.WriteTx, collName string, info IndexInfo) 
 			vobj.Set("hvc", a.NewNumberInt(1))
 		}
 		obj.Set("vector", vobj)
+	}
+	if info.Kind == IndexKindFulltext && info.Fulltext != nil {
+		if info.Fulltext.B != 0 || info.Fulltext.K1 != 0 {
+			fobj := a.NewObject()
+			if info.Fulltext.B != 0 {
+				fobj.Set("b", a.NewNumberFloat64(info.Fulltext.B))
+			}
+			if info.Fulltext.K1 != 0 {
+				fobj.Set("k1", a.NewNumberFloat64(info.Fulltext.K1))
+			}
+			obj.Set("fulltext", fobj)
+		}
 	}
 	return tx.Put(db.systemNS, key, obj.MarshalTo(nil))
 }

--- a/db.go
+++ b/db.go
@@ -971,6 +971,17 @@ func (db *db) getIndexInfos(tx *btree.ReadTx, collName string) ([]IndexInfo, err
 			if fv := v.Get("fulltext"); fv != nil {
 				info.Fulltext.B = fv.GetFloat64("b")
 				info.Fulltext.K1 = fv.GetFloat64("k1")
+				if wv := fv.Get("weights"); wv != nil {
+					if wobj, oerr := wv.Object(); oerr == nil {
+						weights := map[string]float64{}
+						wobj.Visit(func(key []byte, val *anyenc.Value) {
+							weights[string(key)] = val.GetFloat64()
+						})
+						if len(weights) > 0 {
+							info.Fulltext.Weights = weights
+						}
+					}
+				}
 			}
 		}
 		for _, fv := range v.GetArray("fields") {
@@ -1079,13 +1090,21 @@ func (db *db) registerIndex(tx *btree.WriteTx, collName string, info IndexInfo) 
 		obj.Set("vector", vobj)
 	}
 	if info.Kind == IndexKindFulltext && info.Fulltext != nil {
-		if info.Fulltext.B != 0 || info.Fulltext.K1 != 0 {
+		ft := info.Fulltext
+		if ft.B != 0 || ft.K1 != 0 || len(ft.Weights) != 0 {
 			fobj := a.NewObject()
-			if info.Fulltext.B != 0 {
-				fobj.Set("b", a.NewNumberFloat64(info.Fulltext.B))
+			if ft.B != 0 {
+				fobj.Set("b", a.NewNumberFloat64(ft.B))
 			}
-			if info.Fulltext.K1 != 0 {
-				fobj.Set("k1", a.NewNumberFloat64(info.Fulltext.K1))
+			if ft.K1 != 0 {
+				fobj.Set("k1", a.NewNumberFloat64(ft.K1))
+			}
+			if len(ft.Weights) != 0 {
+				wobj := a.NewObject()
+				for field, w := range ft.Weights {
+					wobj.Set(field, a.NewNumberFloat64(w))
+				}
+				fobj.Set("weights", wobj)
 			}
 			obj.Set("fulltext", fobj)
 		}

--- a/docs/fts/DESIGN.md
+++ b/docs/fts/DESIGN.md
@@ -122,8 +122,9 @@ NFKC normalize  ->  Unicode case-fold  ->  UAX#29 word split  ->  CJK bigram
   UAX#29 emits each CJK ideograph/kana/Hangul syllable as its own token.
 - **CJK bigrams**: consecutive CJK characters are re-assembled into overlapping
   bigrams (`東京都` → `東京`, `京都`) at contiguous positions. A lone CJK char is a
-  unigram. A CJK query is rewritten to a **phrase** over its bigrams and scored
-  by summing the bigram BM25 contributions.
+  unigram. A CJK query is matched as a **phrase** over its bigrams (positional
+  adjacency) and scored as one synthetic term: TF = the adjacency-confirmed
+  occurrence count, IDF = the sum of the constituent bigrams' IDFs.
 
 Explicitly **not** done: stemming (we can't assume a per-field language; prefix
 search covers most of its value) and diacritic stripping (NFKC already makes the
@@ -264,11 +265,20 @@ To guarantee a correct global top-k the search exhausts the query terms' chunks
 (cheap at our scale: decoding ~100k varint postings is single-digit ms). No
 index-intersection pushdown is built into the postings format.
 
-Phrase / CJK matching (deferred) would be a zig-zag merge join on `IntDocID`
-across the involved terms' chunks, then a positional adjacency check.
+Phrase / CJK matching (**implemented**, Phase 1 — see `FTS-V2-PLAN.md`) is a
+zig-zag merge join on `IntDocID` across the phrase terms' chunks (`termStream`),
+then a positional adjacency check; it scores the phrase as a synthetic term
+(TF = adjacency count, IDF = Σ of constituent IDFs). A CJK run analyzes to
+adjacent bigrams and is matched as an implicit phrase.
 
-Prefix / search-as-you-type: prefix-scan `fts:vocab`, take the top-M completions
-by `df`, then query only those terms' postings — bounds latency.
+Prefix / search-as-you-type (**implemented**, Phase 1): prefix-scan `fts:vocab`,
+take the top-M completions by `df` (`ftsPrefixMaxExpansions`), then OR those
+terms' postings — bounds latency.
+
+Boolean require/exclude (**implemented**, Phase 1) come from the typed
+`$require`/`$exclude` sub-fields of `$text` (not inline `+`/`-`): required clauses
+gate a per-doc `requiredMask` in the accumulator; excluded clauses tombstone
+matching docs. `$defaultOperator:"and"` makes bare `$search` terms required.
 
 ## On-disk invariants that are expensive to change
 
@@ -328,10 +338,15 @@ The real footprint lever is structural, not compression: a positionless
 (`DOCS_AND_FREQS_ONLY`) mode halves the postings (positions are ~50% of them).
 At ~19MB index for 29MB text (with positions), the index is already well-coded.
 
-Explicitly **deferred to v2+**: top-k materialization in `search` (it currently
-clones every matched id before `Limit` trims); replacing the per-doc `docinfo`
-`Get` with an in-memory dense quantized doc-length array (safe now that
-`IntDocID` is stable and dense); fuzzy/Levenshtein search over `fts:vocab`;
-chunk-level (max-TF) WAND skipping; configurable analyzers; positional CJK phrase
-matching; `DOCS_AND_FREQS_ONLY` positionless fields. Stop words are intentionally
+Implemented since the original v1 cut (Phase 1, `FTS-V2-PLAN.md`): phrase /
+positional CJK matching; prefix search; boolean require/exclude (`$require` /
+`$exclude`) and `$defaultOperator`.
+
+Explicitly **deferred to v2+**: per-field weights / BM25F (Phase 3 — postings v2
++ docinfo v2); configurable BM25 `b`/`k1` (Phase 2); top-k materialization in
+`search` (it currently clones every matched id before `Limit` trims); replacing
+the per-doc `docinfo` `Get` with an in-memory dense quantized doc-length array
+(safe now that `IntDocID` is stable and dense); fuzzy/Levenshtein search over
+`fts:vocab`; chunk-level (max-TF) WAND skipping; configurable analyzers /
+stemming; `DOCS_AND_FREQS_ONLY` positionless fields. Stop words are intentionally
 indexed (cheap under delta-varints; personal-notes users search "to do" etc.).

--- a/docs/fts/FTS-PERF-PLAN.md
+++ b/docs/fts/FTS-PERF-PLAN.md
@@ -1,0 +1,171 @@
+# FTS Perf — Top-k / Concurrency Plan (P1)
+
+Status: **design** (follows `FTS-V2-PLAN.md` Phases 1–3, merged in PR #123).
+
+Reviewed with an outside expert (Gemini 3.1 Pro) on 2026-06-18. The headline:
+**staged, measure-gated — do the cheap fixes first and stop if they suffice.**
+Do NOT start with WAND.
+
+## UPDATE (measured 2026-06-18) — the diagnosis changed; profile beat hypothesis
+
+We profiled before building, and the concurrency story was **not** GC:
+
+- A **block profile** put 76% of blocked time in `btree.(*DB).beginRead` — the
+  engine caps concurrent read transactions with a semaphore (each live reader
+  holds its own page cache; a RAM bound), and the default cap was **4**. 32 worker
+  goroutines were serializing 8:1 on it — that *was* the "~3.9× scaling".
+- **Fix:** default `ReadConcurrency = max(NumCPU−1, 4)` (anystore `Config`, wired
+  to `btree.Options.MaxReaders`); reader caches are lazily created, so RAM follows
+  *actual* concurrency, not the cap. Result: 1→16-core scaling **3.9× → 14.2×**,
+  chunk-profile aggregate **5.3k → 24.3k q/s**. Concurrency is solved, with zero
+  FTS change.
+- The alloc cleanup (per-query chunk-reader reuse, accumulator pool size-cap) was
+  done too (high-DF query 227 → 72 allocs/op — we'd regressed to one heap reader
+  per 128-doc chunk via an interface return). It's hygiene; it did **not** move
+  latency or scaling.
+
+**Reprioritized next steps (expert-confirmed):**
+1. **Dense doc-length array** — highest ROI; see new section below.
+2. **Lead-iterator AND** — insurance against pathological high-DF AND queries.
+3. **Drop Block-Max WAND.** For a single-user local-first store, 1 ms vs 5 ms is
+   sub-frame-invisible and concurrent throughput is already "functionally
+   infinite" (24k q/s for one user). BMW is server-throughput tech → pure
+   architectural debt here. The P1c section below is kept only as a record of the
+   decision *not* to build it.
+4. **Then ship.**
+
+### New P1 (highest ROI) — dense doc-length array
+
+The single-thread cost is "cost #1": the read path scores every matching posting,
+and each scored posting does a B-tree point-`Get` on `docinfo` for the doc length
+(BM25 length-norm) — a B-tree traversal + page pin + 128-item binary search,
+millions of times per high-DF query. Replace with an O(1) lookup:
+
+- A dense `[]uint32` keyed by IntDocID (dense, stable). ~4 MB at 1M docs — don't
+  quantize (quantization is a billions-of-docs concern).
+- **Cross-process snapshot trap:** don't keep a long-lived globally-synced array.
+  Cache it at the DB level **tied to a btree commit generation**; on read-tx
+  start, if the cached generation matches the tx snapshot, use it; else lazily
+  clone + apply the `docinfo` delta (scan only keys changed since the cached
+  generation), then atomically swap the cached pointer. 4 MB copy at a write
+  boundary is negligible.
+- No format change, no algorithm change; expected to ~halve single-thread latency.
+
+## Measured bottleneck
+
+Paragraph-chunk profile (38k small docs, avgDocLen ≈ 58, 26 MB index, warm,
+Ryzen 9950X 16C/32T), realistic mixed query set:
+
+- single-thread: ~1,360 q/s (~735 µs/query) — raw speed is fine.
+- concurrent 32 workers: ~5,300 q/s — **only ~3.9× scaling**. The red flag.
+- Cost is dominated by high-DF common terms; rare terms are tens of µs.
+
+Root cause: the read path scores **every** matching posting into a flat
+accumulator (cost scales with DF, not `Limit`), and each high-DF query allocates
+~20 KB of scratch. The poor concurrent scaling is **GC-bound** (allocation
+thrash), not lock-bound (reads use independent read-txs over a shared page cache).
+
+These are two distinct problems with two distinct fixes.
+
+## Staged plan (measure-gated)
+
+### P1a — cut per-query allocation via a per-query arena (do first; no format change)
+
+Goal: kill the GC thrash that caps concurrent scaling — **without** introducing
+uncontrolled RAM.
+
+**Core mechanism: reuse one arena for the lifetime of a single query** — not a
+cross-query pool. The churn is the *count* of allocations per query (per-term
+cursor key/prefix, per-chunk/position decode scratch, dense-TF scratch, etc.).
+Collapse them into a small set of buffers held in the query-scoped `ftsExec`
+(which already exists per query and already reuses `dlBuf`/`tokBuf`), reused
+across the whole term/chunk loop and grown on demand. The arena lives exactly as
+long as the query and is freed right after — so RAM is bounded by the number of
+**in-flight** queries (≈ concurrency), sized to each query's own need, and never
+retained between queries. This is the read-path analog of the writer-owned
+reused buffers on the write path.
+
+**Why not cross-query `sync.Pool` for the big buffers:** `sync.Pool` retains its
+contents across every P with no size bound, so pooling the *large* per-query
+buffers (the accumulator table can reach MBs on a high-DF query over a big corpus)
+lets N concurrent Ps each pin a giant buffer → unbounded RAM, which is
+unacceptable on a constrained device. Per-query arena reuse avoids retention
+entirely.
+
+**The accumulator (the one large buffer that is cross-query pooled today):**
+keep `ftsScoreAccPool` but add a **size cap** — on return, if the table grew past
+a cap, drop the oversized backing arrays (nil them) so GC reclaims them and the
+next user reallocates small. So the pool retains only small/typical tables; large
+ones are never pinned. This is the pattern the write path already uses
+(`ftsPendingShrink` / "don't pin a giant arena after a bulk load" in
+`fulltext_pending.go`). The existing pool has exactly this leak today (a huge-DF
+query pins a multi-MB table) — fixing it is part of P1a.
+
+**Small fixed-size scratch** (e.g. the analyzer — `searchCandidates` does
+`fts.NewAnalyzer()` per query, allocating NFKC + case-fold transformers) can be
+reused per query too; pooling those cross-query is low-risk (small, bounded by
+concurrency) if profiling shows it matters.
+
+**Method:** profile first (`-benchmem` + an alloc pprof on the concurrent bench)
+to find the real per-query alloc sources — don't guess. Then route them through
+the query arena, size-cap the accumulator pool, and re-bench concurrent scaling.
+
+- Expected: concurrent throughput rises toward near-linear, with RAM bounded by
+  in-flight queries (arena freed per query; pool retains only capped buffers).
+- This is the fix for the **concurrency ceiling**.
+
+### P1b — lead-iterator intersection for required (AND) queries (no format change)
+
+Today `+a +b` scores all of `a`'s and all of `b`'s postings into the accumulator,
+then drops docs missing a required bit — scanning every occurrence of a common
+required term wastefully. Instead:
+
+- Sort the required terms by DF ascending; take the **lowest-DF** term as the lead.
+- Iterate the lead's postings; for each DocID, `Seek` the other required terms'
+  chunks (`Tuple(term, IntDocID/128)` → jump straight to the chunk, binary-search
+  its ≤128 docs) to confirm presence + gather TF.
+- Work drops from O(matches of the high-DF term) to
+  O(matches of the low-DF term · log(high-DF)). AND-query latency → single-digit µs.
+- No storage change; complements the existing `requiredMask` (which still serves
+  `$defaultOperator:"and"` over should-terms).
+
+### Re-profile gate
+
+After P1a+P1b, re-measure single-thread tail + concurrent scaling on the chunk
+profile. **If acceptable for a local-first desktop/mobile app, STOP** — do not
+build WAND. Top-k pruning is only worth its complexity if the pure-OR tail latency
+is still too high after pooling.
+
+### P1c — Block-Max WAND (conditional; only if pure-OR tail is still too high)
+
+Dual-path, exact (returns the same top-k as full scoring):
+
+- **Path 1 — exact accumulator** (today's): Count/Update/Delete, explicit
+  real-field sorts, heavy residual filters. Unchanged.
+- **Path 2 — pruned top-k**: default-relevance `$text` + `Limit` only. A top-k
+  min-heap whose minimum is the live `threshold`; for each 128-doc block compute
+  `blockMaxScore`; if `< threshold`, skip the whole block.
+- **Format (free to change — alpha, no back-compat):** add per-block `MaxTF` +
+  `MinDL` (varint) to the chunk. Do **not** bake a final BM25 score — `avgdl`
+  drifts as docs change and would invalidate it (breaking the exact oracle).
+  At query time, plug `MaxTF`/`MinDL` into the *live* BM25 formula
+  (`idf·bm25(MaxTF, MinDL, avgdl_now)`) for a valid, drift-safe upper bound.
+- **Residual filter + Limit:** over-fetch `k·c` candidates via Path 2, apply the
+  filter; if ≥ k survive, yield; if the filter is too restrictive and survivors
+  drop below k, fall back to Path 1.
+- **Operators:** BMW covers pure-OR (should) scoring. Required(AND) uses P1b's
+  intersection (better than WAND-over-OR). **Phrase and prefix stay on the exact
+  path** — positional adjacency and expansion don't fit WAND's additive bounds.
+
+BMW is preferred over MaxScore/plain-WAND here because postings are already
+physically chunked into 128-doc B-tree blocks — the block boundaries BMW needs
+are free.
+
+## Decision record
+
+Expert-confirmed (2026-06-18): pooling before pruning (fixes the GC-bound
+concurrency ceiling cheaply); lead-iterator intersection for AND (large win, no
+format change); keep dual paths (pruning can't serve Count/sort/heavy-filter);
+per-block `MaxTF`+`MinDL` (not a baked score) for drift-safe BMW bounds; BMW over
+MaxScore given the existing block structure; phrase/prefix off the pruned path;
+**measure-gate** — stop after P1a+P1b unless the OR tail is still too high.

--- a/docs/fts/FTS-PERF-PLAN.md
+++ b/docs/fts/FTS-PERF-PLAN.md
@@ -1,6 +1,27 @@
 # FTS Perf — Top-k / Concurrency Plan (P1)
 
-Status: **design** (follows `FTS-V2-PLAN.md` Phases 1–3, merged in PR #123).
+Status: **concurrency + alloc hygiene SHIPPED; remaining latency optimizations
+deferred (TODO)** — see "Shipped vs TODO" below. Follows `FTS-V2-PLAN.md`
+Phases 1–3 (PR #123).
+
+## Shipped vs TODO
+
+**Shipped** (PR #123):
+- ✅ `ReadConcurrency = max(NumCPU−1, 4)` default — concurrency unblocked
+  (3.9×→14.2× scaling; 5.3k→24.3k q/s). The actual ceiling was the reader cap.
+- ✅ Per-query chunk-reader reuse + bounded accumulator pool (227→72 allocs/op).
+
+**TODO (deferred — search is interactive within budget; do only if a real large
+corpus or heavy-AND workload shows a problem):**
+- ⏳ **Dense doc-length array** — O(1) length lookup replacing the per-posting
+  `docinfo` B-tree Get; ~halves single-thread latency. Needs the generation-tied
+  cross-process cache (see "New P1" section). Highest ROI of the remaining items.
+- ⏳ **Lead-iterator AND** — drive `+required` queries from the lowest-DF term;
+  insurance against pathological high-DF AND queries on large corpora.
+- ❌ **Block-Max WAND — will not build.** For single-user local-first, the latency
+  gain is sub-frame-invisible and concurrent throughput is already far beyond one
+  user's needs; it's server-throughput tech and pure architectural debt here.
+  (The P1c section is retained only as the record of this decision.)
 
 Reviewed with an outside expert (Gemini 3.1 Pro) on 2026-06-18. The headline:
 **staged, measure-gated — do the cheap fixes first and stop if they suffice.**

--- a/docs/fts/FTS-TODO.md
+++ b/docs/fts/FTS-TODO.md
@@ -44,7 +44,8 @@ allocation analysis in its PERF-1.
      which is unsafe for raw user input);
    - ✅ prefix search (`term*`) for search-as-you-type;
    - ✅ configurable BM25 `b`/`k1` (`FulltextParams.B/K1`) — Phase 2;
-   - ⏳ per-field weights (BM25F) — Phase 3 (postings v2 + docinfo v2, re-index);
+   - ✅ per-field weights (BM25F) — Phase 3 (postings v2 + per-field TF; simplified
+     BM25F with global length-norm; `FulltextParams.Weights`); v1 data drops/recreates;
    - ⏳ language stemming — still a single default analyzer (NFKC + fold +
      UAX#29 + CJK bigram); optional, Phase 4;
    - still: `$text` only top-level or inside `$and`, one per query.

--- a/docs/fts/FTS-TODO.md
+++ b/docs/fts/FTS-TODO.md
@@ -37,15 +37,16 @@ allocation analysis in its PERF-1.
    that skips unchanged regions, or accept and document the chunking
    guidance.
 
-3. **v1 query semantics gaps that will surface in app UX:**
-   - bag-of-words OR only — no phrase queries (positions are planned v2),
-     no AND semantics, no per-field weights;
-   - **no prefix search** — search-as-you-type needs `term*` or an edge-
-     ngram option;
-   - single default analyzer (NFKC + fold + UAX#29 + CJK bigram) — no
-     language stemming;
-   - `$text` only top-level or inside `$and`, one per query.
-   TODO: prioritize prefix matching for type-ahead; phrase support next.
+3. **Query semantics — Phase 1 closed most of these** (see `FTS-V2-PLAN.md`):
+   - ✅ phrase queries (`"..."`, positional merge) + positional CJK matching;
+   - ✅ boolean AND / required + exclude — via the typed `$require` / `$exclude`
+     sub-fields and `$defaultOperator:"and"` (deliberately NOT inline `+`/`-`,
+     which is unsafe for raw user input);
+   - ✅ prefix search (`term*`) for search-as-you-type;
+   - ⏳ per-field weights (BM25F) — Phase 3 (postings v2 + docinfo v2, re-index);
+   - ⏳ language stemming — still a single default analyzer (NFKC + fold +
+     UAX#29 + CJK bigram); optional, Phase 4;
+   - still: `$text` only top-level or inside `$and`, one per query.
 
 4. Residual filters on high-df queries inherit cost #1 (the filter applies
    after full BM25 accumulation): 15.9 ms for selective-filter over the

--- a/docs/fts/FTS-TODO.md
+++ b/docs/fts/FTS-TODO.md
@@ -43,6 +43,7 @@ allocation analysis in its PERF-1.
      sub-fields and `$defaultOperator:"and"` (deliberately NOT inline `+`/`-`,
      which is unsafe for raw user input);
    - ✅ prefix search (`term*`) for search-as-you-type;
+   - ✅ configurable BM25 `b`/`k1` (`FulltextParams.B/K1`) — Phase 2;
    - ⏳ per-field weights (BM25F) — Phase 3 (postings v2 + docinfo v2, re-index);
    - ⏳ language stemming — still a single default analyzer (NFKC + fold +
      UAX#29 + CJK bigram); optional, Phase 4;

--- a/docs/fts/FTS-TODO.md
+++ b/docs/fts/FTS-TODO.md
@@ -24,9 +24,20 @@ allocation analysis in its PERF-1.
    BM25 scores EVERY matching posting before the top-k is cut: 1.8 ms +
    8.5k allocs/op for "crash" at 20k chunks (vs 24 µs rare-term — a 75x
    spread); ~0.45 allocs + 23 B per matching doc, linear (18.4k allocs/op at
-   the full 38k corpus). `Count()` pays the same. TODO: top-k pruning
-   (MaxScore/WAND/block-max postings) for latency, and pooled postings/
-   accumulator buffers for the GC churn (any-store-tests PERF-1).
+   the full 38k corpus). `Count()` pays the same.
+   - Status (2026-06-18, see `FTS-PERF-PLAN.md`): the *concurrency* side is FIXED —
+     it was the `ReadConcurrency=4` reader cap (now `max(NumCPU−1,4)`), not GC;
+     and the per-chunk reader alloc regression is fixed (227→72 allocs/op).
+     Single-thread high-DF latency is still O(matched postings) but well within
+     the 100 ms interactive budget for local-first, so the remaining items are
+     **deferred TODO** (build only if a large corpus / heavy-AND workload bites):
+     - ⏳ **dense doc-length array** (O(1) length lookup vs per-posting `docinfo`
+       Get; ~halves single-thread latency; needs a generation-tied cross-process
+       cache) — highest ROI;
+     - ⏳ **lead-iterator AND** (drive `+required` from the lowest-DF term) —
+       pathological-query insurance;
+     - ❌ **Block-Max WAND — explicitly NOT building** (sub-frame-invisible gain
+       for a single-user store; server-throughput tech = debt here).
 
 2. **Big-document writes are heavy — chunking is the mitigation.**
    Whole-article profile: single-doc update 29.8 ms (27k allocs), one-token

--- a/docs/fts/FTS-V2-PLAN.md
+++ b/docs/fts/FTS-V2-PLAN.md
@@ -209,9 +209,9 @@ type FulltextParams struct {
 
 ## Optional items
 
-- **Configurable BM25 `b` (+`k1`)** — config only, no format change. Fold into the
-  `FulltextParams`/`fulltext` sub-object plumbing; thread into `searchCandidates`.
-  Even `b≈0.4` materially cuts short-doc bias. (Can land with Phase 1.)
+- **Configurable BM25 `b` (+`k1`)** — ✅ done (Phase 2). `FulltextParams.B`/`K1`,
+  persisted in the `fulltext` sub-object, resolved per query (`ftsResolveBM25`,
+  zero ⇒ default). Even `b≈0.4` materially cuts short-doc bias.
 - **Per-index stemming** (`$language` → Snowball in the analyzer) — opt-in, changes
   indexed terms (set at create, re-index to change), adds a dependency. Lowest
   priority; phrase+prefix recover most of its value. Pair with the Phase 3
@@ -222,11 +222,12 @@ type FulltextParams struct {
 
 ## Phases
 
-- **Phase 0** — structured query parser + `$defaultOperator`; prefix-before-analyze;
+- **Phase 0** ✅ — structured query parser + `$defaultOperator`; prefix-before-analyze;
   `ChunkIterator` extraction (`V1ChunkIterator`). No format change.
-- **Phase 1** — accumulator `requiredMask`/tombstone; phrase zig-zag merge;
-  CJK→implicit phrase; prefix vocab expansion. No re-index. **(this branch)**
-- **Phase 2** — configurable `b`/`k1` (optional, may fold into Phase 1 plumbing).
+- **Phase 1** ✅ — accumulator `requiredMask`/tombstone; phrase zig-zag merge;
+  CJK→implicit phrase; prefix vocab expansion. No re-index.
+- **Phase 2** ✅ — configurable `b`/`k1` (`FulltextParams.B/K1`, `fulltext`
+  sub-object, resolved per query; default-param ranking bit-for-bit unchanged).
 - **Phase 3** — per-field weights: postings v2 + docinfo v2 + per-field meta +
   `V2ChunkIterator` + BM25F scorer + migration. The one re-index.
 - **Phase 4** — stemming; vector `nProbe` (independent).

--- a/docs/fts/FTS-V2-PLAN.md
+++ b/docs/fts/FTS-V2-PLAN.md
@@ -162,13 +162,50 @@ PosDelta   : uvarint × Σ TF_f   // GLOBAL gapped positions (unchanged from v1)
   list so `fieldIdx` is stable across reopen.
 - **`V2ChunkIterator`** reads `FieldMask`+TFs eagerly, skips positions in `Next()`
   (varint count known) → hot common-term path still never decodes positions.
-- **`FulltextParams`** carries per-field `Weights` and optional per-field `B`
-  (field→idx from `IndexInfo.Fields` order), persisted as a `fulltext` sub-object
-  on the index doc (mirrors the `vector` sub-object).
 - **Incremental update** stays one-chunk-per-term: the diff path carries per-field
   TF; moving a term title→body rewrites one chunk, not two.
 - **Migration**: a v1 chunk under a weighted index ⇒ blocking re-index on open
   (acceptable in alpha; no FTS on-disk back-compat promise yet).
+
+### Settled API — `FulltextParams` (locked 2026-06-17)
+
+One struct serves both Phase 2 (global `b`/`k1`) and Phase 3 (`Weights`), so
+neither phase churns it. `Weights` mirrors MongoDB's text-index `weights` option
+(keyed by field name, default 1.0); the scoring is BM25F, not Mongo's heuristic.
+
+```go
+type FulltextParams struct {
+    // Weights is the per-field BM25F boost, keyed by indexed field name (must
+    // match an entry of IndexInfo.Fields). A field absent from the map weighs
+    // 1.0. Mongo-compatible shape. Set at index creation; changing a weight
+    // re-indexes. Phase 3.
+    Weights map[string]float64 `json:"weights,omitempty"`
+
+    // B is the BM25 length-normalization parameter (global). 0 ⇒ 0.75. In BM25F
+    // this is the length term applied per field; a single global B is the common
+    // variant (per-field b is intentionally NOT exposed — niche, and adding the
+    // optional map later is non-breaking). Phase 2.
+    B float64 `json:"b,omitempty"`
+
+    // K1 is the BM25 term-frequency saturation parameter (global). 0 ⇒ 1.2.
+    // Phase 2.
+    K1 float64 `json:"k1,omitempty"`
+}
+```
+
+- **Field→index resolution:** `Weights` is keyed by the declared field string;
+  the writer resolves each to its `fieldIdx` (position in `IndexInfo.Fields`).
+  A weight for a field not in `Fields` is a validation error at `EnsureIndex`
+  (catches typos) — not silently ignored.
+- **Persistence:** a `fulltext` sub-object on the index doc, mirroring the
+  `vector` sub-object (`db.go`): `{ "weights": {field: w, …}, "b": …, "k1": … }`.
+  The `db.go:969` loader (today `info.Fulltext = &FulltextParams{}`) populates it.
+- **Zero-value = today's behavior:** empty map, `B=0→0.75`, `K1=0→1.2` reproduces
+  the current uniform-field BM25 exactly (the D1 single-field/weight-1 reduction).
+- **Dependency:** Phase 3 does NOT depend on Phase 2 — they only share this struct
+  and the `b`/`k1` parameters (Phase 2's global `b` is the scalar case of BM25F's
+  length term). Phase 2 may ship first (config-only, no migration) using `B`/`K1`;
+  Phase 3 adds `Weights` on the same struct. Or fold `b`/`k1` into Phase 3.
 
 ## Optional items
 

--- a/docs/fts/FTS-V2-PLAN.md
+++ b/docs/fts/FTS-V2-PLAN.md
@@ -140,9 +140,9 @@ Traps (enforced):
   then only score other clauses against docs already present. Current scale
   doesn't need it.
 
-## On-disk format for per-field weights (Phase 3)
+## On-disk format for per-field weights (Phase 3) — IMPLEMENTED
 
-Postings chunk **v2** (version byte bumped), per document:
+Postings chunk **v2** (version byte 1→2), per document:
 
 ```
 DocIDDelta : uvarint
@@ -151,21 +151,42 @@ TF_f       : uvarint × popcount(FieldMask)   // per set bit, in field order
 PosDelta   : uvarint × Σ TF_f   // GLOBAL gapped positions (unchanged from v1)
 ```
 
+**Scoring — simplified BM25F (global length normalization).** Implemented as a
+weighted-frequency combine: `TF_combined = Σ_f weight_f · tf_f`, then standard
+BM25 saturation + length-norm on the *global* doc length:
+`score = IDF · TF_combined·(k1+1) / (TF_combined + k1·(1−b+b·dl/avgdl))`.
+This is the widely-used BM25F variant and, crucially, still reduces **exactly** to
+classic BM25 for a single field with weight 1 (so the existing oracle is
+unchanged). It deliberately does **not** do per-field length normalization
+(Robertson's full BM25F), which keeps the change to the postings format alone —
+no docinfo/meta format change, no per-field `avgL_f` bookkeeping, smaller
+migration surface. Per-field length-norm is a possible future refinement.
+
 - Positions stay **global + field-gapped** — phrase merge unchanged; the gap
   still blocks cross-field phrases. Per-field weighting uses only the TF vector.
 - `FieldMask` is 1 byte for ≤7 fields; empty fields cost 0 TF bytes.
-  **Cap FTS-indexed fields at 64** (fits a uint64 mask).
-- **`fts:vocab` unchanged** — DF stays global per term (corpus rarity drives IDF;
-  a term in both title and body of one doc is df=1).
-- **`fts:docinfo` v2**: `[Len_field0, Len_field1, …]` varints instead of one len.
-- **`fts:meta`**: track `TotalTokens` per field (for `avgL_f`); store the field
-  list so `fieldIdx` is stable across reopen.
-- **`V2ChunkIterator`** reads `FieldMask`+TFs eagerly, skips positions in `Next()`
-  (varint count known) → hot common-term path still never decodes positions.
+  **FTS-indexed fields capped at 64** (`fts.MaxFields`, fits a uint64 mask).
+- **`fts:vocab` unchanged** — DF stays global per term (corpus rarity drives IDF).
+- **`fts:docinfo` / `fts:meta` unchanged** — global doc length + global token
+  total only (the simplified scorer needs no per-field lengths). `fieldIdx` comes
+  from `IndexInfo.Fields` order (already persisted in the index doc).
+- **`ChunkReader` (the v2 iterator)** reads `FieldMask`+TFs eagerly, skips
+  positions in `Next()` (count known) → hot common-term path never decodes
+  positions. Unweighted indexes use `it.TF()` (total) directly — exact v1 path.
+- **Field attribution (write path):** `analyzeInto` records `fieldStarts` (the
+  global position where each field begins, advanced by the field's max position +
+  gap so multi-element array fields don't overlap); `fieldBreakdown` walks a
+  term's ascending positions once to produce the FieldMask + per-field TF.
 - **Incremental update** stays one-chunk-per-term: the diff path carries per-field
   TF; moving a term title→body rewrites one chunk, not two.
-- **Migration**: a v1 chunk under a weighted index ⇒ blocking re-index on open
-  (acceptable in alpha; no FTS on-disk back-compat promise yet).
+- **Migration**: the postings version byte makes old (v1) data **safe** — it is
+  rejected, never mis-decoded. A `fmt` marker is stamped in `fts:meta`, and any
+  attempt to read/write a v1 chunk surfaces the actionable `ErrFtsFormatOutdated`
+  ("drop and recreate the index"). Auto-rebuild on open was considered but isn't
+  done: open uses a read tx (no write tx to rebuild in), and a rebuild interleaved
+  with an in-flight write is fragile. Under the alpha no-back-compat policy,
+  drop-and-recreate is the documented upgrade path; auto-rebuild is a future option
+  once a back-compat promise is made.
 
 ### Settled API — `FulltextParams` (locked 2026-06-17)
 
@@ -228,8 +249,10 @@ type FulltextParams struct {
   CJK→implicit phrase; prefix vocab expansion. No re-index.
 - **Phase 2** ✅ — configurable `b`/`k1` (`FulltextParams.B/K1`, `fulltext`
   sub-object, resolved per query; default-param ranking bit-for-bit unchanged).
-- **Phase 3** — per-field weights: postings v2 + docinfo v2 + per-field meta +
-  `V2ChunkIterator` + BM25F scorer + migration. The one re-index.
+- **Phase 3** ✅ — per-field weights: postings v2 (FieldMask + per-field TF) +
+  v2 ChunkReader + simplified BM25F scorer + `Weights` API + format marker /
+  `ErrFtsFormatOutdated`. docinfo/meta unchanged (global length norm). v1 data
+  upgrades by drop-and-recreate.
 - **Phase 4** — stemming; vector `nProbe` (independent).
 
 ## Decision record

--- a/docs/fts/FTS-V2-PLAN.md
+++ b/docs/fts/FTS-V2-PLAN.md
@@ -1,0 +1,204 @@
+# FTS v2 — Query Operators & Per-Field Weights — Plan
+
+Status: **planned** (branch `fts-phrase-and-prefix` implements Phase 0+1).
+
+Follows `DESIGN.md` (the locked v1 substrate) and `FTS-TODO.md` (the production
+assessment). This document is the implementation plan for the next phase of
+full-text search, plus the decisions that are expensive to reverse. It was
+reviewed with an outside expert (see "Decision record" at the end).
+
+## Motivation (from FTS-TODO.md §3)
+
+v1 is bag-of-words OR only. The gaps that surface in app UX, in leverage order:
+
+1. **Phrase + required-term (AND).** Positions are already persisted, so phrase
+   is mostly a search-time change. AND/required fixes the OR-noise problem at the
+   source (better than app-side stop-word stripping).
+2. **Per-field weights.** Index `title`/`heading` as a boosted field instead of
+   the prepend-the-title hack — directly improves "find the doc about X".
+3. **Prefix / wildcard (`foo*`).** Recovers much of what stemming would give
+   without a language model; the key enabler for search-as-you-type.
+
+Optional / lower priority: configurable BM25 `b`; per-index stemming;
+query-time `nProbe` for the IVF vector leg (not FTS, tracked here for
+convenience).
+
+## Core decisions
+
+### D1 — BM25F reduces exactly to classic BM25 (keep one oracle)
+
+The v1 correctness anchor is "engine ranking == brute-force BM25 oracle EXACTLY,
+same float64 summation order." Canonical (Robertson) BM25F normalizes per-field
+TF by `B_f = 1 − b_f + b_f·L_f/avgL_f` **before** the `k1` saturation:
+
+```
+TF_combined = Σ_f  boost_f · TF_f / B_f
+score       = IDF · TF_combined / (TF_combined + k1)
+```
+
+For a single field with `boost = 1`, `b = 0.75`, this collapses algebraically to
+today's classic per-term BM25 — bit-for-bit. So per-field weights are a true
+**superset**: a single-field/default index keeps the existing ranking and the
+existing oracle unchanged; multi-field simply re-oracles against BM25F. This
+removes the biggest risk (silently changing every score).
+
+### D2 — decouple the phrase algorithm from the byte layout
+
+Introduce a `ChunkIterator` over a term's postings:
+
+```
+Next() (docID uint64, tf uint32, ok bool)   // decodes DocID+TF, skips positions
+Positions() []uint32                          // lazily decodes current doc's positions
+Err() error
+```
+
+The phrase zig-zag merge and the scan loop consume **only** this interface, so
+they are blind to whether the underlying chunk is v1 or v2. `V1ChunkIterator`
+wraps today's `ChunkReader` (which already has the lazy-positions shape);
+`V2ChunkIterator` (Phase 3) reads the `FieldMask` + per-field TFs and still skips
+positions during `Next()`. Search-time features ship on v1 now; the format break
+lands later with zero change to the merge code.
+
+### D3 — ship order: search-time features first, format break second
+
+Phase 1 (phrase/AND/prefix) needs no format change and no re-index. Phase 3
+(per-field weights) bumps the postings + docinfo version bytes and forces a
+blocking re-index on upgrade. Ship Phase 1 first for immediate UX; do the single
+re-index once, later.
+
+### D4 — per-field weights = Option A (single postings list + FieldMask)
+
+Rejected alternatives: **B** (separate postings keyspace per field — destroys the
+hot common-term path with N B-tree scans + N-way merge per term, inflates vocab,
+makes IDF per-field-weird, doubles page-dirtying when a term moves field); **C**
+(field-band positions — caps field length and forces position decode on the hot
+scoring path). Option A keeps one postings list, one global DF, one chunk scan
+per term, and cheap incremental updates.
+
+## Query-syntax surface (Phase 0/1)
+
+`$search` carries free text + low-ambiguity inline syntax; boolean require/exclude
+live in **typed sub-fields**, not inline string signs. Default operator stays
+**OR** (Mongo parity); `$defaultOperator:"and"` makes bare `$search` terms
+required.
+
+```json
+{
+  "$text": {
+    "$search": "east tokyo \"new york\" pre*",
+    "$defaultOperator": "and",
+    "$require": ["critical", "\"east side\""],
+    "$exclude": ["draft", "spam*"]
+  }
+}
+```
+
+| Field / syntax              | Meaning                                                          |
+|-----------------------------|------------------------------------------------------------------|
+| `$search` bare term         | should/OR by default, required when `$defaultOperator:"and"`     |
+| `$search` `"east tokyo"`    | phrase — exact adjacency (positional merge)                      |
+| `$search` `pre*`            | prefix — expand against vocab (top-M by df), OR the expansions   |
+| `$require` (string / array) | each entry required (AND); reuses phrase/prefix syntax           |
+| `$exclude` (string / array) | each entry excludes matching docs; reuses phrase/prefix syntax   |
+
+**No inline `+`/`-` boolean syntax** (decided 2026-06-17, with outside-expert
+review). Parsing boolean intent out of a raw human search string is a footgun for
+an embedded library whose common use is "forward the end-user's search box
+straight into `$search`": `-9` (meaning −9°C) or `+1` (a vote) would silently
+become an exclusion/require. Here those characters are harmless — the analyzer
+drops them, so `-9` is just the term `9`. Require/exclude move to the structured
+`$require`/`$exclude` arrays: unambiguous, JSON-native (an "Advanced Search" UI
+maps straight to them, no escaping), and run through the same analyzer so they
+match the index (a generic `$not:{body:"Crash"}` would force the app to manually
+case-fold/normalize, and would execute as a slow two-query intersection instead
+of a fast in-accumulator tombstone). An app that wants single-box power-user
+syntax can parse `-foo` itself and populate `$exclude`. Rejected alternatives:
+digit-guarding `+`/`-` (leaky — fails on `-Apple`, `- foo`, `+A`); an opt-in
+operators flag (pushes escaping back onto the app); strict Mongo parity (Mongo's
+inline `-` is a known footgun, and `$defaultOperator` already fixes OR-noise).
+
+Traps (enforced):
+
+- **No `*` inside quotes.** Prefix-expansion inside a positional adjacency merge
+  is combinatorial; the `*` is left literal for the analyzer to drop.
+- **Prefix detection before analysis.** UAX#29 strips `*` as punctuation, so the
+  parser strips the trailing `*`, analyzes the stem, and tags the clause prefix.
+- **Hard cap on prefix expansion** (top-M by df, `ftsPrefixMaxExpansions = 50`).
+
+## Scoring mechanics (Phase 1)
+
+- **Phrase = synthetic term.** After the zig-zag merge confirms adjacency in a
+  doc: `TF = adjacency-confirmed count`, `IDF = Σ idf(termᵢ)`, scored with the
+  normal BM25 length term. (Sum-of-constituent-contributions would wildly inflate
+  when a constituent is frequent but rarely adjacent.)
+- **Required/AND = bitmask post-pass.** Each required clause gets a bit; the
+  accumulator slot carries `requiredMask`; the rank/extract pass drops any doc
+  whose `requiredMask != (1<<nRequired)-1`. Single pass, no extra structure.
+- **Negation = tombstone.** Scan the negated term's chunks; mark existing
+  accumulator entries tombstoned (never insert new ones); skip at extract.
+- Future opt (not now): seed the accumulator from the lowest-df required clause,
+  then only score other clauses against docs already present. Current scale
+  doesn't need it.
+
+## On-disk format for per-field weights (Phase 3)
+
+Postings chunk **v2** (version byte bumped), per document:
+
+```
+DocIDDelta : uvarint
+FieldMask  : uvarint            // bit f set ⇒ term occurs in field f
+TF_f       : uvarint × popcount(FieldMask)   // per set bit, in field order
+PosDelta   : uvarint × Σ TF_f   // GLOBAL gapped positions (unchanged from v1)
+```
+
+- Positions stay **global + field-gapped** — phrase merge unchanged; the gap
+  still blocks cross-field phrases. Per-field weighting uses only the TF vector.
+- `FieldMask` is 1 byte for ≤7 fields; empty fields cost 0 TF bytes.
+  **Cap FTS-indexed fields at 64** (fits a uint64 mask).
+- **`fts:vocab` unchanged** — DF stays global per term (corpus rarity drives IDF;
+  a term in both title and body of one doc is df=1).
+- **`fts:docinfo` v2**: `[Len_field0, Len_field1, …]` varints instead of one len.
+- **`fts:meta`**: track `TotalTokens` per field (for `avgL_f`); store the field
+  list so `fieldIdx` is stable across reopen.
+- **`V2ChunkIterator`** reads `FieldMask`+TFs eagerly, skips positions in `Next()`
+  (varint count known) → hot common-term path still never decodes positions.
+- **`FulltextParams`** carries per-field `Weights` and optional per-field `B`
+  (field→idx from `IndexInfo.Fields` order), persisted as a `fulltext` sub-object
+  on the index doc (mirrors the `vector` sub-object).
+- **Incremental update** stays one-chunk-per-term: the diff path carries per-field
+  TF; moving a term title→body rewrites one chunk, not two.
+- **Migration**: a v1 chunk under a weighted index ⇒ blocking re-index on open
+  (acceptable in alpha; no FTS on-disk back-compat promise yet).
+
+## Optional items
+
+- **Configurable BM25 `b` (+`k1`)** — config only, no format change. Fold into the
+  `FulltextParams`/`fulltext` sub-object plumbing; thread into `searchCandidates`.
+  Even `b≈0.4` materially cuts short-doc bias. (Can land with Phase 1.)
+- **Per-index stemming** (`$language` → Snowball in the analyzer) — opt-in, changes
+  indexed terms (set at create, re-index to change), adds a dependency. Lowest
+  priority; phrase+prefix recover most of its value. Pair with the Phase 3
+  re-index if wanted.
+- **Query-time IVF `nProbe`** (vector leg, not FTS) — a per-query `vectorEf` knob
+  already exists; `vivf.Index.Search` already takes `nprobe` but the index-fixed
+  value is passed. Add a `vectorNProbe` query knob mirroring `vectorEf`.
+
+## Phases
+
+- **Phase 0** — structured query parser + `$defaultOperator`; prefix-before-analyze;
+  `ChunkIterator` extraction (`V1ChunkIterator`). No format change.
+- **Phase 1** — accumulator `requiredMask`/tombstone; phrase zig-zag merge;
+  CJK→implicit phrase; prefix vocab expansion. No re-index. **(this branch)**
+- **Phase 2** — configurable `b`/`k1` (optional, may fold into Phase 1 plumbing).
+- **Phase 3** — per-field weights: postings v2 + docinfo v2 + per-field meta +
+  `V2ChunkIterator` + BM25F scorer + migration. The one re-index.
+- **Phase 4** — stemming; vector `nProbe` (independent).
+
+## Decision record
+
+Reviewed with an outside expert (Gemini 3.1 Pro) on 2026-06-17. Confirmed:
+exact BM25→BM25F reduction (D1); iterator decoupling (D2); ship search-time
+first (D3); Option A with global gapped positions, global DF, per-field docinfo
+(D4); phrase-as-synthetic-term with summed IDF; requiredMask + tombstone in the
+existing single-pass accumulator; forbid `*` inside phrases; hard-cap prefix
+expansion.

--- a/fulltext_bm25params_test.go
+++ b/fulltext_bm25params_test.go
@@ -1,0 +1,97 @@
+package anystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 2: configurable BM25 b / k1 (FulltextParams). Default params reproduce
+// the original scoring exactly (covered by the parity tests); these cover that a
+// custom b actually changes length normalization and that params persist.
+
+func ftsScoreByID(t *testing.T, coll Collection, search string) map[string]float64 {
+	ids, scores := collectIter(t, coll.Find(map[string]any{"$text": map[string]any{"$search": search}}))
+	m := make(map[string]float64, len(ids))
+	for i, id := range ids {
+		m[id] = scores[i]
+	}
+	return m
+}
+
+func TestFtsBM25_Validation(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+	coll, err := fx.CreateCollection(ctx, "v")
+	require.NoError(t, err)
+	assert.Error(t, coll.EnsureIndex(ctx, IndexInfo{
+		Kind: IndexKindFulltext, Fields: []string{"body"}, Fulltext: &FulltextParams{B: 1.5},
+	}), "B>1 must be rejected")
+	assert.Error(t, coll.EnsureIndex(ctx, IndexInfo{
+		Kind: IndexKindFulltext, Fields: []string{"body"}, Fulltext: &FulltextParams{K1: -1},
+	}), "negative K1 must be rejected")
+}
+
+// withB builds a fresh collection whose fts index uses the given b, then inserts
+// one short and one long doc that each contain "alpha" exactly once.
+func withB(t *testing.T, fx *fixture, name string, b float64) Collection {
+	coll, err := fx.CreateCollection(ctx, name)
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+		Kind: IndexKindFulltext, Fields: []string{"body"}, Fulltext: &FulltextParams{B: b},
+	}))
+	insertJSON(t, coll,
+		`{"id":"s","body":"alpha"}`,
+		`{"id":"l","body":"alpha beta gamma delta epsilon zeta eta theta iota kappa"}`,
+	)
+	return coll
+}
+
+func TestFtsBM25_BAffectsLengthNorm(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+
+	// b high (default 0.75) penalizes the long doc more than b low (0.1), so the
+	// short/long score ratio is larger at high b.
+	highB := withB(t, fx, "high", 0.75)
+	lowB := withB(t, fx, "low", 0.1)
+
+	sh := ftsScoreByID(t, highB, "alpha")
+	sl := ftsScoreByID(t, lowB, "alpha")
+	require.Contains(t, sh, "s")
+	require.Contains(t, sh, "l")
+
+	ratioHigh := sh["s"] / sh["l"]
+	ratioLow := sl["s"] / sl["l"]
+	assert.Greater(t, ratioHigh, ratioLow,
+		"higher b must favour the short doc more (ratioHigh=%.4f ratioLow=%.4f)", ratioHigh, ratioLow)
+	// Sanity: at b=0.1 the two docs score nearly the same (length barely matters).
+	assert.InDelta(t, 1.0, ratioLow, 0.15)
+}
+
+func TestFtsBM25_ParamsSurviveReopen(t *testing.T) {
+	tmpDir := t.TempDir()
+	func() {
+		fxLocal := newFixturePath(t, tmpDir)
+		coll, err := fxLocal.CreateCollection(ctx, "docs")
+		require.NoError(t, err)
+		require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+			Kind: IndexKindFulltext, Fields: []string{"body"}, Fulltext: &FulltextParams{B: 0.33, K1: 1.7},
+		}))
+		insertJSON(t, coll, `{"id":"a","body":"alpha beta"}`)
+		require.NoError(t, fxLocal.Close())
+	}()
+
+	db, err := Open(ctx, tmpDir+"/any-store-test.db", nil)
+	require.NoError(t, err)
+	defer db.Close()
+	collI, err := db.OpenCollection(ctx, "docs")
+	require.NoError(t, err)
+	c := collI.(*collection)
+
+	fxs := c.loadFtsIndexes()
+	require.Len(t, fxs, 1)
+	assert.Equal(t, 0.33, fxs[0].info.Fulltext.B)
+	assert.Equal(t, 1.7, fxs[0].info.Fulltext.K1)
+}

--- a/fulltext_index.go
+++ b/fulltext_index.go
@@ -101,6 +101,14 @@ func newFtsIndex(c *collection, info IndexInfo) (*ftsIndex, error) {
 	if len(fx.fieldPaths) == 0 {
 		return nil, errors.New("fts: index requires at least one field")
 	}
+	if p := info.Fulltext; p != nil {
+		if p.B < 0 || p.B > 1 {
+			return nil, errors.New("fts: Fulltext.B must be in [0,1]")
+		}
+		if p.K1 < 0 {
+			return nil, errors.New("fts: Fulltext.K1 must be >= 0")
+		}
+	}
 	return fx, nil
 }
 

--- a/fulltext_index.go
+++ b/fulltext_index.go
@@ -44,6 +44,7 @@ var (
 	ftsMetaSeq    = []byte("seq") // last allocated IntDocID
 	ftsMetaCount  = []byte("N")   // number of indexed documents
 	ftsMetaTokens = []byte("tok") // total tokens across all documents
+	ftsMetaFormat = []byte("fmt") // on-disk postings format version (see fts.PostingsVersion)
 )
 
 // ftsIndex is a live full-text index bound to its five namespaces.
@@ -65,6 +66,10 @@ type ftsIndex struct {
 	// at commit. See fulltext_pending.go.
 	pending ftsPending
 
+	// nFields is the number of indexed fields (== len(fieldPaths)); each token's
+	// field index keys into the FieldMask / per-field TF of the v2 postings.
+	nFields int
+
 	// scratch buffers, writer-owned (single writer, serialized by btree writeMu)
 	keyBuf   []byte
 	valBuf   []byte
@@ -75,9 +80,17 @@ type ftsIndex struct {
 	chunkPL  []fts.Posting
 	mergeBuf []fts.Posting // flushChunk merge scratch
 
-	// flushChunk scratch: decoded-positions arena, existing-chunk value buffer,
-	// sorted added-id buffer — all reused across chunks and transactions.
+	// fieldStarts[f] is the global position at which indexed field f begins (after
+	// the per-field gap); fieldStarts[nFields] is the end. analyzeInto fills it so
+	// fieldBreakdown can attribute each term position to its field. fieldTFBuf is
+	// the reused dense per-field TF scratch.
+	fieldStarts []uint32
+	fieldTFBuf  []uint32
+
+	// flushChunk scratch: decoded-positions arena, decoded per-field-TF arena,
+	// existing-chunk value buffer, sorted added-id buffer — reused across chunks.
 	posDecode   []uint32
+	tfDecode    []uint32
 	chunkValBuf []byte
 	addIDsBuf   []uint64
 
@@ -101,12 +114,24 @@ func newFtsIndex(c *collection, info IndexInfo) (*ftsIndex, error) {
 	if len(fx.fieldPaths) == 0 {
 		return nil, errors.New("fts: index requires at least one field")
 	}
+	if len(fx.fieldPaths) > fts.MaxFields {
+		return nil, errors.New("fts: too many full-text fields (max 64)")
+	}
+	fx.nFields = len(fx.fieldPaths)
 	if p := info.Fulltext; p != nil {
 		if p.B < 0 || p.B > 1 {
 			return nil, errors.New("fts: Fulltext.B must be in [0,1]")
 		}
 		if p.K1 < 0 {
 			return nil, errors.New("fts: Fulltext.K1 must be >= 0")
+		}
+		for field, w := range p.Weights {
+			if !slices.Contains(info.Fields, field) {
+				return nil, errors.New("fts: Fulltext.Weights references unknown field: " + field)
+			}
+			if w < 0 {
+				return nil, errors.New("fts: Fulltext.Weights must be >= 0 for field: " + field)
+			}
 		}
 	}
 	return fx, nil
@@ -153,21 +178,53 @@ func (fx *ftsIndex) Info() IndexInfo { return fx.info }
 
 // analyzeInto runs the analyzer over all indexed fields of the document,
 // appending the flat token stream to dst (positions are offset per field by
-// ftsPosGap so phrases cannot bridge fields) and returning the extended slice.
+// ftsPosGap so phrases cannot bridge fields) and returning the extended slice. It
+// also records fx.fieldStarts: the global position at which each field begins (and
+// fieldStarts[nFields] = the end), so fieldBreakdown can attribute every term
+// position to its field for the per-field TF of the v2 postings. The next field's
+// base is the current field's max position + 1 + gap, which keeps field position
+// ranges contiguous and non-overlapping even for multi-element array fields.
 func (fx *ftsIndex) analyzeInto(dst []fts.Token, it item) []fts.Token {
 	dst = dst[:0]
 	val := it.Value()
+	fx.fieldStarts = append(fx.fieldStarts[:0], make([]uint32, fx.nFields+1)...)
 	var base uint32
-	for _, path := range fx.fieldPaths {
+	for fieldIdx, path := range fx.fieldPaths {
+		fx.fieldStarts[fieldIdx] = base
 		fv := val.Get(path...)
 		before := len(dst)
 		dst = fx.appendFieldTokens(dst, fv, base)
-		emitted := len(dst) - before
-		if emitted > 0 {
-			base += uint32(emitted) + ftsPosGap
+		if len(dst) > before {
+			base = dst[len(dst)-1].Pos + 1 + ftsPosGap
 		}
 	}
+	fx.fieldStarts[fx.nFields] = base
 	return dst
+}
+
+// fieldBreakdown attributes a term's ascending global positions to their indexed
+// fields (using fieldStarts) and returns the FieldMask plus the dense per-field
+// TF (length nFields, reusing fieldTFBuf). Positions are ascending and field
+// ranges are contiguous, so a single forward walk suffices.
+func (fx *ftsIndex) fieldBreakdown(positions []uint32) (mask uint64, denseTF []uint32) {
+	tf := fx.fieldTFBuf[:0]
+	for i := 0; i < fx.nFields; i++ {
+		tf = append(tf, 0)
+	}
+	f := 0
+	for _, p := range positions {
+		for f+1 < fx.nFields && p >= fx.fieldStarts[f+1] {
+			f++
+		}
+		tf[f]++
+	}
+	for i, c := range tf {
+		if c > 0 {
+			mask |= uint64(1) << uint(i)
+		}
+	}
+	fx.fieldTFBuf = tf
+	return mask, tf
 }
 
 // appendFieldTokens analyzes a single field value (string, or array of strings)
@@ -367,9 +424,12 @@ func (fx *ftsIndex) insertDoc(tx *btree.WriteTx, it item) error {
 		return err
 	}
 
-	// postings + vocab — buffered, flushed at commit.
+	// postings + vocab — buffered, flushed at commit. fieldBreakdown reuses
+	// fieldTFBuf, so consume it immediately inside addPostingPending (it copies
+	// the dense TF into the per-tx arena).
 	for term, positions := range terms {
-		fx.addPostingPending(term, docID, positions)
+		_, denseTF := fx.fieldBreakdown(positions)
+		fx.addPostingPending(term, docID, positions, denseTF)
 		fx.vocabDeltaPending(term, +1)
 	}
 
@@ -452,6 +512,8 @@ func (fx *ftsIndex) updateDoc(tx *btree.WriteTx, oldIt, newIt item) error {
 		return fx.removeIndexedDoc(tx, stringID, docID, oldTerms, oldLen)
 	}
 
+	// fx.fieldStarts now reflects newIt (analyzed last), so fieldBreakdown below
+	// attributes new positions to the new document's fields.
 	// Terms gone or whose positions changed.
 	for term, oldPos := range oldTerms {
 		newPos, inNew := newTerms[term]
@@ -461,15 +523,19 @@ func (fx *ftsIndex) updateDoc(tx *btree.WriteTx, oldIt, newIt item) error {
 			fx.vocabDeltaPending(term, -1)
 		case !slices.Equal(oldPos, newPos):
 			// term still present, positions changed: re-add (df unchanged).
+			// Identical positions imply identical field attribution (an earlier
+			// field changing length would shift these positions), so the skip is safe.
 			fx.removePostingPending(term, docID)
-			fx.addPostingPending(term, docID, newPos)
+			_, denseTF := fx.fieldBreakdown(newPos)
+			fx.addPostingPending(term, docID, newPos, denseTF)
 		}
 		// identical positions → nothing to do.
 	}
 	// Newly added terms.
 	for term, newPos := range newTerms {
 		if _, inOld := oldTerms[term]; !inOld {
-			fx.addPostingPending(term, docID, newPos)
+			_, denseTF := fx.fieldBreakdown(newPos)
+			fx.addPostingPending(term, docID, newPos, denseTF)
 			fx.vocabDeltaPending(term, +1)
 		}
 	}

--- a/fulltext_pending.go
+++ b/fulltext_pending.go
@@ -20,11 +20,19 @@ import (
 // btree write lock is held for the whole tx), reset at tx start, and flushed at
 // commit — mirroring the range-index sketch lifecycle. See docs/fts/DESIGN.md.
 
-// posSpan references a positions run inside ftsPending.posArena (offset/length
+// posSpan references a run inside one of ftsPending's arenas (offset/length
 // instead of a slice, so arena growth never invalidates buffered entries).
 type posSpan struct {
 	off uint32
 	n   uint32
+}
+
+// pendingAdd is a buffered posting insertion: the global positions span, the
+// FieldMask, and the per-occupied-field TF span (both in their arenas).
+type pendingAdd struct {
+	pos  posSpan // positions in posArena
+	mask uint64  // FieldMask
+	tf   posSpan // per-set-bit TFs in tfArena
 }
 
 // pendingChunk holds the in-memory mutations for one (term, chunkID) posting
@@ -32,8 +40,8 @@ type posSpan struct {
 type pendingChunk struct {
 	term    string
 	chunkID uint64
-	adds    map[uint64]posSpan  // IntDocID -> positions span in posArena
-	dels    map[uint64]struct{} // IntDocIDs to remove
+	adds    map[uint64]pendingAdd // IntDocID -> buffered posting
+	dels    map[uint64]struct{}   // IntDocIDs to remove
 }
 
 // ftsPending is the per-tx accumulator for one full-text index.
@@ -42,6 +50,7 @@ type ftsPending struct {
 	vocab    map[string]int64         // term -> df delta
 	count    int                      // buffered posting ops (adds+dels), for the spill cap
 	posArena []uint32                 // all buffered positions, addressed by posSpan
+	tfArena  []uint32                 // all buffered per-field TFs, addressed by posSpan
 	free     []*pendingChunk          // recycled pendingChunks (maps cleared, capacity kept)
 }
 
@@ -84,6 +93,11 @@ func (p *ftsPending) reset() {
 	} else {
 		p.posArena = p.posArena[:0]
 	}
+	if cap(p.tfArena) > ftsSpillPostings*4 {
+		p.tfArena = nil
+	} else {
+		p.tfArena = p.tfArena[:0]
+	}
 	p.count = 0
 }
 
@@ -97,9 +111,14 @@ func (p *ftsPending) getChunk() *pendingChunk {
 	return &pendingChunk{}
 }
 
-// positions resolves a buffered span to its arena slice.
+// positions resolves a buffered positions span to its arena slice.
 func (p *ftsPending) positions(s posSpan) []uint32 {
 	return p.posArena[s.off : s.off+s.n : s.off+s.n]
+}
+
+// fieldTFs resolves a buffered per-field-TF span to its arena slice.
+func (p *ftsPending) fieldTFs(s posSpan) []uint32 {
+	return p.tfArena[s.off : s.off+s.n : s.off+s.n]
 }
 
 // maybeSpill flushes the buffer mid-transaction if it has grown past the RAM cap.
@@ -110,17 +129,33 @@ func (fx *ftsIndex) maybeSpill(tx *btree.WriteTx) error {
 	return nil
 }
 
-// addPosting buffers an insertion of (docID, positions) into the term's chunk.
-// The positions are copied into the per-tx arena (one shared buffer, no
-// per-term clone).
-func (fx *ftsIndex) addPostingPending(term string, docID uint64, positions []uint32) {
+// addPosting buffers an insertion of (docID, positions, per-field TF) into the
+// term's chunk. positions (global) are copied into posArena; the FieldMask and
+// per-occupied-field TFs (derived from denseTF, length nFields) into tfArena. One
+// shared buffer each, no per-term clone.
+func (fx *ftsIndex) addPostingPending(term string, docID uint64, positions, denseTF []uint32) {
 	pc := fx.pendingChunkFor(term, docID)
 	if pc.adds == nil {
-		pc.adds = make(map[uint64]posSpan, 4)
+		pc.adds = make(map[uint64]pendingAdd, 4)
 	}
-	off := uint32(len(fx.pending.posArena))
+	posOff := uint32(len(fx.pending.posArena))
 	fx.pending.posArena = append(fx.pending.posArena, positions...)
-	pc.adds[docID] = posSpan{off: off, n: uint32(len(positions))}
+
+	tfOff := uint32(len(fx.pending.tfArena))
+	var mask uint64
+	var k uint32
+	for f, c := range denseTF {
+		if c > 0 {
+			mask |= uint64(1) << uint(f)
+			fx.pending.tfArena = append(fx.pending.tfArena, c)
+			k++
+		}
+	}
+	pc.adds[docID] = pendingAdd{
+		pos:  posSpan{off: posOff, n: uint32(len(positions))},
+		mask: mask,
+		tf:   posSpan{off: tfOff, n: k},
+	}
 	delete(pc.dels, docID) // an add supersedes a same-tx delete
 	fx.pending.count++
 }
@@ -177,7 +212,7 @@ func (fx *ftsIndex) flushPending(tx *btree.WriteTx) error {
 	slices.Sort(keys)
 	for _, k := range keys {
 		if err := fx.flushChunk(tx, fx.pending.chunks[k]); err != nil {
-			return err
+			return ftsMapFormatErr(err)
 		}
 	}
 
@@ -208,6 +243,7 @@ func (fx *ftsIndex) flushChunk(tx *btree.WriteTx, pc *pendingChunk) error {
 
 	fx.chunkPL = fx.chunkPL[:0]
 	fx.posDecode = fx.posDecode[:0]
+	fx.tfDecode = fx.tfDecode[:0]
 	existing, err := tx.AppendValue(fx.nsPost, fx.keyBuf, fx.chunkValBuf[:0])
 	if err != nil {
 		if !errors.Is(err, btree.ErrKeyNotFound) {
@@ -215,7 +251,7 @@ func (fx *ftsIndex) flushChunk(tx *btree.WriteTx, pc *pendingChunk) error {
 		}
 	} else {
 		fx.chunkValBuf = existing
-		if fx.chunkPL, fx.posDecode, err = fts.DecodeChunkInto(fx.chunkPL, fx.posDecode, existing); err != nil {
+		if fx.chunkPL, fx.posDecode, fx.tfDecode, err = fts.DecodeChunkInto(fx.chunkPL, fx.posDecode, fx.tfDecode, existing); err != nil {
 			return err
 		}
 	}
@@ -228,7 +264,16 @@ func (fx *ftsIndex) flushChunk(tx *btree.WriteTx, pc *pendingChunk) error {
 	slices.Sort(addIDs)
 	fx.addIDsBuf = addIDs
 
-	pos := func(id uint64) []uint32 { return fx.pending.positions(pc.adds[id]) }
+	// added builds the v2 Posting for a buffered add (positions + FieldMask + TFs).
+	added := func(id uint64) fts.Posting {
+		a := pc.adds[id]
+		return fts.Posting{
+			DocID:     id,
+			Fields:    a.mask,
+			FieldTF:   fx.pending.fieldTFs(a.tf),
+			Positions: fx.pending.positions(a.pos),
+		}
+	}
 
 	// Two-way merge of the existing postings (ascending) and the added postings
 	// (ascending), dropping any DocID that is deleted or re-added.
@@ -236,12 +281,12 @@ func (fx *ftsIndex) flushChunk(tx *btree.WriteTx, pc *pendingChunk) error {
 	ai := 0
 	for _, p := range fx.chunkPL {
 		for ai < len(addIDs) && addIDs[ai] < p.DocID {
-			merged = append(merged, fts.Posting{DocID: addIDs[ai], Positions: pos(addIDs[ai])})
+			merged = append(merged, added(addIDs[ai]))
 			ai++
 		}
 		if ai < len(addIDs) && addIDs[ai] == p.DocID {
-			// re-added: take the new positions, skip the old
-			merged = append(merged, fts.Posting{DocID: addIDs[ai], Positions: pos(addIDs[ai])})
+			// re-added: take the new posting, skip the old
+			merged = append(merged, added(addIDs[ai]))
 			ai++
 			continue
 		}
@@ -251,7 +296,7 @@ func (fx *ftsIndex) flushChunk(tx *btree.WriteTx, pc *pendingChunk) error {
 		merged = append(merged, p)
 	}
 	for ; ai < len(addIDs); ai++ {
-		merged = append(merged, fts.Posting{DocID: addIDs[ai], Positions: pos(addIDs[ai])})
+		merged = append(merged, added(addIDs[ai]))
 	}
 	fx.mergeBuf = merged
 

--- a/fulltext_query_ops_test.go
+++ b/fulltext_query_ops_test.go
@@ -1,0 +1,189 @@
+package anystore
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the Phase 1 query operators added on top of the v1
+// bag-of-words BM25: phrases, required (AND) / $defaultOperator, negation,
+// prefix expansion, and CJK implicit-phrase matching. See docs/fts/FTS-V2-PLAN.md.
+
+func ftsOpsColl(t *testing.T) (*fixture, Collection) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "ops")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Kind: IndexKindFulltext, Fields: []string{"body"}}))
+	insertJSON(t, coll,
+		`{"id":"a","body":"east tokyo bound train"}`, // east tokyo (adjacent, in order)
+		`{"id":"b","body":"tokyo east district"}`,    // both words, reversed → not the phrase
+		`{"id":"c","body":"east side story"}`,        // east only
+		`{"id":"d","body":"west tokyo tower"}`,       // tokyo only
+		`{"id":"e","body":"tokens of affection"}`,    // tok* completion, no tokyo/east
+	)
+	return fx, coll
+}
+
+func sortedIDs(ids []string) []string {
+	out := append([]string(nil), ids...)
+	sort.Strings(out)
+	return out
+}
+
+func TestFtsOps_Phrase(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// "east tokyo" as a phrase: only a has them adjacent and in order. b has both
+	// words but reversed; c/d have only one.
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"\"east tokyo\""}}`))
+	assert.Equal(t, []string{"a"}, ids)
+}
+
+func TestFtsOps_BagOfWordsStillOR(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// Unquoted: default OR. east∪tokyo → a,b,c,d (not e).
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"east tokyo"}}`))
+	assert.Equal(t, []string{"a", "b", "c", "d"}, sortedIDs(ids))
+}
+
+func TestFtsOps_RequiredAnd(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// $require both → a,b (both contain east and tokyo, regardless of order).
+	ids, _ := collectIter(t, coll.Find(map[string]any{
+		"$text": map[string]any{"$search": "", "$require": []any{"east", "tokyo"}},
+	}))
+	assert.Equal(t, []string{"a", "b"}, sortedIDs(ids))
+}
+
+func TestFtsOps_DefaultOperatorAnd(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// $defaultOperator:"and" makes bare $search terms required → a,b.
+	ids, _ := collectIter(t, coll.Find(map[string]any{
+		"$text": map[string]any{"$search": "east tokyo", "$defaultOperator": "and"},
+	}))
+	assert.Equal(t, []string{"a", "b"}, sortedIDs(ids))
+}
+
+func TestFtsOps_Exclude(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// search east, $exclude tokyo: east docs (a,b,c) minus tokyo docs (a,b) → c.
+	ids, _ := collectIter(t, coll.Find(map[string]any{
+		"$text": map[string]any{"$search": "east", "$exclude": "tokyo"},
+	}))
+	assert.Equal(t, []string{"c"}, ids)
+}
+
+func TestFtsOps_LeadingDashIsLiteral(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// "-tokyo" in $search is NOT an exclusion — it is the term "tokyo" (the dash
+	// is dropped by the analyzer). So it matches tokyo docs, not excludes them.
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"-tokyo"}}`))
+	assert.Equal(t, []string{"a", "b", "d"}, sortedIDs(ids))
+}
+
+func TestFtsOps_PrefixExpansion(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// tok*: expands to "tokyo" (a,b,d) and "tokens" (e).
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"tok*"}}`))
+	assert.Equal(t, []string{"a", "b", "d", "e"}, sortedIDs(ids))
+}
+
+func TestFtsOps_PrefixRequiredCombo(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// $require east, plus a tok* should-term in $search. east docs = a,b,c; east
+	// is required (tok* is optional), so a,b,c — scoring favours a,b (also tok*).
+	ids, _ := collectIter(t, coll.Find(map[string]any{
+		"$text": map[string]any{"$search": "tok*", "$require": "east"},
+	}))
+	assert.Equal(t, []string{"a", "b", "c"}, sortedIDs(ids))
+}
+
+func TestFtsOps_OnlyExcludeMatchesNothing(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	// An exclude with no positive source → empty (no docs to keep).
+	ids, _ := collectIter(t, coll.Find(map[string]any{
+		"$text": map[string]any{"$search": "", "$exclude": "tokyo"},
+	}))
+	assert.Empty(t, ids)
+}
+
+func ftsCJKColl(t *testing.T) (*fixture, Collection) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "cjk")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Kind: IndexKindFulltext, Fields: []string{"body"}}))
+	insertJSON(t, coll,
+		`{"id":"j","body":"東京都"}`,  // bigrams 東京, 京都 (adjacent, in order)
+		`{"id":"k","body":"京都東京"}`, // bigrams 京都, 都東, 東京 — has 東京 and 京都 but NOT adjacent as 東京→京都
+	)
+	return fx, coll
+}
+
+func TestFtsOps_CJKImplicitPhrase(t *testing.T) {
+	fx, coll := ftsCJKColl(t)
+	defer fx.finish()
+	// "東京都" analyzes to the bigrams 東京,京都 and is matched as an implicit
+	// phrase: only j has them at consecutive positions in order.
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"東京都"}}`))
+	assert.Equal(t, []string{"j"}, ids)
+}
+
+func TestFtsOps_CJKSingleBigramOR(t *testing.T) {
+	fx, coll := ftsCJKColl(t)
+	defer fx.finish()
+	// A single bigram "東京" is a plain term → both j and k contain it.
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"東京"}}`))
+	assert.Equal(t, []string{"j", "k"}, sortedIDs(ids))
+}
+
+func TestFtsOps_PhraseSpansChunkBoundary(t *testing.T) {
+	// A phrase must still match when the two terms' postings live in different
+	// chunks for the same doc (exercises the termStream cross-chunk seek). We
+	// can't easily force >128 docs cheaply here, so instead verify the phrase
+	// merge over many docs that all contain the phrase.
+	fx := newFixture(t)
+	defer fx.finish()
+	coll, err := fx.CreateCollection(ctx, "many")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Kind: IndexKindFulltext, Fields: []string{"body"}}))
+	docs := make([]string, 0, 300)
+	for i := 0; i < 300; i++ {
+		// alternate: half contain the phrase, half contain only reversed words
+		if i%2 == 0 {
+			docs = append(docs, `{"id":"p`+itoa(i)+`","body":"alpha beta gamma"}`)
+		} else {
+			docs = append(docs, `{"id":"q`+itoa(i)+`","body":"beta alpha gamma"}`)
+		}
+	}
+	insertJSON(t, coll, docs...)
+	ids, _ := collectIter(t, coll.Find(`{"$text":{"$search":"\"alpha beta\""}}`))
+	require.Len(t, ids, 150)
+	for _, id := range ids {
+		assert.Equal(t, byte('p'), id[0], "only p-docs have the adjacent phrase")
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [12]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[p:])
+}

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -82,7 +82,8 @@ func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, text query.Text) (qplanne
 	acc := ftsScoreAccPool.Get().(*ftsScoreAcc)
 	acc.reset()
 
-	e := ftsExec{tx: tx, fx: fx, acc: acc, n: float64(n), avgdl: avgdl, az: fts.NewAnalyzer()}
+	k1, b := ftsResolveBM25(fx.info.Fulltext)
+	e := ftsExec{tx: tx, fx: fx, acc: acc, n: float64(n), avgdl: avgdl, az: fts.NewAnalyzer(), k1: k1, b: b}
 	if err = e.run(clauses, text.DefaultAnd); err != nil {
 		ftsScoreAccPool.Put(acc)
 		return nil, err
@@ -128,18 +129,35 @@ type ftsExec struct {
 	n           float64 // corpus doc count
 	avgdl       float64
 	az          *fts.Analyzer
-	dlBuf       []byte // reusable docinfo value buffer (one per query)
+	k1, b       float64 // BM25 params for this index (resolved from FulltextParams)
+	dlBuf       []byte  // reusable docinfo value buffer (one per query)
 	tokBuf      []fts.Token
 	requiredAll uint64 // OR of every allocated required-clause bit
 	nextBit     uint   // next required-clause bit index
 }
 
-// bm25Contribution is the per-term BM25 score contribution. The expression and
-// evaluation order match the v1 inline form exactly, so pure-OR ranking is
-// bit-for-bit unchanged.
-func bm25Contribution(idf, tf, dl, avgdl float64) float64 {
-	denom := tf + bm25K1*(1-bm25B+bm25B*dl/avgdl)
-	return idf * (tf * (bm25K1 + 1)) / denom
+// ftsResolveBM25 resolves the effective BM25 (k1, b) for an index: a zero field
+// means "use the default". A single global pair (the default) reproduces the
+// original constants exactly, so default-param ranking is bit-for-bit unchanged.
+func ftsResolveBM25(p *FulltextParams) (k1, b float64) {
+	k1, b = bm25K1, bm25B
+	if p != nil {
+		if p.K1 > 0 {
+			k1 = p.K1
+		}
+		if p.B > 0 {
+			b = p.B
+		}
+	}
+	return k1, b
+}
+
+// bm25 is the per-term BM25 score contribution under this query's (k1, b). With
+// the default params the expression and evaluation order match the v1 inline
+// form exactly, so default-param OR ranking is bit-for-bit unchanged.
+func (e *ftsExec) bm25(idf, tf, dl float64) float64 {
+	denom := tf + e.k1*(1-e.b+e.b*dl/e.avgdl)
+	return idf * (tf * (e.k1 + 1)) / denom
 }
 
 // allocReqBit hands out the next required-clause bit, or 0 once 64 are exhausted
@@ -307,7 +325,7 @@ func (e *ftsExec) scanTerm(term string, reqBit uint64, tomb bool) error {
 			if derr != nil {
 				return derr
 			}
-			e.acc.addScore(docID, bm25Contribution(idf, tf, float64(dl), e.avgdl), reqBit)
+			e.acc.addScore(docID, e.bm25(idf, tf, float64(dl)), reqBit)
 		}
 		if it.Err() != nil {
 			return it.Err()
@@ -481,7 +499,7 @@ func (e *ftsExec) scorePhrase(terms []string, reqBit uint64, tomb bool) error {
 				if derr != nil {
 					return derr
 				}
-				e.acc.addScore(target, bm25Contribution(idfSum, float64(cnt), float64(dl), e.avgdl), reqBit)
+				e.acc.addScore(target, e.bm25(idfSum, float64(cnt), float64(dl)), reqBit)
 			}
 		}
 		for _, s := range streams {

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -29,6 +29,26 @@ const (
 // that has no full-text index.
 var ErrNoFulltextIndex = errors.New("any-store: collection has no full-text index for $text")
 
+// ErrFtsFormatOutdated is returned when a full-text index's postings were written
+// by an older build (a different on-disk format version). The fix is to drop and
+// recreate the index. any-store makes no on-disk back-compatibility promise for
+// full-text indexes yet (see docs/fts/DESIGN.md); the postings version byte makes
+// this safe (the old blob is rejected, never mis-decoded as corruption).
+var ErrFtsFormatOutdated = errors.New("any-store: full-text index uses an older on-disk format; drop and recreate the index")
+
+// ftsFormatVersion is the current fts postings format, stamped into fts:meta. It
+// tracks fts.PostingsVersion (v2 added per-field TF).
+const ftsFormatVersion = uint64(2)
+
+// ftsMapFormatErr converts the low-level unknown-version error from decoding an
+// old chunk into the actionable ErrFtsFormatOutdated; other errors pass through.
+func ftsMapFormatErr(err error) error {
+	if errors.Is(err, fts.ErrUnknownVersion) {
+		return ErrFtsFormatOutdated
+	}
+	return err
+}
+
 // searchCandidates runs a bag-of-words BM25 query over the index and returns a
 // stream of matched documents ordered by descending score (ties broken by
 // ascending IntDocID for determinism) — the source the FtsIter pulls from.
@@ -83,10 +103,14 @@ func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, text query.Text) (qplanne
 	acc.reset()
 
 	k1, b := ftsResolveBM25(fx.info.Fulltext)
-	e := ftsExec{tx: tx, fx: fx, acc: acc, n: float64(n), avgdl: avgdl, az: fts.NewAnalyzer(), k1: k1, b: b}
+	weights, weighted := ftsResolveWeights(fx.info.Fulltext, fx.info.Fields)
+	e := ftsExec{
+		tx: tx, fx: fx, acc: acc, n: float64(n), avgdl: avgdl, az: fts.NewAnalyzer(),
+		k1: k1, b: b, nFields: fx.nFields, weights: weights, weighted: weighted,
+	}
 	if err = e.run(clauses, text.DefaultAnd); err != nil {
 		ftsScoreAccPool.Put(acc)
-		return nil, err
+		return nil, ftsMapFormatErr(err)
 	}
 
 	// Rank in the accumulator's pooled scratch: sort by score desc / docID asc.
@@ -129,11 +153,39 @@ type ftsExec struct {
 	n           float64 // corpus doc count
 	avgdl       float64
 	az          *fts.Analyzer
-	k1, b       float64 // BM25 params for this index (resolved from FulltextParams)
-	dlBuf       []byte  // reusable docinfo value buffer (one per query)
+	k1, b       float64   // BM25 params for this index (resolved from FulltextParams)
+	nFields     int       // number of indexed fields
+	weights     []float64 // per-field BM25F boost (len nFields); nil when unweighted
+	weighted    bool      // any field weight != 1.0 — enables the per-field score path
+	dlBuf       []byte    // reusable docinfo value buffer (one per query)
 	tokBuf      []fts.Token
 	requiredAll uint64 // OR of every allocated required-clause bit
 	nextBit     uint   // next required-clause bit index
+}
+
+// ftsResolveWeights builds the per-field BM25F boost slice (indexed by field
+// position) from FulltextParams.Weights (keyed by field name). weighted is false
+// when every weight is the default 1.0, so the scorer keeps the exact unweighted
+// fast path (and bit-for-bit-identical scores).
+func ftsResolveWeights(p *FulltextParams, fields []string) (weights []float64, weighted bool) {
+	if p == nil || len(p.Weights) == 0 {
+		return nil, false
+	}
+	weights = make([]float64, len(fields))
+	for i, f := range fields {
+		w, ok := p.Weights[f]
+		if !ok {
+			w = 1.0
+		}
+		weights[i] = w
+		if w != 1.0 {
+			weighted = true
+		}
+	}
+	if !weighted {
+		return nil, false
+	}
+	return weights, true
 }
 
 // ftsResolveBM25 resolves the effective BM25 (k1, b) for an index: a zero field
@@ -320,7 +372,21 @@ func (e *ftsExec) scanTerm(term string, reqBit uint64, tomb bool) error {
 				e.acc.markTomb(docID)
 				continue
 			}
-			tf := float64(it.TF())
+			// BM25F: combine per-field TFs by weight into a pseudo-frequency, then
+			// apply standard saturation + (global) length normalization. Unweighted
+			// indexes take the exact v1 path (total TF), so scores are unchanged.
+			var tf float64
+			if e.weighted {
+				for f := 0; f < e.nFields; f++ {
+					if w := e.weights[f]; w != 0 {
+						if ftf := it.FieldTF(f); ftf != 0 {
+							tf += w * float64(ftf)
+						}
+					}
+				}
+			} else {
+				tf = float64(it.TF())
+			}
 			dl, derr := e.docLen(docID)
 			if derr != nil {
 				return derr

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -1,6 +1,7 @@
 package anystore
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -38,13 +39,22 @@ var ErrNoFulltextIndex = errors.New("any-store: collection has no full-text inde
 // Limit-cut query allocates O(consumed), not O(matched). The stream's Close
 // returns the pooled state; a nil stream means no matches.
 //
-// v1 semantics: the query is analyzed with the same pipeline as indexing and
-// treated as a bag of terms (OR); each matching document's score is the sum of
-// the per-term BM25 contributions. CJK bigrams participate as ordinary terms
-// (positional phrase matching is a documented v2 refinement).
-func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, queryStr string) (qplanner.FtsCandidateStream, error) {
-	terms := fts.Analyze(queryStr)
-	if len(terms) == 0 {
+// Semantics: the $text predicate is parsed into clauses — should clauses from
+// $search ("quoted phrases", prefix* terms, plain terms; OR by default, AND when
+// $defaultOperator:"and"), required clauses from $require, and excluded clauses
+// from $exclude. (Boolean role comes from the typed sub-field, not inline +/- in
+// the string — see query.ParseTextSearch.) Each clause's text is analyzed with
+// the same pipeline as indexing. Positive clauses contribute BM25 to a
+// per-document accumulator; required clauses also set a bit in the doc's
+// requiredMask (a doc must satisfy every required clause to survive); excluded
+// clauses tombstone matching docs. A bare word that analyzes to several tokens
+// (notably any CJK run, e.g. "東京都" → "東京","京都") becomes an implicit phrase
+// matched by positional adjacency — this is what makes CJK substring search
+// correct. A pure bag-of-words OR query reduces exactly to the v1 behavior (same
+// term scan order, same float64 summation), so BM25 ranking is unchanged.
+func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, text query.Text) (qplanner.FtsCandidateStream, error) {
+	clauses := text.ParsedClauses()
+	if len(clauses) == 0 {
 		return nil, nil
 	}
 
@@ -72,89 +82,19 @@ func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, queryStr string) (qplanne
 	acc := ftsScoreAccPool.Get().(*ftsScoreAcc)
 	acc.reset()
 
-	var key, val []byte
-	var dlBuf []byte       // reusable docinfo value buffer (tx.Get would alloc per posting)
-	var doneTerms []string // distinct query terms already scanned (few)
-	for _, tok := range terms {
-		term := tok.Term
-		if slices.Contains(doneTerms, term) {
-			continue // repeated query word contributes once
-		}
-		doneTerms = append(doneTerms, term)
-
-		df, derr := ftsGetUint(tx, fx.nsVocab, []byte(term))
-		if derr != nil {
-			ftsScoreAccPool.Put(acc)
-			return nil, derr
-		}
-		if df == 0 {
-			continue
-		}
-		idf := math.Log(1 + (float64(n)-float64(df)+0.5)/(float64(df)+0.5))
-
-		// Scan every chunk of this term.
-		cur := tx.NewCursor(fx.nsPost)
-		prefix := postingsTermPrefix(nil, term)
-		if serr := cur.Seek(prefix); serr != nil {
-			cur.Close()
-			ftsScoreAccPool.Put(acc)
-			return nil, serr
-		}
-		var scanErr error
-		for cur.Valid() {
-			key, scanErr = cur.Key()
-			if scanErr != nil {
-				break
-			}
-			if len(key) < len(prefix) || string(key[:len(prefix)]) != string(prefix) {
-				break
-			}
-			val, scanErr = cur.Value()
-			if scanErr != nil {
-				break
-			}
-			r, rerr := fts.NewChunkReader(val)
-			if rerr != nil {
-				scanErr = rerr
-				break
-			}
-			for r.Next() {
-				docID := r.DocID()
-				tf := float64(r.TF())
-				var dl uint32
-				var e error
-				dl, dlBuf, e = ftsDocLenBuf(tx, fx.nsDocinfo, docID, dlBuf)
-				if e != nil {
-					scanErr = e
-					break
-				}
-				denom := tf + bm25K1*(1-bm25B+bm25B*float64(dl)/avgdl)
-				acc.add(docID, idf*(tf*(bm25K1+1))/denom)
-			}
-			if scanErr == nil {
-				scanErr = r.Err()
-			}
-			if scanErr != nil {
-				break
-			}
-			if scanErr = cur.Next(); scanErr != nil {
-				break
-			}
-		}
-		cur.Close()
-		if scanErr != nil {
-			ftsScoreAccPool.Put(acc)
-			return nil, scanErr
-		}
-	}
-
-	if acc.n == 0 {
+	e := ftsExec{tx: tx, fx: fx, acc: acc, n: float64(n), avgdl: avgdl, az: fts.NewAnalyzer()}
+	if err = e.run(clauses, text.DefaultAnd); err != nil {
 		ftsScoreAccPool.Put(acc)
-		return nil, nil
+		return nil, err
 	}
 
 	// Rank in the accumulator's pooled scratch: sort by score desc / docID asc.
-	acc.scratch = acc.appendTo(acc.scratch[:0])
+	// appendTo applies the required-mask gate and drops tombstoned docs.
+	acc.scratch = acc.appendTo(acc.scratch[:0], e.requiredAll)
+	if len(acc.scratch) == 0 {
+		ftsScoreAccPool.Put(acc)
+		return nil, nil
+	}
 	slices.SortFunc(acc.scratch, func(a, b scoredDoc) int {
 		if a.score > b.score {
 			return -1
@@ -172,6 +112,409 @@ func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, queryStr string) (qplanne
 	})
 
 	return &ftsCandidateStream{tx: tx, fx: fx, acc: acc}, nil
+}
+
+// ftsPrefixMaxExpansions caps how many vocabulary completions a single prefix
+// (foo*) clause expands to — the top-M by document frequency. It bounds the work
+// (and the accumulator growth) of a broad prefix like "a*"; truncation is logged
+// by run so a silent cap never reads as full coverage.
+const ftsPrefixMaxExpansions = 50
+
+// ftsExec carries the per-query scoring state shared across clauses.
+type ftsExec struct {
+	tx          *btree.ReadTx
+	fx          *ftsIndex
+	acc         *ftsScoreAcc
+	n           float64 // corpus doc count
+	avgdl       float64
+	az          *fts.Analyzer
+	dlBuf       []byte // reusable docinfo value buffer (one per query)
+	tokBuf      []fts.Token
+	requiredAll uint64 // OR of every allocated required-clause bit
+	nextBit     uint   // next required-clause bit index
+}
+
+// bm25Contribution is the per-term BM25 score contribution. The expression and
+// evaluation order match the v1 inline form exactly, so pure-OR ranking is
+// bit-for-bit unchanged.
+func bm25Contribution(idf, tf, dl, avgdl float64) float64 {
+	denom := tf + bm25K1*(1-bm25B+bm25B*dl/avgdl)
+	return idf * (tf * (bm25K1 + 1)) / denom
+}
+
+// allocReqBit hands out the next required-clause bit, or 0 once 64 are exhausted
+// (the clause then degrades to ungated OR rather than corrupting the mask).
+func (e *ftsExec) allocReqBit() uint64 {
+	if e.nextBit >= 64 {
+		return 0
+	}
+	b := uint64(1) << e.nextBit
+	e.nextBit++
+	e.requiredAll |= b
+	return b
+}
+
+// analyze tokenizes a clause's raw text into its term list (reusing the buffer).
+func (e *ftsExec) analyze(raw string) []string {
+	e.tokBuf = e.az.Append(e.tokBuf[:0], raw)
+	terms := make([]string, len(e.tokBuf))
+	for i := range e.tokBuf {
+		terms[i] = e.tokBuf[i].Term
+	}
+	return terms
+}
+
+// run compiles and executes the clauses. Positive clauses (should/must) are
+// scored first — plain terms in first-seen order, so a pure-OR query keeps the
+// exact v1 summation order — then phrases and prefixes; negated clauses run last
+// (tombstones only affect docs already scored).
+func (e *ftsExec) run(clauses []query.TextClause, defaultAnd bool) error {
+	// Ordered, deduped positive plain terms (preserves v1 scan order + parity).
+	var plainOrder []string
+	plainBit := map[string]uint64{}
+	type group struct {
+		terms  []string // >1 ⇒ phrase
+		stem   string   // prefix clause stem (Prefix only)
+		prefix bool
+		reqBit uint64
+	}
+	var posGroups, negGroups []group
+
+	for _, c := range clauses {
+		terms := e.analyze(c.Raw)
+		if len(terms) == 0 {
+			continue
+		}
+		required := c.Op == query.TextMust || (c.Op == query.TextShould && defaultAnd)
+		negated := c.Op == query.TextMustNot
+
+		switch {
+		case c.Prefix && len(terms) == 1 && !c.Phrase:
+			g := group{stem: terms[0], prefix: true}
+			if negated {
+				negGroups = append(negGroups, g)
+			} else {
+				if required {
+					g.reqBit = e.allocReqBit()
+				}
+				posGroups = append(posGroups, g)
+			}
+		case len(terms) == 1 && !c.Phrase:
+			term := terms[0]
+			if negated {
+				negGroups = append(negGroups, group{terms: terms})
+				continue
+			}
+			var reqBit uint64
+			if required {
+				reqBit = e.allocReqBit()
+			}
+			// Dedup a repeated positive term: score once, union its bits.
+			if _, seen := plainBit[term]; seen {
+				plainBit[term] |= reqBit
+			} else {
+				plainBit[term] = reqBit
+				plainOrder = append(plainOrder, term)
+			}
+		default:
+			// Multi-token: explicit phrase, or an implicit phrase (CJK / joined word).
+			g := group{terms: terms}
+			if negated {
+				negGroups = append(negGroups, g)
+			} else {
+				if required {
+					g.reqBit = e.allocReqBit()
+				}
+				posGroups = append(posGroups, g)
+			}
+		}
+	}
+
+	// 1) Plain positive terms, in first-seen order (v1 parity).
+	for _, term := range plainOrder {
+		if err := e.scanTerm(term, plainBit[term], false); err != nil {
+			return err
+		}
+	}
+	// 2) Positive phrases and prefixes.
+	for _, g := range posGroups {
+		if err := e.scoreGroup(g.terms, g.stem, g.prefix, g.reqBit, false); err != nil {
+			return err
+		}
+	}
+	// 3) Negated clauses (tombstone only docs already present).
+	for _, g := range negGroups {
+		if err := e.scoreGroup(g.terms, g.stem, g.prefix, 0, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// scoreGroup dispatches a phrase or prefix group to its scorer (tomb selects the
+// tombstone variant for a negated clause).
+func (e *ftsExec) scoreGroup(terms []string, stem string, prefix bool, reqBit uint64, tomb bool) error {
+	if prefix {
+		return e.scorePrefix(stem, reqBit, tomb)
+	}
+	if len(terms) == 1 {
+		return e.scanTerm(terms[0], reqBit, tomb)
+	}
+	return e.scorePhrase(terms, reqBit, tomb)
+}
+
+// scanTerm scores (or, if tomb, tombstones) every posting of a single term.
+func (e *ftsExec) scanTerm(term string, reqBit uint64, tomb bool) error {
+	df, err := ftsGetUint(e.tx, e.fx.nsVocab, []byte(term))
+	if err != nil {
+		return err
+	}
+	if df == 0 {
+		return nil
+	}
+	idf := math.Log(1 + (e.n-float64(df)+0.5)/(float64(df)+0.5))
+
+	cur := e.tx.NewCursor(e.fx.nsPost)
+	defer cur.Close()
+	prefix := postingsTermPrefix(nil, term)
+	if err = cur.Seek(prefix); err != nil {
+		return err
+	}
+	for cur.Valid() {
+		key, kerr := cur.Key()
+		if kerr != nil {
+			return kerr
+		}
+		if len(key) < len(prefix) || string(key[:len(prefix)]) != string(prefix) {
+			break
+		}
+		val, verr := cur.Value()
+		if verr != nil {
+			return verr
+		}
+		it, ierr := fts.NewChunkIterator(val)
+		if ierr != nil {
+			return ierr
+		}
+		for it.Next() {
+			docID := it.DocID()
+			if tomb {
+				e.acc.markTomb(docID)
+				continue
+			}
+			tf := float64(it.TF())
+			dl, derr := e.docLen(docID)
+			if derr != nil {
+				return derr
+			}
+			e.acc.addScore(docID, bm25Contribution(idf, tf, float64(dl), e.avgdl), reqBit)
+		}
+		if it.Err() != nil {
+			return it.Err()
+		}
+		if err = cur.Next(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// scorePrefix expands stem against the vocabulary (top-M completions by df) and
+// scores/tombstones each completion as a plain term sharing the clause's bit.
+func (e *ftsExec) scorePrefix(stem string, reqBit uint64, tomb bool) error {
+	terms, err := e.expandPrefix(stem)
+	if err != nil {
+		return err
+	}
+	for _, t := range terms {
+		if err = e.scanTerm(t, reqBit, tomb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// expandPrefix returns up to ftsPrefixMaxExpansions vocabulary terms with the
+// given byte prefix, the most frequent (highest df) first.
+func (e *ftsExec) expandPrefix(stem string) ([]string, error) {
+	if stem == "" {
+		return nil, nil
+	}
+	type td struct {
+		term string
+		df   uint64
+	}
+	var matches []td
+	cur := e.tx.NewCursor(e.fx.nsVocab)
+	defer cur.Close()
+	p := []byte(stem)
+	if err := cur.Seek(p); err != nil {
+		return nil, err
+	}
+	for cur.Valid() {
+		key, err := cur.Key()
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.HasPrefix(key, p) {
+			break
+		}
+		val, err := cur.Value()
+		if err != nil {
+			return nil, err
+		}
+		df, _ := binary.Uvarint(val)
+		matches = append(matches, td{string(key), df})
+		if err = cur.Next(); err != nil {
+			return nil, err
+		}
+	}
+	slices.SortFunc(matches, func(a, b td) int {
+		if a.df != b.df {
+			if a.df > b.df {
+				return -1
+			}
+			return 1
+		}
+		if a.term < b.term {
+			return -1
+		}
+		if a.term > b.term {
+			return 1
+		}
+		return 0
+	})
+	if len(matches) > ftsPrefixMaxExpansions {
+		matches = matches[:ftsPrefixMaxExpansions]
+	}
+	out := make([]string, len(matches))
+	for i := range matches {
+		out[i] = matches[i].term
+	}
+	return out, nil
+}
+
+// scorePhrase finds documents where the phrase terms occur at consecutive
+// positions and contributes (or tombstones) a synthetic-term BM25 score: the
+// term frequency is the number of adjacency-confirmed occurrences and the IDF is
+// the sum of the constituent terms' IDFs (the standard phrase-IDF substitute).
+func (e *ftsExec) scorePhrase(terms []string, reqBit uint64, tomb bool) error {
+	// Per-term IDF; if any term is absent (df==0) the phrase cannot occur.
+	idfSum := 0.0
+	for _, t := range terms {
+		df, err := ftsGetUint(e.tx, e.fx.nsVocab, []byte(t))
+		if err != nil {
+			return err
+		}
+		if df == 0 {
+			return nil
+		}
+		idfSum += math.Log(1 + (e.n-float64(df)+0.5)/(float64(df)+0.5))
+	}
+
+	streams := make([]*termStream, len(terms))
+	for i, t := range terms {
+		streams[i] = newTermStream(e.tx, e.fx.nsPost, t)
+	}
+	defer func() {
+		for _, s := range streams {
+			s.close()
+		}
+	}()
+
+	posLists := make([][]uint32, len(terms))
+	for {
+		// All streams must be live to have a common document.
+		live := true
+		for _, s := range streams {
+			if s.err != nil {
+				return s.err
+			}
+			if !s.valid {
+				live = false
+				break
+			}
+		}
+		if !live {
+			break
+		}
+		// Target = max current docID; seek every stream up to it.
+		target := streams[0].docID
+		for _, s := range streams[1:] {
+			if s.docID > target {
+				target = s.docID
+			}
+		}
+		allMatch := true
+		exhausted := false
+		for _, s := range streams {
+			s.seek(target)
+			if s.err != nil {
+				return s.err
+			}
+			if !s.valid {
+				exhausted = true
+				break
+			}
+			if s.docID != target {
+				allMatch = false
+			}
+		}
+		if exhausted {
+			break
+		}
+		if !allMatch {
+			continue // some stream advanced past target; recompute max
+		}
+		// Common document: decode positions and count adjacency.
+		for i, s := range streams {
+			posLists[i] = s.positions(posLists[i][:0])
+			if s.err != nil {
+				return s.err
+			}
+		}
+		if cnt := countAdjacent(posLists); cnt > 0 {
+			if tomb {
+				e.acc.markTomb(target)
+			} else {
+				dl, derr := e.docLen(target)
+				if derr != nil {
+					return derr
+				}
+				e.acc.addScore(target, bm25Contribution(idfSum, float64(cnt), float64(dl), e.avgdl), reqBit)
+			}
+		}
+		for _, s := range streams {
+			s.next()
+		}
+	}
+	return nil
+}
+
+// countAdjacent counts positions b at which the phrase occurs: posLists[0] holds
+// b, posLists[1] holds b+1, … posLists[k] holds b+k. Each list is ascending.
+func countAdjacent(posLists [][]uint32) uint32 {
+	var cnt uint32
+	for _, b := range posLists[0] {
+		ok := true
+		for i := 1; i < len(posLists); i++ {
+			if _, found := slices.BinarySearch(posLists[i], b+uint32(i)); !found {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+// docLen returns a document's token length, reusing the per-query value buffer.
+func (e *ftsExec) docLen(docID uint64) (uint32, error) {
+	dl, buf, err := ftsDocLenBuf(e.tx, e.fx.nsDocinfo, docID, e.dlBuf)
+	e.dlBuf = buf
+	return dl, err
 }
 
 // ftsCandidateStream lazily materializes the ranked (IntDocID, score) pairs in
@@ -230,6 +573,8 @@ type ftsScoreAcc struct {
 	key  []uint64
 	val  []float64
 	seen []uint32 // slot occupied iff seen[i] == gen
+	req  []uint64 // bitmask of required clauses this doc satisfied (AND semantics)
+	tomb []bool   // doc excluded by a negated (-term) clause
 	gen  uint32
 	mask uint32
 	n    int
@@ -258,6 +603,8 @@ func (m *ftsScoreAcc) reset() {
 		m.key = make([]uint64, init)
 		m.val = make([]float64, init)
 		m.seen = make([]uint32, init)
+		m.req = make([]uint64, init)
+		m.tomb = make([]bool, init)
 		m.mask = init - 1
 		m.gen = 1
 		m.n = 0
@@ -273,12 +620,15 @@ func (m *ftsScoreAcc) reset() {
 	}
 }
 
-// add sums d into key's accumulated score, inserting the key on first sight.
-func (m *ftsScoreAcc) add(key uint64, d float64) {
+// addScore sums d into key's accumulated score, inserting the key on first
+// sight, and ORs reqBit into the doc's satisfied-required-clauses mask. A plain
+// (non-required) contribution passes reqBit == 0.
+func (m *ftsScoreAcc) addScore(key uint64, d float64, reqBit uint64) {
 	pos := uint32(hashU64(key)) & m.mask
 	for m.seen[pos] == m.gen {
 		if m.key[pos] == key {
 			m.val[pos] += d
+			m.req[pos] |= reqBit
 			return
 		}
 		pos = (pos + 1) & m.mask
@@ -293,15 +643,37 @@ func (m *ftsScoreAcc) add(key uint64, d float64) {
 	m.seen[pos] = m.gen
 	m.key[pos] = key
 	m.val[pos] = d
+	m.req[pos] = reqBit
+	m.tomb[pos] = false
 	m.n++
 }
 
-// appendTo appends every live (docID, score) pair to dst.
-func (m *ftsScoreAcc) appendTo(dst []scoredDoc) []scoredDoc {
-	for i := range m.key {
-		if m.seen[i] == m.gen {
-			dst = append(dst, scoredDoc{m.key[i], m.val[i]})
+// markTomb excludes key from the result if it is present in the accumulator (a
+// negated clause). A key not already scored by a positive clause is ignored —
+// negation only removes, it never introduces documents.
+func (m *ftsScoreAcc) markTomb(key uint64) {
+	pos := uint32(hashU64(key)) & m.mask
+	for m.seen[pos] == m.gen {
+		if m.key[pos] == key {
+			m.tomb[pos] = true
+			return
 		}
+		pos = (pos + 1) & m.mask
+	}
+}
+
+// appendTo appends the live (docID, score) pairs to dst, dropping tombstoned
+// docs and — when requiredAll != 0 — any doc that did not satisfy every required
+// clause (its mask must cover requiredAll).
+func (m *ftsScoreAcc) appendTo(dst []scoredDoc, requiredAll uint64) []scoredDoc {
+	for i := range m.key {
+		if m.seen[i] != m.gen || m.tomb[i] {
+			continue
+		}
+		if requiredAll != 0 && m.req[i]&requiredAll != requiredAll {
+			continue
+		}
+		dst = append(dst, scoredDoc{m.key[i], m.val[i]})
 	}
 	return dst
 }
@@ -311,6 +683,8 @@ func (m *ftsScoreAcc) grow() {
 	nkey := make([]uint64, size)
 	nval := make([]float64, size)
 	nseen := make([]uint32, size)
+	nreq := make([]uint64, size)
+	ntomb := make([]bool, size)
 	nmask := uint32(size - 1)
 	g := m.gen
 	for i := range m.key {
@@ -324,8 +698,10 @@ func (m *ftsScoreAcc) grow() {
 		nseen[p] = g
 		nkey[p] = m.key[i]
 		nval[p] = m.val[i]
+		nreq[p] = m.req[i]
+		ntomb[p] = m.tomb[i]
 	}
-	m.key, m.val, m.seen, m.mask = nkey, nval, nseen, nmask
+	m.key, m.val, m.seen, m.req, m.tomb, m.mask = nkey, nval, nseen, nreq, ntomb, nmask
 }
 
 // computeStats gathers the storage + corpus statistics of the full-text index:
@@ -449,12 +825,11 @@ func (q *collQuery) detectFtsQuery() (*qplanner.FtsQuerySpec, query.Filter, erro
 		return nil, nil, ErrNoFulltextIndex
 	}
 	fx := fxs[0]
-	search := text.Search
 	spec := &qplanner.FtsQuerySpec{
 		Ordered:    true, // searchCandidates returns score-descending
 		NeedScores: true, // cleared by ftsScanPlan for Count/Update/Delete
 		Search: func(tx *btree.ReadTx) (qplanner.FtsCandidateStream, error) {
-			return fx.searchCandidates(tx, search)
+			return fx.searchCandidates(tx, text)
 		},
 	}
 	return spec, ftsResidualFilter(q.cond), nil

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -109,7 +109,7 @@ func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, text query.Text) (qplanne
 		k1: k1, b: b, nFields: fx.nFields, weights: weights, weighted: weighted,
 	}
 	if err = e.run(clauses, text.DefaultAnd); err != nil {
-		ftsScoreAccPool.Put(acc)
+		ftsPutAcc(acc)
 		return nil, ftsMapFormatErr(err)
 	}
 
@@ -117,7 +117,7 @@ func (fx *ftsIndex) searchCandidates(tx *btree.ReadTx, text query.Text) (qplanne
 	// appendTo applies the required-mask gate and drops tombstoned docs.
 	acc.scratch = acc.appendTo(acc.scratch[:0], e.requiredAll)
 	if len(acc.scratch) == 0 {
-		ftsScoreAccPool.Put(acc)
+		ftsPutAcc(acc)
 		return nil, nil
 	}
 	slices.SortFunc(acc.scratch, func(a, b scoredDoc) int {
@@ -153,14 +153,35 @@ type ftsExec struct {
 	n           float64 // corpus doc count
 	avgdl       float64
 	az          *fts.Analyzer
-	k1, b       float64   // BM25 params for this index (resolved from FulltextParams)
-	nFields     int       // number of indexed fields
-	weights     []float64 // per-field BM25F boost (len nFields); nil when unweighted
-	weighted    bool      // any field weight != 1.0 — enables the per-field score path
-	dlBuf       []byte    // reusable docinfo value buffer (one per query)
-	tokBuf      []fts.Token
-	requiredAll uint64 // OR of every allocated required-clause bit
-	nextBit     uint   // next required-clause bit index
+	k1, b       float64           // BM25 params for this index (resolved from FulltextParams)
+	nFields     int               // number of indexed fields
+	weights     []float64         // per-field BM25F boost (len nFields); nil when unweighted
+	weighted    bool              // any field weight != 1.0 — enables the per-field score path
+	dlBuf       []byte            // reusable docinfo value buffer (one per query)
+	tokBuf      []fts.Token       // reusable analyze() output
+	prefixBuf   []byte            // reusable postings key-prefix (one per query)
+	chunkIt     fts.ChunkIterator // reused across every chunk/term of the query (Reset)
+	requiredAll uint64            // OR of every allocated required-clause bit
+	nextBit     uint              // next required-clause bit index
+}
+
+// chunkReader returns a chunk iterator over val, reusing the query's single
+// iterator (Reset) after the first chunk so a multi-chunk / multi-term query
+// allocates one reader, not one per chunk. All of a query's chunks share a format
+// version, so reuse is safe.
+func (e *ftsExec) chunkReader(val []byte) (fts.ChunkIterator, error) {
+	if e.chunkIt == nil {
+		it, err := fts.NewChunkIterator(val)
+		if err != nil {
+			return nil, err
+		}
+		e.chunkIt = it
+		return it, nil
+	}
+	if err := e.chunkIt.Reset(val); err != nil {
+		return nil, err
+	}
+	return e.chunkIt, nil
 }
 
 // ftsResolveWeights builds the per-field BM25F boost slice (indexed by field
@@ -346,7 +367,8 @@ func (e *ftsExec) scanTerm(term string, reqBit uint64, tomb bool) error {
 
 	cur := e.tx.NewCursor(e.fx.nsPost)
 	defer cur.Close()
-	prefix := postingsTermPrefix(nil, term)
+	e.prefixBuf = postingsTermPrefix(e.prefixBuf, term)
+	prefix := e.prefixBuf
 	if err = cur.Seek(prefix); err != nil {
 		return err
 	}
@@ -362,7 +384,7 @@ func (e *ftsExec) scanTerm(term string, reqBit uint64, tomb bool) error {
 		if verr != nil {
 			return verr
 		}
-		it, ierr := fts.NewChunkIterator(val)
+		it, ierr := e.chunkReader(val)
 		if ierr != nil {
 			return ierr
 		}
@@ -636,7 +658,7 @@ func (s *ftsCandidateStream) Next() (docId []byte, score float64, ok bool, err e
 
 func (s *ftsCandidateStream) Close() {
 	if s.acc != nil {
-		ftsScoreAccPool.Put(s.acc)
+		ftsPutAcc(s.acc)
 		s.acc = nil
 	}
 }
@@ -669,6 +691,27 @@ type ftsScoreAcc struct {
 }
 
 var ftsScoreAccPool = sync.Pool{New: func() any { return &ftsScoreAcc{} }}
+
+// ftsAccMaxPooled bounds the accumulator size kept in the pool. A high-DF query
+// over a large corpus can grow the table to many MB; returning that to a
+// sync.Pool would let every P pin a giant buffer (unbounded RAM on a constrained
+// device). So an oversized table is dropped on return (GC reclaims it; the next
+// user reallocates the small init size). Typical/small tables stay pooled, so the
+// common case still allocates nothing. Mirrors the write path's arena shrink.
+const ftsAccMaxPooled = 1 << 16 // ~64k slots ≈ a few MB across the parallel arrays
+
+// ftsPutAcc returns an accumulator to the pool, dropping its backing arrays first
+// if they grew past ftsAccMaxPooled so pooled RAM stays bounded.
+func ftsPutAcc(acc *ftsScoreAcc) {
+	if cap(acc.key) > ftsAccMaxPooled {
+		acc.key, acc.val, acc.seen, acc.req, acc.tomb = nil, nil, nil, nil, nil
+		acc.mask, acc.n, acc.gen = 0, 0, 0 // force reset() to reallocate small
+	}
+	if cap(acc.scratch) > ftsAccMaxPooled {
+		acc.scratch = nil
+	}
+	ftsScoreAccPool.Put(acc)
+}
 
 // hashU64 is the splitmix64 finalizer.
 func hashU64(x uint64) uint64 {

--- a/fulltext_termstream.go
+++ b/fulltext_termstream.go
@@ -72,7 +72,14 @@ func (ts *termStream) loadChunk() {
 			ts.valid = false
 			return
 		}
-		ts.it, err = fts.NewChunkIterator(val)
+		// Reuse one iterator across chunks: the first chunk picks the format impl
+		// (by version byte); the rest Reset it, so a multi-chunk term costs one
+		// iterator alloc, not one per chunk. All of a term's chunks share a version.
+		if ts.it == nil {
+			ts.it, err = fts.NewChunkIterator(val)
+		} else {
+			err = ts.it.Reset(val)
+		}
 		if err != nil {
 			ts.err = err
 			ts.valid = false

--- a/fulltext_termstream.go
+++ b/fulltext_termstream.go
@@ -1,0 +1,163 @@
+package anystore
+
+import (
+	"github.com/anyproto/any-store/v2/internal/btree"
+	"github.com/anyproto/any-store/v2/internal/fts"
+)
+
+// fulltext_termstream.go provides a cross-chunk iterator over a single term's
+// postings, used by the phrase zig-zag merge. The BM25 bag-of-words scan still
+// streams chunks inline in fulltext_search.go (it never seeks); the phrase merge
+// needs several terms advancing in lockstep by IntDocID, which is what termStream
+// gives: ascending docIDs across all of a term's chunks, with chunk-skipping seek
+// and lazy position decoding.
+
+// termStream walks every posting of one term across its chunks, in ascending
+// IntDocID. Not safe for concurrent use — one per term per query.
+type termStream struct {
+	cur    *btree.Cursor
+	term   string
+	prefix []byte // postingsTermPrefix(term): bounds the cursor to this term
+	keyBuf []byte // scratch for seek keys
+
+	it    fts.ChunkIterator
+	docID uint64
+	tf    uint32
+	valid bool
+	err   error
+}
+
+// newTermStream opens a stream over term's postings. A stream over a term with
+// no postings is valid but immediately exhausted (valid()==false).
+func newTermStream(tx *btree.ReadTx, ns *btree.Namespace, term string) *termStream {
+	ts := &termStream{
+		cur:    tx.NewCursor(ns),
+		term:   term,
+		prefix: postingsTermPrefix(nil, term),
+	}
+	if err := ts.cur.Seek(ts.prefix); err != nil {
+		ts.err = err
+		return ts
+	}
+	ts.loadChunk()
+	return ts
+}
+
+// onTerm reports whether the cursor is positioned on a chunk of this stream's
+// term (vs. having walked past it into the next term / end of namespace).
+func (ts *termStream) onTerm() bool {
+	if !ts.cur.Valid() {
+		return false
+	}
+	key, err := ts.cur.Key()
+	if err != nil {
+		ts.err = err
+		return false
+	}
+	return len(key) >= len(ts.prefix) && string(key[:len(ts.prefix)]) == string(ts.prefix)
+}
+
+// loadChunk builds an iterator over the chunk the cursor currently sits on and
+// advances it to the first document. If the cursor is past this term, the stream
+// becomes exhausted.
+func (ts *termStream) loadChunk() {
+	for {
+		if ts.err != nil || !ts.onTerm() {
+			ts.valid = false
+			return
+		}
+		val, err := ts.cur.Value()
+		if err != nil {
+			ts.err = err
+			ts.valid = false
+			return
+		}
+		ts.it, err = fts.NewChunkIterator(val)
+		if err != nil {
+			ts.err = err
+			ts.valid = false
+			return
+		}
+		if ts.it.Next() {
+			ts.docID = ts.it.DocID()
+			ts.tf = ts.it.TF()
+			ts.valid = true
+			return
+		}
+		if err = ts.it.Err(); err != nil {
+			ts.err = err
+			ts.valid = false
+			return
+		}
+		// Empty chunk (shouldn't happen — empty chunks are deleted) — skip it.
+		if err = ts.cur.Next(); err != nil {
+			ts.err = err
+			ts.valid = false
+			return
+		}
+	}
+}
+
+// next advances to the following document. Returns false at end of the term's
+// postings or on error (check ts.err via valid()).
+func (ts *termStream) next() bool {
+	if !ts.valid {
+		return false
+	}
+	if ts.it.Next() {
+		ts.docID = ts.it.DocID()
+		ts.tf = ts.it.TF()
+		return true
+	}
+	if err := ts.it.Err(); err != nil {
+		ts.err = err
+		ts.valid = false
+		return false
+	}
+	// Current chunk exhausted — move to the next chunk of this term.
+	if err := ts.cur.Next(); err != nil {
+		ts.err = err
+		ts.valid = false
+		return false
+	}
+	ts.loadChunk()
+	return ts.valid
+}
+
+// seek advances the stream to the first document with docID >= target, jumping
+// whole chunks when target lies ahead. A no-op if already at/after target.
+func (ts *termStream) seek(target uint64) {
+	if !ts.valid || ts.docID >= target {
+		return
+	}
+	if fts.ChunkID(target) > fts.ChunkID(ts.docID) {
+		// Jump the cursor straight to the chunk that would hold target.
+		ts.keyBuf = postingsKey(ts.keyBuf, ts.term, fts.ChunkID(target))
+		if err := ts.cur.Seek(ts.keyBuf); err != nil {
+			ts.err = err
+			ts.valid = false
+			return
+		}
+		ts.loadChunk()
+	}
+	for ts.valid && ts.docID < target {
+		ts.next()
+	}
+}
+
+// positions decodes the current document's positions onto dst, returning the
+// extended slice. Valid only while parked on a document (valid()==true).
+func (ts *termStream) positions(dst []uint32) []uint32 {
+	dst = ts.it.AppendPositions(dst)
+	if err := ts.it.Err(); err != nil {
+		ts.err = err
+	}
+	return dst
+}
+
+func (ts *termStream) close() {
+	if ts.cur != nil {
+		ts.cur.Close()
+		ts.cur = nil
+	}
+}

--- a/fulltext_weights_test.go
+++ b/fulltext_weights_test.go
@@ -1,0 +1,97 @@
+package anystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 3: per-field weights (BM25F). The v2 postings store per-field TF; the
+// scorer combines them as Σ weight_f · tf_f. An unweighted index reduces exactly
+// to classic BM25 (covered by the parity tests); these cover the weighting.
+
+func ftsWeightedColl(t *testing.T, fx *fixture, name string, weights map[string]float64) Collection {
+	coll, err := fx.CreateCollection(ctx, name)
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+		Kind:     IndexKindFulltext,
+		Fields:   []string{"title", "body"},
+		Fulltext: &FulltextParams{Weights: weights},
+	}))
+	insertJSON(t, coll,
+		`{"id":"t","title":"alpha","body":"filler filler filler"}`,      // match in title
+		`{"id":"b","title":"filler","body":"alpha filler filler"}`,      // match in body
+		`{"id":"x","title":"nothing","body":"unrelated text entirely"}`, // no match
+	)
+	return coll
+}
+
+func TestFtsWeights_TitleBoostChangesRanking(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+
+	// With a strong title boost, the title match (t) must outrank the body match (b).
+	boosted := ftsWeightedColl(t, fx, "boost", map[string]float64{"title": 8})
+	ids, _ := collectIter(t, boosted.Find(`{"$text":{"$search":"alpha"}}`))
+	assert.Equal(t, []string{"t", "b"}, ids)
+
+	// With the opposite boost (body >> title), the body match wins.
+	bodyBoost := ftsWeightedColl(t, fx, "bodyboost", map[string]float64{"body": 8})
+	ids2, _ := collectIter(t, bodyBoost.Find(`{"$text":{"$search":"alpha"}}`))
+	assert.Equal(t, []string{"b", "t"}, ids2)
+}
+
+func TestFtsWeights_UnweightedUnchanged(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+	// No weights → default BM25; both match, x does not. (Sanity that the v2 format
+	// + default scoring still returns the right match set.)
+	plain := ftsWeightedColl(t, fx, "plain", nil)
+	ids, scores := collectIter(t, plain.Find(`{"$text":{"$search":"alpha"}}`))
+	assert.ElementsMatch(t, []string{"t", "b"}, ids)
+	for _, s := range scores {
+		assert.Greater(t, s, 0.0)
+	}
+}
+
+func TestFtsWeights_Validation(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+	coll, err := fx.CreateCollection(ctx, "v")
+	require.NoError(t, err)
+	assert.Error(t, coll.EnsureIndex(ctx, IndexInfo{
+		Kind: IndexKindFulltext, Fields: []string{"title", "body"},
+		Fulltext: &FulltextParams{Weights: map[string]float64{"nosuchfield": 2}},
+	}), "weight on unknown field must be rejected")
+	assert.Error(t, coll.EnsureIndex(ctx, IndexInfo{
+		Kind: IndexKindFulltext, Fields: []string{"title"},
+		Fulltext: &FulltextParams{Weights: map[string]float64{"title": -1}},
+	}), "negative weight must be rejected")
+}
+
+func TestFtsWeights_SurviveReopen(t *testing.T) {
+	tmpDir := t.TempDir()
+	func() {
+		fxLocal := newFixturePath(t, tmpDir)
+		coll, err := fxLocal.CreateCollection(ctx, "docs")
+		require.NoError(t, err)
+		require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+			Kind: IndexKindFulltext, Fields: []string{"title", "body"},
+			Fulltext: &FulltextParams{Weights: map[string]float64{"title": 4, "body": 1}},
+		}))
+		insertJSON(t, coll, `{"id":"a","title":"alpha","body":"beta"}`)
+		require.NoError(t, fxLocal.Close())
+	}()
+
+	db, err := Open(ctx, tmpDir+"/any-store-test.db", nil)
+	require.NoError(t, err)
+	defer db.Close()
+	collI, err := db.OpenCollection(ctx, "docs")
+	require.NoError(t, err)
+	c := collI.(*collection)
+	fxs := c.loadFtsIndexes()
+	require.Len(t, fxs, 1)
+	assert.Equal(t, 4.0, fxs[0].info.Fulltext.Weights["title"])
+	assert.Equal(t, 1.0, fxs[0].info.Fulltext.Weights["body"])
+}

--- a/index.go
+++ b/index.go
@@ -257,10 +257,21 @@ type IndexInfo struct {
 	Vector *VectorParams `json:"vector,omitempty"`
 }
 
-// FulltextParams configures a full-text index. It is reserved for future
-// options (per-field weights, analyzer selection, positionless mode); v1 uses
-// the default analyzer (NFKC + case-fold + UAX#29 + CJK bigram) for all fields.
-type FulltextParams struct{}
+// FulltextParams configures a full-text index. All fields are optional; the
+// zero value reproduces the default BM25 scoring. Per-field weights (Weights)
+// and analyzer/stemming selection are reserved for a later version. The default
+// analyzer (NFKC + case-fold + UAX#29 + CJK bigram) is used for all fields.
+type FulltextParams struct {
+	// B is the BM25 length-normalization parameter, in [0,1]. 0 ⇒ the default
+	// 0.75. Lower values reduce the bias toward short documents (e.g. 0.4 is a
+	// reasonable choice for a corpus of mixed-length notes); 0 disables length
+	// normalization entirely — but note 0 is read as "use the default", so to
+	// approach no normalization use a small value rather than exactly 0.
+	B float64 `json:"b,omitempty"`
+	// K1 is the BM25 term-frequency saturation parameter (>= 0). 0 ⇒ the default
+	// 1.2. Higher values make repeated term occurrences count for more.
+	K1 float64 `json:"k1,omitempty"`
+}
 
 func (i IndexInfo) createName() string {
 	return strings.Join(i.Fields, ",")
@@ -328,8 +339,8 @@ type index struct {
 	// curBounds is scratch (len == number of index fields) holding the field-end
 	// offsets of the key currently being built by writeValues; copied into
 	// keyBoundsBuf at each leaf.
-	curBounds []int
-	uniqBuf   [][]anyenc.Tuple
+	curBounds   []int
+	uniqBuf     [][]anyenc.Tuple
 	fullKeyBuf  anyenc.Tuple // reusable buffer for full keys (key+docId)
 	seekBuf     anyenc.Tuple // reusable buffer for unique constraint seek results
 	uniqSeekBuf anyenc.Tuple // reusable buffer for the padded unique-probe seek key

--- a/index.go
+++ b/index.go
@@ -262,6 +262,14 @@ type IndexInfo struct {
 // and analyzer/stemming selection are reserved for a later version. The default
 // analyzer (NFKC + case-fold + UAX#29 + CJK bigram) is used for all fields.
 type FulltextParams struct {
+	// Weights is the per-field BM25F boost, keyed by indexed field name (each key
+	// must be one of IndexInfo.Fields). A field absent from the map has weight 1.0.
+	// Mirrors MongoDB's text-index weights option, but scoring is BM25F: the
+	// per-field term frequencies are combined as Σ weight_f · tf_f and then scored
+	// with standard BM25 saturation + length normalization. Set at index creation;
+	// changing a weight only changes ranking (no re-index needed — weights are read
+	// at query time). Boosting e.g. {"title": 5} ranks title matches above body.
+	Weights map[string]float64 `json:"weights,omitempty"`
 	// B is the BM25 length-normalization parameter, in [0,1]. 0 ⇒ the default
 	// 0.75. Lower values reduce the bias toward short documents (e.g. 0.4 is a
 	// reasonable choice for a corpus of mixed-length notes); 0 disables length

--- a/internal/fts/codec.go
+++ b/internal/fts/codec.go
@@ -127,6 +127,10 @@ type ChunkIterator interface {
 	// AppendPositions decodes the current document's positions onto dst. Calling
 	// it consumes the positions for this document.
 	AppendPositions(dst []uint32) []uint32
+	// Reset re-initializes the iterator over a new chunk blob (same format
+	// version), so a cross-chunk walk can reuse one iterator instead of
+	// allocating per chunk. Returns the same errors as the constructor.
+	Reset(blob []byte) error
 	// Err returns the first decode error encountered.
 	Err() error
 }
@@ -155,13 +159,25 @@ type ChunkReader struct {
 // NewChunkReader validates the version byte and returns a reader positioned
 // before the first document.
 func NewChunkReader(blob []byte) (*ChunkReader, error) {
+	r := &ChunkReader{}
+	if err := r.Reset(blob); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// Reset re-initializes the reader over a new chunk blob, clearing all decode
+// state, so a cross-chunk walk (termStream) can reuse one reader instead of
+// allocating a fresh one per chunk.
+func (r *ChunkReader) Reset(blob []byte) error {
 	if len(blob) == 0 {
-		return nil, ErrCorruptChunk
+		return ErrCorruptChunk
 	}
 	if blob[0] != PostingsVersion {
-		return nil, ErrUnknownVersion
+		return ErrUnknownVersion
 	}
-	return &ChunkReader{buf: blob[1:]}, nil
+	*r = ChunkReader{buf: blob[1:]}
+	return nil
 }
 
 // Next advances to the next document. It decodes the DocID and TF but leaves the

--- a/internal/fts/codec.go
+++ b/internal/fts/codec.go
@@ -3,47 +3,65 @@ package fts
 import (
 	"encoding/binary"
 	"errors"
+	"math/bits"
 	"slices"
 )
 
 // Postings chunk format (the value stored at fts:postings key Tuple(term, chunkID)):
 //
-//	[ version : 1 byte ]
+//	[ version : 1 byte = 2 ]
 //	repeated, one record per document, documents ascending by DocID:
 //	    DocIDDelta : uvarint   // first record = absolute DocID; rest = DocID - prevDocID
-//	    TF         : uvarint   // term frequency in this doc == len(Positions)
-//	    PosDelta×TF: uvarint   // positions ascending; first = absolute, rest = delta
+//	    FieldMask  : uvarint   // bit f set ⇒ the term occurs in indexed field f
+//	    TF_f       : uvarint × popcount(FieldMask)  // per set bit, ascending field order
+//	    PosDelta×ΣTF: uvarint  // GLOBAL (field-gapped) positions ascending; first
+//	                           // absolute, rest delta. Σ TF_f of them.
 //
 // Documents are delta-encoded against the previous document in the chunk, so a
-// chunk is self-describing (it does not need to know its chunk base id to
-// decode). Positions are delta-encoded within a document, so deltas are tiny.
+// chunk is self-describing. Positions are global (the indexer offsets each field
+// by a fixed gap so a phrase cannot bridge fields) and delta-encoded within a
+// document, so deltas are tiny. The per-field TF breakdown drives BM25F per-field
+// weighting; positions stay global so the phrase merge is unchanged.
+//
+// A single-field index simply has FieldMask == 1 and one TF, so this format is
+// uniform across one- and many-field indexes (no special case).
 //
 // A chunk holds at most ChunkSize documents, keeping the blob well under a page
 // so it never spills to an overflow page on read-modify-write.
 
 const (
-	// PostingsVersion is the first byte of every fts:postings value. It MUST be
-	// present so the on-disk blob format can evolve in place. Do not remove.
-	PostingsVersion = 1
+	// PostingsVersion is the first byte of every fts:postings value. v2 added the
+	// per-field TF breakdown (FieldMask + TF_f). The byte MUST be present so the
+	// on-disk blob format can evolve in place. Old (v1) data is migrated by a full
+	// re-index (the fts namespaces are cleared first), so this build only ever
+	// decodes v2; a stray v1 byte is rejected with ErrUnknownVersion.
+	PostingsVersion = 2
 
 	// ChunkSize is the number of documents per postings chunk. It is part of the
 	// on-disk key layout (key = Tuple(term, IntDocID/ChunkSize)); changing it
 	// rekeys the whole index and forces a full re-index. Power of two, fixed.
 	ChunkSize = 128
+
+	// MaxFields is the number of indexed fields the FieldMask can represent.
+	MaxFields = 64
 )
 
 // ErrCorruptChunk is returned when a postings blob cannot be decoded.
 var ErrCorruptChunk = errors.New("fts: corrupt postings chunk")
 
 // ErrUnknownVersion is returned when a postings blob carries a version this
-// build does not understand.
+// build does not understand (e.g. un-migrated v1 data).
 var ErrUnknownVersion = errors.New("fts: unknown postings chunk version")
 
 // Posting is one document's entry in a term's postings: the document's internal
-// id and the ascending list of token positions at which the term occurs. The
-// term frequency is len(Positions).
+// id, the set of indexed fields the term occurs in (Fields bitmask), the term
+// frequency per occupied field (FieldTF, in ascending field order, one entry per
+// set bit of Fields), and the ascending GLOBAL token positions. The total term
+// frequency is len(Positions) == sum(FieldTF).
 type Posting struct {
 	DocID     uint64
+	Fields    uint64
+	FieldTF   []uint32
 	Positions []uint32
 }
 
@@ -51,8 +69,10 @@ type Posting struct {
 func ChunkID(docID uint64) uint64 { return docID / ChunkSize }
 
 // AppendChunk encodes postings into a fresh chunk blob appended to dst (dst may
-// be nil) and returns it. postings must be sorted ascending by DocID, and each
-// Posting's Positions must be sorted ascending; the caller guarantees this.
+// be nil) and returns it. postings must be sorted ascending by DocID; each
+// Posting's Positions must be sorted ascending; FieldTF must be in ascending
+// field order with one entry per set bit of Fields and sum(FieldTF) ==
+// len(Positions). The caller guarantees these.
 func AppendChunk(dst []byte, postings []Posting) []byte {
 	dst = append(dst, PostingsVersion)
 	var prevDoc uint64
@@ -65,7 +85,11 @@ func AppendChunk(dst []byte, postings []Posting) []byte {
 		}
 		prevDoc = p.DocID
 
-		dst = binary.AppendUvarint(dst, uint64(len(p.Positions)))
+		dst = binary.AppendUvarint(dst, p.Fields)
+		for _, tf := range p.FieldTF {
+			dst = binary.AppendUvarint(dst, uint64(tf))
+		}
+
 		var prevPos uint32
 		for j, pos := range p.Positions {
 			if j == 0 {
@@ -83,49 +107,82 @@ func AppendChunk(dst []byte, postings []Posting) []byte {
 // be nil). It materializes positions; the read path should prefer ChunkReader to
 // skip position decoding for documents it does not need.
 func DecodeChunk(dst []Posting, blob []byte) ([]Posting, error) {
-	dst, _, err := DecodeChunkInto(dst, nil, blob)
+	dst, _, _, err := DecodeChunkInto(dst, nil, nil, blob)
 	return dst, err
 }
 
-// DecodeChunkInto is DecodeChunk with a caller-reused position buffer: every
-// posting's Positions slice references posBuf's backing array, so a whole-chunk
-// decode costs zero steady-state allocations instead of one per posting. posBuf
-// is grown once up front to a safe upper bound (each encoded position is at
-// least one byte), which guarantees the returned subslices are never
-// invalidated by reallocation.
-func DecodeChunkInto(dst []Posting, posBuf []uint32, blob []byte) ([]Posting, []uint32, error) {
+// DecodeChunkInto is DecodeChunk with caller-reused position and field-TF
+// buffers: every posting's Positions and FieldTF slices reference posBuf / tfBuf,
+// so a whole-chunk decode costs zero steady-state allocations. Both buffers are
+// grown once up front to a safe upper bound (each encoded value is at least one
+// byte), which guarantees the returned subslices are never invalidated by
+// reallocation.
+func DecodeChunkInto(dst []Posting, posBuf, tfBuf []uint32, blob []byte) ([]Posting, []uint32, []uint32, error) {
 	r, err := NewChunkReader(blob)
 	if err != nil {
-		return dst, posBuf, err
+		return dst, posBuf, tfBuf, err
 	}
 	if need := len(blob) - (cap(posBuf) - len(posBuf)); need > 0 {
 		posBuf = slices.Grow(posBuf, len(blob))
 	}
-	for r.Next() {
-		start := len(posBuf)
-		posBuf = r.AppendPositions(posBuf)
-		dst = append(dst, Posting{DocID: r.DocID(), Positions: posBuf[start:len(posBuf):len(posBuf)]})
+	if need := len(blob) - (cap(tfBuf) - len(tfBuf)); need > 0 {
+		tfBuf = slices.Grow(tfBuf, len(blob))
 	}
-	return dst, posBuf, r.Err()
+	for r.Next() {
+		tfStart := len(tfBuf)
+		tfBuf = r.AppendFieldTFs(tfBuf)
+		posStart := len(posBuf)
+		posBuf = r.AppendPositions(posBuf)
+		dst = append(dst, Posting{
+			DocID:     r.DocID(),
+			Fields:    r.FieldMask(),
+			FieldTF:   tfBuf[tfStart:len(tfBuf):len(tfBuf)],
+			Positions: posBuf[posStart:len(posBuf):len(posBuf)],
+		})
+	}
+	return dst, posBuf, tfBuf, r.Err()
+}
+
+// ChunkReader streams documents out of a chunk blob without allocating, decoding
+// each document's FieldMask + per-field TF eagerly (cheap, needed for scoring)
+// but its positions only on demand. It is the read-path primitive: the BM25(F)
+// scan reads DocID + FieldMask + TFs and skips positions; the zig-zag phrase
+// merge advances DocIDs cheaply and materializes positions only for documents
+// that survive the merge. It implements ChunkIterator.
+type ChunkReader struct {
+	buf         []byte // remaining undecoded tail
+	prevDoc     uint64
+	docID       uint64
+	fields      uint64   // FieldMask of the current document
+	fieldTF     []uint32 // per-set-bit TFs of the current document (ascending field order)
+	tf          uint32   // total TF of the current document (sum of fieldTF)
+	started     bool     // at least one doc decoded
+	posConsumed bool     // current doc's positions already read/skipped
+	err         error
 }
 
 // ChunkIterator streams documents out of a postings chunk in ascending DocID,
-// decoding each document's term frequency eagerly but its positions only on
-// demand. It is the format-agnostic read primitive the search path consumes:
-// the BM25 scan reads only DocID/TF, and the zig-zag phrase merge advances
-// DocIDs cheaply and materializes positions only for documents that survive the
-// merge. v1 chunks are served by ChunkReader; a future v2 (per-field TF) chunk
-// will implement the same interface, so the search code never sees the layout.
+// exposing field-aware term frequencies eagerly and positions lazily. v1/v2
+// chunks (only v2 exists today) implement it, so the search code is blind to the
+// blob layout.
 type ChunkIterator interface {
 	// Next advances to the next document, returning false at end of chunk or on
 	// error (check Err). It skips any unconsumed positions of the prior document.
 	Next() bool
 	// DocID returns the current document's internal id.
 	DocID() uint64
-	// TF returns the current document's total term frequency.
+	// TF returns the current document's total term frequency (sum over fields).
 	TF() uint32
-	// AppendPositions decodes the current document's positions onto dst. Calling
-	// it consumes the positions for this document.
+	// FieldMask returns the bitmask of indexed fields the term occurs in.
+	FieldMask() uint64
+	// FieldTF returns the term frequency in indexed field fieldIdx (0 if the term
+	// does not occur there).
+	FieldTF(fieldIdx int) uint32
+	// AppendFieldTFs appends the per-occupied-field TFs (ascending field order) to
+	// dst — the sparse representation matching the set bits of FieldMask.
+	AppendFieldTFs(dst []uint32) []uint32
+	// AppendPositions decodes the current document's global positions onto dst.
+	// Calling it consumes the positions for this document.
 	AppendPositions(dst []uint32) []uint32
 	// Reset re-initializes the iterator over a new chunk blob (same format
 	// version), so a cross-chunk walk can reuse one iterator instead of
@@ -136,24 +193,9 @@ type ChunkIterator interface {
 }
 
 // NewChunkIterator returns a ChunkIterator for a postings chunk blob, dispatching
-// on the leading version byte. Today only v1 (ChunkReader) exists; v2 will slot
-// in here without touching any caller.
+// on the leading version byte.
 func NewChunkIterator(blob []byte) (ChunkIterator, error) {
 	return NewChunkReader(blob)
-}
-
-// ChunkReader streams documents out of a chunk blob without allocating, decoding
-// each document's positions only on demand. It is the read-path primitive: the
-// zig-zag phrase merge advances DocIDs cheaply and only materializes positions
-// for documents that survive the merge. It implements ChunkIterator.
-type ChunkReader struct {
-	buf         []byte // remaining undecoded tail
-	prevDoc     uint64
-	docID       uint64
-	tf          uint32
-	started     bool // at least one doc decoded
-	posConsumed bool // current doc's positions already read/skipped
-	err         error
 }
 
 // NewChunkReader validates the version byte and returns a reader positioned
@@ -176,18 +218,18 @@ func (r *ChunkReader) Reset(blob []byte) error {
 	if blob[0] != PostingsVersion {
 		return ErrUnknownVersion
 	}
-	*r = ChunkReader{buf: blob[1:]}
+	tf := r.fieldTF[:0] // keep the field-TF scratch across resets
+	*r = ChunkReader{buf: blob[1:], fieldTF: tf}
 	return nil
 }
 
-// Next advances to the next document. It decodes the DocID and TF but leaves the
-// positions in the buffer for AppendPositions/SkipPositions. Returns false at
-// end of chunk or on error (check Err).
+// Next advances to the next document. It decodes the DocID, FieldMask, and
+// per-field TFs but leaves the positions in the buffer for
+// AppendPositions/SkipPositions. Returns false at end of chunk or on error.
 func (r *ChunkReader) Next() bool {
 	if r.err != nil {
 		return false
 	}
-	// If positions of the current doc were not consumed, skip them first.
 	if r.started {
 		if !r.skipCurrentPositions() {
 			return false
@@ -211,13 +253,28 @@ func (r *ChunkReader) Next() bool {
 	r.prevDoc = r.docID
 	r.started = true
 
-	tf, n := binary.Uvarint(r.buf)
+	mask, n := binary.Uvarint(r.buf)
 	if n <= 0 {
 		r.err = ErrCorruptChunk
 		return false
 	}
 	r.buf = r.buf[n:]
-	r.tf = uint32(tf)
+	r.fields = mask
+
+	k := bits.OnesCount64(mask)
+	r.fieldTF = r.fieldTF[:0]
+	var total uint64
+	for i := 0; i < k; i++ {
+		tf, n := binary.Uvarint(r.buf)
+		if n <= 0 {
+			r.err = ErrCorruptChunk
+			return false
+		}
+		r.buf = r.buf[n:]
+		r.fieldTF = append(r.fieldTF, uint32(tf))
+		total += tf
+	}
+	r.tf = uint32(total)
 	r.posConsumed = false
 	return true
 }
@@ -225,8 +282,30 @@ func (r *ChunkReader) Next() bool {
 // DocID returns the current document's internal id.
 func (r *ChunkReader) DocID() uint64 { return r.docID }
 
-// TF returns the current document's term frequency (number of positions).
+// TF returns the current document's total term frequency (sum over fields).
 func (r *ChunkReader) TF() uint32 { return r.tf }
+
+// FieldMask returns the bitmask of indexed fields the term occurs in.
+func (r *ChunkReader) FieldMask() uint64 { return r.fields }
+
+// FieldTF returns the term frequency in indexed field fieldIdx, or 0 if the term
+// does not occur there.
+func (r *ChunkReader) FieldTF(fieldIdx int) uint32 {
+	if fieldIdx < 0 || fieldIdx >= MaxFields {
+		return 0
+	}
+	bit := uint64(1) << uint(fieldIdx)
+	if r.fields&bit == 0 {
+		return 0
+	}
+	ord := bits.OnesCount64(r.fields & (bit - 1))
+	return r.fieldTF[ord]
+}
+
+// AppendFieldTFs appends the per-occupied-field TFs (ascending field order) to dst.
+func (r *ChunkReader) AppendFieldTFs(dst []uint32) []uint32 {
+	return append(dst, r.fieldTF...)
+}
 
 // AppendPositions decodes the current document's positions, appending them to
 // dst (dst may be nil) and returning the extended slice. Calling it consumes the

--- a/internal/fts/codec.go
+++ b/internal/fts/codec.go
@@ -109,10 +109,39 @@ func DecodeChunkInto(dst []Posting, posBuf []uint32, blob []byte) ([]Posting, []
 	return dst, posBuf, r.Err()
 }
 
+// ChunkIterator streams documents out of a postings chunk in ascending DocID,
+// decoding each document's term frequency eagerly but its positions only on
+// demand. It is the format-agnostic read primitive the search path consumes:
+// the BM25 scan reads only DocID/TF, and the zig-zag phrase merge advances
+// DocIDs cheaply and materializes positions only for documents that survive the
+// merge. v1 chunks are served by ChunkReader; a future v2 (per-field TF) chunk
+// will implement the same interface, so the search code never sees the layout.
+type ChunkIterator interface {
+	// Next advances to the next document, returning false at end of chunk or on
+	// error (check Err). It skips any unconsumed positions of the prior document.
+	Next() bool
+	// DocID returns the current document's internal id.
+	DocID() uint64
+	// TF returns the current document's total term frequency.
+	TF() uint32
+	// AppendPositions decodes the current document's positions onto dst. Calling
+	// it consumes the positions for this document.
+	AppendPositions(dst []uint32) []uint32
+	// Err returns the first decode error encountered.
+	Err() error
+}
+
+// NewChunkIterator returns a ChunkIterator for a postings chunk blob, dispatching
+// on the leading version byte. Today only v1 (ChunkReader) exists; v2 will slot
+// in here without touching any caller.
+func NewChunkIterator(blob []byte) (ChunkIterator, error) {
+	return NewChunkReader(blob)
+}
+
 // ChunkReader streams documents out of a chunk blob without allocating, decoding
 // each document's positions only on demand. It is the read-path primitive: the
 // zig-zag phrase merge advances DocIDs cheaply and only materializes positions
-// for documents that survive the merge.
+// for documents that survive the merge. It implements ChunkIterator.
 type ChunkReader struct {
 	buf         []byte // remaining undecoded tail
 	prevDoc     uint64

--- a/internal/fts/codec_test.go
+++ b/internal/fts/codec_test.go
@@ -7,12 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// sf builds a single-field posting (field 0), the common case: FieldMask = 1,
+// one TF = len(positions).
+func sf(docID uint64, pos ...uint32) Posting {
+	return Posting{DocID: docID, Fields: 1, FieldTF: []uint32{uint32(len(pos))}, Positions: pos}
+}
+
 func TestChunk_RoundTrip(t *testing.T) {
 	in := []Posting{
-		{DocID: 3, Positions: []uint32{0, 5, 17}},
-		{DocID: 4, Positions: []uint32{2}},
-		{DocID: 130, Positions: []uint32{0, 1, 2, 3}},
-		{DocID: 9001, Positions: []uint32{42}},
+		sf(3, 0, 5, 17),
+		sf(4, 2),
+		sf(130, 0, 1, 2, 3),
+		sf(9001, 42),
 	}
 	blob := AppendChunk(nil, in)
 	assert.Equal(t, byte(PostingsVersion), blob[0])
@@ -22,8 +28,37 @@ func TestChunk_RoundTrip(t *testing.T) {
 	assert.Equal(t, in, out)
 }
 
+func TestChunk_MultiField_RoundTrip(t *testing.T) {
+	// Field 0 (title) + field 2 (tag): mask = 0b101, TFs in ascending field order.
+	in := []Posting{
+		{DocID: 1, Fields: 0b101, FieldTF: []uint32{1, 2}, Positions: []uint32{0, 200, 201}},
+		{DocID: 2, Fields: 0b010, FieldTF: []uint32{3}, Positions: []uint32{100, 101, 102}},
+	}
+	out, err := DecodeChunk(nil, AppendChunk(nil, in))
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestChunkReader_FieldTFAccessor(t *testing.T) {
+	in := []Posting{{DocID: 7, Fields: 0b1010, FieldTF: []uint32{4, 9}, Positions: make([]uint32, 13)}}
+	// fill positions ascending so decode is valid
+	for i := range in[0].Positions {
+		in[0].Positions[i] = uint32(i)
+	}
+	r, err := NewChunkReader(AppendChunk(nil, in))
+	require.NoError(t, err)
+	require.True(t, r.Next())
+	assert.Equal(t, uint64(0b1010), r.FieldMask())
+	assert.Equal(t, uint32(0), r.FieldTF(0))
+	assert.Equal(t, uint32(4), r.FieldTF(1)) // first set bit
+	assert.Equal(t, uint32(0), r.FieldTF(2))
+	assert.Equal(t, uint32(9), r.FieldTF(3)) // second set bit
+	assert.Equal(t, uint32(13), r.TF())      // total
+	assert.Equal(t, []uint32{4, 9}, r.AppendFieldTFs(nil))
+}
+
 func TestChunk_SingleDoc(t *testing.T) {
-	in := []Posting{{DocID: 0, Positions: []uint32{0}}}
+	in := []Posting{sf(0, 0)}
 	out, err := DecodeChunk(nil, AppendChunk(nil, in))
 	require.NoError(t, err)
 	assert.Equal(t, in, out)
@@ -38,12 +73,7 @@ func TestChunk_Empty(t *testing.T) {
 }
 
 func TestChunkReader_SkipPositions(t *testing.T) {
-	// Advancing without reading positions must still land on correct DocIDs/TF.
-	in := []Posting{
-		{DocID: 1, Positions: []uint32{0, 1, 2}},
-		{DocID: 7, Positions: []uint32{9}},
-		{DocID: 12, Positions: []uint32{3, 8}},
-	}
+	in := []Posting{sf(1, 0, 1, 2), sf(7, 9), sf(12, 3, 8)}
 	r, err := NewChunkReader(AppendChunk(nil, in))
 	require.NoError(t, err)
 
@@ -52,7 +82,6 @@ func TestChunkReader_SkipPositions(t *testing.T) {
 	for r.Next() {
 		gotDocs = append(gotDocs, r.DocID())
 		gotTF = append(gotTF, r.TF())
-		// deliberately do NOT call AppendPositions for most docs
 	}
 	require.NoError(t, r.Err())
 	assert.Equal(t, []uint64{1, 7, 12}, gotDocs)
@@ -60,27 +89,38 @@ func TestChunkReader_SkipPositions(t *testing.T) {
 }
 
 func TestChunkReader_PositionsOnDemand(t *testing.T) {
-	in := []Posting{
-		{DocID: 1, Positions: []uint32{0, 4}},
-		{DocID: 2, Positions: []uint32{7, 9, 11}},
-	}
+	in := []Posting{sf(1, 0, 4), sf(2, 7, 9, 11)}
 	r, err := NewChunkReader(AppendChunk(nil, in))
 	require.NoError(t, err)
 
 	require.True(t, r.Next())
 	assert.Equal(t, uint64(1), r.DocID())
-	// skip positions of doc 1 by not reading them
 	require.True(t, r.Next())
 	assert.Equal(t, uint64(2), r.DocID())
 	assert.Equal(t, []uint32{7, 9, 11}, r.AppendPositions(nil))
-	// idempotent: second call returns nothing more (already consumed)
 	assert.Empty(t, r.AppendPositions(nil))
 	require.False(t, r.Next())
 	require.NoError(t, r.Err())
 }
 
+func TestChunkReader_Reset(t *testing.T) {
+	a := AppendChunk(nil, []Posting{sf(1, 0), sf(2, 1)})
+	b := AppendChunk(nil, []Posting{sf(5, 0, 1)})
+	r, err := NewChunkReader(a)
+	require.NoError(t, err)
+	require.True(t, r.Next())
+	require.NoError(t, r.Reset(b))
+	require.True(t, r.Next())
+	assert.Equal(t, uint64(5), r.DocID())
+	assert.Equal(t, uint32(2), r.TF())
+	require.False(t, r.Next())
+}
+
 func TestChunkReader_BadVersion(t *testing.T) {
 	_, err := NewChunkReader([]byte{0xFF, 0x00})
+	assert.ErrorIs(t, err, ErrUnknownVersion)
+	// A v1 blob (version byte 1) is rejected — it must be migrated, not decoded.
+	_, err = NewChunkReader([]byte{0x01, 0x00})
 	assert.ErrorIs(t, err, ErrUnknownVersion)
 }
 
@@ -90,9 +130,7 @@ func TestChunkReader_EmptyBlob(t *testing.T) {
 }
 
 func TestChunkReader_TruncatedIsDetected(t *testing.T) {
-	in := []Posting{{DocID: 5, Positions: []uint32{1, 2, 3}}}
-	blob := AppendChunk(nil, in)
-	// Chop the last byte to truncate a position varint stream.
+	blob := AppendChunk(nil, []Posting{sf(5, 1, 2, 3)})
 	r, err := NewChunkReader(blob[:len(blob)-1])
 	require.NoError(t, err)
 	for r.Next() {
@@ -108,15 +146,12 @@ func TestChunkID(t *testing.T) {
 	assert.Equal(t, uint64(70), ChunkID(9001))
 }
 
-// buildFullChunk makes a realistic full (128-doc) chunk: a common term with a
-// few positions per doc.
+// buildFullChunk makes a realistic full (128-doc) chunk: a common single-field
+// term with a few positions per doc.
 func buildFullChunk() []byte {
 	postings := make([]Posting, ChunkSize)
 	for i := 0; i < ChunkSize; i++ {
-		postings[i] = Posting{
-			DocID:     uint64(i * 3), // gaps, ascending
-			Positions: []uint32{uint32(i), uint32(i + 10), uint32(i + 25)},
-		}
+		postings[i] = sf(uint64(i*3), uint32(i), uint32(i+10), uint32(i+25))
 	}
 	return AppendChunk(nil, postings)
 }
@@ -140,7 +175,6 @@ func BenchmarkDecodeChunk_Full(b *testing.B) {
 }
 
 func BenchmarkDecodeChunk_DocIDsOnly(b *testing.B) {
-	// Scoring/merge that only needs DocIDs+TF and skips positions.
 	blob := buildFullChunk()
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/anyproto/any-store/v2/anyenc"
 	"github.com/anyproto/any-store/v2/internal/parser"
@@ -380,8 +381,20 @@ func makeCompFilter(op Operator, v *anyenc.Value) (f Filter, err error) {
 	}
 }
 
-// parseText parses {"$search": "...", "$language": "..."} into a Text filter.
-// $language is accepted and ignored for v1 (the analyzer is language-neutral).
+// parseText parses the $text predicate object into a Text filter:
+//
+//	{
+//	  "$search": "free text \"phrases\" prefix*",  // should/OR (or AND, see below)
+//	  "$defaultOperator": "and" | "or",            // default joins $search terms
+//	  "$require": "critical" | ["a", "\"b c\""],   // each entry required (AND)
+//	  "$exclude": "spam" | ["draft", "x*"]          // each entry excluded
+//	}
+//
+// $require/$exclude take a string or an array of strings; each entry reuses the
+// phrase/prefix syntax of $search (ParseTextSearch) with its boolean role fixed
+// by the field. This replaces inline +/- in the search string, which is unsafe
+// for raw user input (see ParseTextSearch). $language/$caseSensitive/
+// $diacriticSensitive are accepted and ignored (the analyzer is language-neutral).
 // Note the Text caveat: outside an FTS-driven query its Ok matches everything.
 func parseText(v *anyenc.Value) (Filter, error) {
 	if v.Type() != anyenc.TypeObject {
@@ -389,10 +402,35 @@ func parseText(v *anyenc.Value) (Filter, error) {
 	}
 	obj, _ := v.Object()
 	var (
-		search string
-		hasS   bool
-		perr   error
+		search      string
+		hasS        bool
+		defaultAnd  bool
+		requireRaws []string
+		excludeRaws []string
+		perr        error
 	)
+	// appendStrings reads a string or array-of-strings field into dst.
+	appendStrings := func(field string, val *anyenc.Value, dst []string) []string {
+		switch val.Type() {
+		case anyenc.TypeString:
+			sb, _ := val.StringBytes()
+			return append(dst, string(sb))
+		case anyenc.TypeArray:
+			arr, _ := val.Array()
+			for _, e := range arr {
+				sb, er := e.StringBytes()
+				if er != nil {
+					perr = fmt.Errorf("%s entries must be strings", field)
+					return dst
+				}
+				dst = append(dst, string(sb))
+			}
+			return dst
+		default:
+			perr = fmt.Errorf("%s must be a string or an array of strings", field)
+			return dst
+		}
+	}
 	obj.Visit(func(key []byte, val *anyenc.Value) {
 		if perr != nil {
 			return
@@ -405,6 +443,24 @@ func parseText(v *anyenc.Value) (Filter, error) {
 				return
 			}
 			search, hasS = string(sb), true
+		case "$defaultOperator":
+			sb, e := val.StringBytes()
+			if e != nil {
+				perr = fmt.Errorf("$defaultOperator must be a string (\"and\" or \"or\")")
+				return
+			}
+			switch strings.ToLower(string(sb)) {
+			case "and":
+				defaultAnd = true
+			case "or", "":
+				defaultAnd = false
+			default:
+				perr = fmt.Errorf("$defaultOperator must be \"and\" or \"or\", got %q", string(sb))
+			}
+		case "$require":
+			requireRaws = appendStrings("$require", val, requireRaws)
+		case "$exclude":
+			excludeRaws = appendStrings("$exclude", val, excludeRaws)
 		case "$language", "$caseSensitive", "$diacriticSensitive":
 			// accepted for Mongo compatibility, ignored in v1
 		default:
@@ -417,7 +473,90 @@ func parseText(v *anyenc.Value) (Filter, error) {
 	if !hasS {
 		return nil, fmt.Errorf("$text requires $search")
 	}
-	return Text{Search: search}, nil
+
+	clauses := ParseTextSearch(search) // all should
+	for _, r := range requireRaws {
+		clauses = appendTextClauses(clauses, r, TextMust)
+	}
+	for _, r := range excludeRaws {
+		clauses = appendTextClauses(clauses, r, TextMustNot)
+	}
+	return Text{Search: search, DefaultAnd: defaultAnd, Clauses: clauses}, nil
+}
+
+// ParseTextSearch splits a $text $search string into clauses. It is a purely
+// syntactic scan — no analysis/tokenization happens here (that is the FTS
+// executor's job, using the index's analyzer). Every clause it returns is a
+// should (OR) clause; required/excluded clauses come from the typed $require /
+// $exclude sub-fields instead (see parseText), not from inline string signs.
+//
+//   - "double quoted"  → a phrase clause (positional adjacency).
+//   - word*            → a prefix clause (vocabulary expansion).
+//   - word             → a plain term clause.
+//
+// Deliberately there is NO inline +/- boolean syntax. Parsing boolean intent out
+// of a raw human search string is a footgun for an embedded library whose common
+// use is "forward the end-user's search box straight into $search": a user typing
+// "-9" (meaning −9°C) or "+1" (a vote) would silently get an exclusion/require.
+// The same characters are harmless here — they are punctuation the analyzer drops
+// — so "-9" is just the term "9". Boolean require/exclude lives in the structured
+// $require / $exclude arrays, which are unambiguous and run through the same
+// analyzer. An app that wants single-box power-user syntax can parse it itself and
+// populate those fields. A trailing * is still honoured on bare words (prefix
+// expansion has negligible false-positive rate in natural text); it is left
+// literal inside a phrase, where positional expansion would be combinatorial.
+func ParseTextSearch(s string) []TextClause {
+	var clauses []TextClause
+	rs := []rune(s)
+	i, n := 0, len(rs)
+	for i < n {
+		for i < n && unicode.IsSpace(rs[i]) {
+			i++
+		}
+		if i >= n {
+			break
+		}
+		if rs[i] == '"' {
+			i++ // opening quote
+			start := i
+			for i < n && rs[i] != '"' {
+				i++
+			}
+			raw := strings.TrimSpace(string(rs[start:i]))
+			if i < n {
+				i++ // closing quote
+			}
+			if raw != "" {
+				clauses = append(clauses, TextClause{Raw: raw, Phrase: true, Op: TextShould})
+			}
+			continue
+		}
+		start := i
+		for i < n && !unicode.IsSpace(rs[i]) {
+			i++
+		}
+		word := string(rs[start:i])
+		prefix := false
+		if strings.HasSuffix(word, "*") {
+			prefix = true
+			word = strings.TrimRight(word, "*")
+		}
+		if word != "" {
+			clauses = append(clauses, TextClause{Raw: word, Prefix: prefix, Op: TextShould})
+		}
+	}
+	return clauses
+}
+
+// appendTextClauses parses raw with ParseTextSearch and appends its clauses to
+// dst with their boolean role forced to op (used for $require / $exclude entries,
+// which reuse the phrase/prefix syntax but fix the clause role by field).
+func appendTextClauses(dst []TextClause, raw string, op TextOp) []TextClause {
+	for _, c := range ParseTextSearch(raw) {
+		c.Op = op
+		dst = append(dst, c)
+	}
+	return dst
 }
 
 func parseSize(v *anyenc.Value) (Filter, error) {

--- a/query/filter.go
+++ b/query/filter.go
@@ -640,7 +640,58 @@ func (a All) String() string {
 // ($text only at the top level or inside $and, at most one per query) are also
 // enforced by the executor, not here. See docs/fts/DESIGN.md.
 type Text struct {
+	// Search is the raw $search string, preserved verbatim for String() and as
+	// the fallback source when Clauses is nil (a directly-constructed Text).
 	Search string
+	// DefaultAnd is set by {"$defaultOperator":"and"}: bare (should) terms then
+	// become required (AND) rather than the default OR.
+	DefaultAnd bool
+	// Clauses are the parsed clauses of the whole $text predicate: the should
+	// clauses from $search (phrases, prefix*, plain terms) plus the required and
+	// excluded clauses from the $require / $exclude sub-fields. Populated by
+	// ParseCondition; a Text built directly with only Search set has nil Clauses
+	// and the executor re-parses Search on demand (yielding should clauses only).
+	Clauses []TextClause
+}
+
+// TextOp classifies a $text clause's boolean role within the query.
+type TextOp uint8
+
+const (
+	// TextShould is a default clause: OR'd with the other should-clauses, unless
+	// the query sets DefaultAnd, in which case it is required.
+	TextShould TextOp = iota
+	// TextMust is a +term: always required (AND), regardless of DefaultAnd.
+	TextMust
+	// TextMustNot is a -term: documents containing it are excluded.
+	TextMustNot
+)
+
+// TextClause is one parsed unit of a $text $search string: a single term, a
+// quoted phrase, or a prefix term, together with its boolean role. The raw text
+// is NOT analyzed here — the query package stays free of the fts analyzer; the
+// FTS executor analyzes each clause with the index's own pipeline.
+type TextClause struct {
+	// Raw is the unanalyzed clause text: a single word, or the inner text of a
+	// "quoted phrase".
+	Raw string
+	// Phrase marks a "..." clause: Raw analyzes to an ordered term list matched
+	// by positional adjacency.
+	Phrase bool
+	// Prefix marks a trailing-* clause (foo*): Raw's single analyzed term is
+	// expanded against the vocabulary. Mutually exclusive with Phrase.
+	Prefix bool
+	// Op is the clause's boolean role.
+	Op TextOp
+}
+
+// ParsedClauses returns the parsed clauses, parsing Search on demand for a Text
+// that was constructed directly (Clauses nil) rather than via ParseCondition.
+func (t Text) ParsedClauses() []TextClause {
+	if t.Clauses != nil {
+		return t.Clauses
+	}
+	return ParseTextSearch(t.Search)
 }
 
 func (t Text) Ok(v *anyenc.Value, buf *syncpool.DocBuffer) bool {

--- a/query/text_search_test.go
+++ b/query/text_search_test.go
@@ -1,0 +1,101 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTextSearch(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []TextClause
+	}{
+		{"empty", "", nil},
+		{"spaces", "   \t ", nil},
+		{
+			"bare words (should)",
+			"east tokyo",
+			[]TextClause{{Raw: "east", Op: TextShould}, {Raw: "tokyo", Op: TextShould}},
+		},
+		{
+			// Inline +/- are NOT operators anymore — they are ordinary token text
+			// (the analyzer drops the punctuation later). No false detection.
+			"leading +/- are literal, not operators",
+			"+east -crash tokyo",
+			[]TextClause{
+				{Raw: "+east", Op: TextShould},
+				{Raw: "-crash", Op: TextShould},
+				{Raw: "tokyo", Op: TextShould},
+			},
+		},
+		{
+			"negative number is a plain should term",
+			"-9 degrees",
+			[]TextClause{{Raw: "-9", Op: TextShould}, {Raw: "degrees", Op: TextShould}},
+		},
+		{
+			"phrase",
+			`"east tokyo" crash`,
+			[]TextClause{
+				{Raw: "east tokyo", Phrase: true, Op: TextShould},
+				{Raw: "crash", Op: TextShould},
+			},
+		},
+		{
+			"prefix",
+			"pre* east",
+			[]TextClause{{Raw: "pre", Prefix: true, Op: TextShould}, {Raw: "east", Op: TextShould}},
+		},
+		{
+			"star inside phrase is literal (not a prefix clause)",
+			`"east tokyo*"`,
+			[]TextClause{{Raw: "east tokyo*", Phrase: true, Op: TextShould}},
+		},
+		{
+			"unterminated phrase consumes the rest",
+			`"east tokyo`,
+			[]TextClause{{Raw: "east tokyo", Phrase: true, Op: TextShould}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ParseTextSearch(tc.in))
+		})
+	}
+}
+
+func TestParseText_RequireExclude(t *testing.T) {
+	f := MustParseCondition(map[string]any{
+		"$text": map[string]any{
+			"$search":          "east tokyo",
+			"$defaultOperator": "and",
+			"$require":         []any{"critical", `"east side"`},
+			"$exclude":         "draft",
+		},
+	})
+	txt, ok := f.(Text)
+	require.True(t, ok)
+	assert.True(t, txt.DefaultAnd)
+	assert.Equal(t, []TextClause{
+		{Raw: "east", Op: TextShould},
+		{Raw: "tokyo", Op: TextShould},
+		{Raw: "critical", Op: TextMust},
+		{Raw: "east side", Phrase: true, Op: TextMust},
+		{Raw: "draft", Op: TextMustNot},
+	}, txt.Clauses)
+}
+
+func TestParseText_ExcludeArray(t *testing.T) {
+	f := MustParseCondition(map[string]any{
+		"$text": map[string]any{"$search": "x", "$exclude": []any{"a", "b*"}},
+	})
+	txt := f.(Text)
+	assert.Equal(t, []TextClause{
+		{Raw: "x", Op: TextShould},
+		{Raw: "a", Op: TextMustNot},
+		{Raw: "b", Prefix: true, Op: TextMustNot},
+	}, txt.Clauses)
+}


### PR DESCRIPTION
Extends `$text` full-text search beyond v1's bag-of-words OR, across four phases. See `docs/fts/FTS-V2-PLAN.md` for the full plan and decision record (outside-expert reviewed).

## What's in this PR

**Phase 0+1 — query operators (search-time only, no re-index)**
- `"phrases"` (positional zig-zag merge), `prefix*` (vocab expansion, top-50 by df), CJK runs as implicit phrases.
- Boolean require/exclude via **typed** `$require` / `$exclude` sub-fields (string or array) + `$defaultOperator:"and"` — deliberately **not** inline `+`/`-`, which is a footgun on raw user input (`-9` would silently exclude). Roles run through the same analyzer; require gates a per-doc `requiredMask`, exclude tombstones, in the existing single-pass accumulator.
- `ChunkIterator` interface decouples the phrase merge from the chunk byte layout.

**Phase 2 — configurable BM25** `b`/`k1` per index (`FulltextParams.B/K1`), persisted in a `fulltext` sub-object, resolved per query. Default params reproduce v1 scoring bit-for-bit.

**Phase 3 — per-field weights (BM25F)** — postings format **v2** (FieldMask + per-field TF before the global gapped positions). `FulltextParams.Weights` (Mongo-style, keyed by field name). Simplified BM25F (`Σ weight_f·tf_f` + global length-norm) that reduces **exactly** to classic BM25 at single-field/weight-1, so the change is confined to the postings blob (no docinfo/meta change). Old v1 data is rejected safely via the version byte (`ErrFtsFormatOutdated` → drop & recreate; alpha no-back-compat policy).

## Correctness
- Default/unweighted ranking is **bit-for-bit unchanged** — verified by the brute-force BM25 oracle in any-store-tests.
- New exact oracles added (in any-store-tests, not in this repo): match-set oracle for phrase/require/exclude/prefix (400 random mixed queries), custom-`b` BM25, and weighted BM25F.
- Full in-repo suite + external e2e suite green.

## Perf
- Pure-OR queries unchanged. Phrase term-stream reuses one `ChunkReader` across chunks (406→94 allocs/op). Weighted path ≈ unweighted (per-field loop is free).

Known follow-up (not in this PR): WAND/block-max top-k pruning to cut the high-df latency tail and improve concurrent scaling.