### PR TITLE
fix(tx): roll back and re-panic instead of leaking the write lock or committing a partial batch

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -470,8 +470,12 @@ func (c *collection) Insert(ctx context.Context, docs ...*anyenc.Value) (err err
 	// Inserts drive IVF-PQ centroid drift (they create no HNSW tombstones, so this
 	// is a no-op for the graph modes beyond a cheap enabled-check), so an insert can
 	// cross a vector index's auto-maintenance threshold just like an update/delete.
+	// returned is set once the write tx returns; err == nil alone would also hold
+	// while a panic unwinds, and compaction opens its own write tx — it must never
+	// run mid-panic. See doWriteTxW.
+	returned := false
 	defer func() {
-		if err == nil {
+		if returned && err == nil {
 			c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -494,6 +498,7 @@ func (c *collection) Insert(ctx context.Context, docs ...*anyenc.Value) (err err
 		}
 		return nil
 	})
+	returned = true
 	return
 }
 
@@ -534,8 +539,10 @@ func (c *collection) insertItem(tx *btree.WriteTx, buf *syncpool.DocBuffer, it i
 }
 
 func (c *collection) UpdateOne(ctx context.Context, doc *anyenc.Value) (err error) {
+	// See Insert: gated on a normal return, not on err == nil alone.
+	returned := false
 	defer func() {
-		if err == nil {
+		if returned && err == nil {
 			c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -547,17 +554,23 @@ func (c *collection) UpdateOne(ctx context.Context, doc *anyenc.Value) (err erro
 		return
 	}
 
-	return c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
+	err = c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
 		if txErr = c.alive(); txErr != nil {
 			return false, txErr
 		}
 		return c.update(tx, it, item{})
 	})
+	returned = true
+	return
 }
 
 func (c *collection) UpdateId(ctx context.Context, id any, mod query.Modifier) (res ModifyResult, err error) {
+	// mod.Modify (user code) runs inside the write tx below. A panic there unwinds
+	// through here with err still nil, so gate on a normal return: compaction opens
+	// its own write tx and must never run mid-panic. See Insert and doWriteTxW.
+	returned := false
 	defer func() {
-		if err == nil {
+		if returned && err == nil {
 			c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -567,7 +580,7 @@ func (c *collection) UpdateId(ctx context.Context, id any, mod query.Modifier) (
 	buf2 := c.db.syncPool.GetDocBuf()
 	defer c.db.syncPool.ReleaseDocBuf(buf2)
 
-	if err = c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
+	err = c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
 		if txErr = c.alive(); txErr != nil {
 			return false, txErr
 		}
@@ -592,15 +605,19 @@ func (c *collection) UpdateId(ctx context.Context, id any, mod query.Modifier) (
 			return false, vErr
 		}
 		return c.update(tx, newIt, it)
-	}); err != nil {
+	})
+	returned = true
+	if err != nil {
 		return ModifyResult{}, err
 	}
 	return
 }
 
 func (c *collection) UpsertId(ctx context.Context, id any, mod query.Modifier) (res ModifyResult, err error) {
+	// mod.Modify (user code) runs inside the write tx below; see UpdateId.
+	returned := false
 	defer func() {
-		if err == nil {
+		if returned && err == nil {
 			c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -610,7 +627,7 @@ func (c *collection) UpsertId(ctx context.Context, id any, mod query.Modifier) (
 	buf2 := c.db.syncPool.GetDocBuf()
 	defer c.db.syncPool.ReleaseDocBuf(buf2)
 
-	if err = c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
+	err = c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
 		if txErr = c.alive(); txErr != nil {
 			return false, txErr
 		}
@@ -663,7 +680,9 @@ func (c *collection) UpsertId(ctx context.Context, id any, mod query.Modifier) (
 			res.Matched = 1
 			return c.update(tx, newIt, prevItem)
 		}
-	}); err != nil {
+	})
+	returned = true
+	if err != nil {
 		return ModifyResult{}, err
 	}
 	return
@@ -741,8 +760,10 @@ func (c *collection) loadById(tx *btree.WriteTx, buf *syncpool.DocBuffer, id any
 }
 
 func (c *collection) UpsertOne(ctx context.Context, doc *anyenc.Value) (err error) {
+	// See Insert: gated on a normal return, not on err == nil alone.
+	returned := false
 	defer func() {
-		if err == nil {
+		if returned && err == nil {
 			c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -767,19 +788,22 @@ func (c *collection) UpsertOne(ctx context.Context, doc *anyenc.Value) (err erro
 		}
 		return true, nil
 	})
+	returned = true
 	return err
 }
 
 func (c *collection) DeleteId(ctx context.Context, id any) (err error) {
+	// See Insert: gated on a normal return, not on err == nil alone.
+	returned := false
 	defer func() {
-		if err == nil {
+		if returned && err == nil {
 			c.maybeAutoCompactVectors(ctx)
 		}
 	}()
 	buf := c.db.syncPool.GetDocBuf()
 	defer c.db.syncPool.ReleaseDocBuf(buf)
 
-	return c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
+	err = c.db.doWriteTxModified(ctx, func(tx *btree.WriteTx) (modified bool, txErr error) {
 		if txErr = c.alive(); txErr != nil {
 			return false, txErr
 		}
@@ -791,6 +815,8 @@ func (c *collection) DeleteId(ctx context.Context, id any) (err error) {
 		}
 		return true, c.deleteItem(tx, buf, buf.SmallBuf)
 	})
+	returned = true
+	return err
 }
 
 func (c *collection) deleteItem(tx *btree.WriteTx, buf *syncpool.DocBuffer, id []byte) (err error) {
@@ -1311,6 +1337,12 @@ func (c *collection) Rename(ctx context.Context, newName string) error {
 	})
 }
 
+// Drop runs through doWriteTx — the variant that registers no undo — yet its
+// callback calls c.close(), evicting the handle from db.openedCollections. A
+// rollback (an error, or now a panic: see doWriteTxW) therefore restores the
+// on-disk collection while this handle stays closed; callers re-obtain it via
+// db.Collection, which heals the divergence because the map entry is gone.
+// Pre-existing on the error path; tracked separately.
 func (c *collection) Drop(ctx context.Context) error {
 	return c.db.doWriteTx(ctx, func(tx *btree.WriteTx) (err error) {
 		c.mu.Lock()

--- a/db.go
+++ b/db.go
@@ -1004,10 +1004,35 @@ func (db *db) doWriteTxW(ctx context.Context, do func(wtx WriteTx, tx *btree.Wri
 	if err != nil {
 		return err
 	}
+	// User code runs inside this tx (a query.Modifier, a DDL callback). A panic
+	// must not escape holding the btree write lock: BeginWrite has no ctx-cancel
+	// escape, so every later write — and Close() — would block forever. Roll back
+	// to release the lock, then re-panic so the caller still sees their bug.
+	//
+	// Deliberately not armed across Commit: both commit layers mark themselves
+	// done before doing any work (writeTx.Commit consumes the version CAS on
+	// entry and pools the commonTx; btree.WriteTx.Commit sets closed before
+	// pager.commit), so a rollback once commit has begun is a silent no-op on an
+	// already-recycled tx. A commit-time panic still leaks the lock — that needs
+	// the release moved into a defer inside btree.WriteTx.Commit; see BUG-14.
+	//
+	// The rollback runs the undo log, whose closures take c.mu / db.mu: a
+	// callback must not panic while holding either with an explicit (non-defer)
+	// unlock, or the unwind deadlocks here.
+	committing := false
+	defer func() {
+		if r := recover(); r != nil {
+			if !committing {
+				_ = tx.Rollback()
+			}
+			panic(r)
+		}
+	}()
 	if err = do(tx, tx.btreeWriteTx()); err != nil {
 		return errors.Join(err, tx.Rollback())
 	}
 	tx.SetModified()
+	committing = true
 	return tx.Commit()
 }
 
@@ -1018,6 +1043,18 @@ func (db *db) doWriteTxModifiedW(ctx context.Context, do func(wtx WriteTx, tx *b
 	if err != nil {
 		return err
 	}
+	// Rollback-on-panic; see doWriteTxW for why the guard stops at Commit. This
+	// is the single-doc modifier path (UpdateId/UpsertId call mod.Modify inside
+	// the callback), the one BUG-34 reported as wedging the DB.
+	committing := false
+	defer func() {
+		if r := recover(); r != nil {
+			if !committing {
+				_ = tx.Rollback()
+			}
+			panic(r)
+		}
+	}()
 	var modified bool
 	if modified, err = do(tx, tx.btreeWriteTx()); err != nil {
 		return errors.Join(err, tx.Rollback())
@@ -1025,6 +1062,7 @@ func (db *db) doWriteTxModifiedW(ctx context.Context, do func(wtx WriteTx, tx *b
 	if modified {
 		tx.SetModified()
 	}
+	committing = true
 	return tx.Commit()
 }
 
@@ -1058,10 +1096,25 @@ func (db *db) doReadTx(ctx context.Context, do func(tx *btree.ReadTx) error) err
 	if err != nil {
 		return err
 	}
+	// Rollback-on-panic, read side: Commit is a read tx's release path
+	// (readTx.Commit rolls back the underlying btree tx) — ReadTx has no
+	// Rollback. Left unreleased, a panic strands the reader-sem slot and
+	// db.mu.RLock; after MaxReaders of them every read blocks and Close() hangs.
+	// See doWriteTxW.
+	committing := false
+	defer func() {
+		if r := recover(); r != nil {
+			if !committing {
+				_ = tx.Commit()
+			}
+			panic(r)
+		}
+	}()
 	if err = do(tx.btreeReadTx()); err != nil {
 		_ = tx.Commit()
 		return err
 	}
+	committing = true
 	return tx.Commit()
 }
 

--- a/query.go
+++ b/query.go
@@ -281,8 +281,12 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	// Reclaim tombstones this bulk update creates once it commits, mirroring the
 	// single-doc mutators. Registered before the commit defer so it runs after
 	// commit; no-ops inside a caller-managed tx (the guard in maybeAutoCompactVectors).
+	// Gated on an explicit commit, not on err == nil: err is still nil while a
+	// panic unwinds, and compaction opens its own write tx — it must never run
+	// on a failed operation, let alone mid-panic.
+	committed := false
 	defer func() {
-		if err == nil {
+		if committed {
 			q.c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -292,10 +296,19 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 		return
 	}
 	defer func() {
+		// A panic (a user modifier's bug) leaves err == nil, so keying the commit
+		// on err alone would durably persist the documents modified before it — a
+		// torn bulk update. Roll back, then re-panic.
+		if r := recover(); r != nil {
+			_ = tx.Rollback()
+			panic(r)
+		}
 		if err != nil {
 			_ = tx.Rollback()
-		} else {
-			err = tx.Commit()
+			return
+		}
+		if err = tx.Commit(); err == nil {
+			committed = true
 		}
 	}()
 
@@ -336,6 +349,21 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 		})
 	}
 
+	// Close-once: the plan must be closed before the write loop below (see the
+	// cursor-invalidation note), but a panic in a user Filter inside Next() would
+	// skip that call and strand the cursors' pinned pages. The deferred call
+	// covers the panic and error paths; Plan.Close is not idempotent, hence the
+	// flag. Registered after the tx finalizer so LIFO releases the cursors while
+	// the tx is still live.
+	planClosed := false
+	closePlan := func() {
+		if !planClosed {
+			planClosed = true
+			plan.Close()
+		}
+	}
+	defer closePlan()
+
 	// Collect all matching docIds into a contiguous buffer to avoid
 	// per-ID allocations and cursor invalidation during updates. Dedup
 	// multi-key entries so an UpdateMany over an array-indexed $in
@@ -346,7 +374,6 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	for {
 		_, docId, mk, iterErr := plan.Root.Next()
 		if iterErr != nil {
-			plan.Close()
 			err = iterErr
 			return
 		}
@@ -359,7 +386,7 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 		idOffsets = append(idOffsets, uint32(len(idBuf)))
 		idBuf = append(idBuf, docId...)
 	}
-	plan.Close()
+	closePlan()
 
 	// Build slice references into the contiguous buffer.
 	idsToUpdate := make([][]byte, len(idOffsets))
@@ -439,8 +466,12 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	// Reclaim tombstones this bulk delete creates once it commits, mirroring the
 	// single-doc mutators. Registered before the commit defer so it runs after
 	// commit; no-ops inside a caller-managed tx (the guard in maybeAutoCompactVectors).
+	// Gated on an explicit commit, not on err == nil: err is still nil while a
+	// panic unwinds, and compaction opens its own write tx — it must never run
+	// on a failed operation, let alone mid-panic.
+	committed := false
 	defer func() {
-		if err == nil {
+		if committed {
 			q.c.maybeAutoCompactVectors(ctx)
 		}
 	}()
@@ -450,10 +481,19 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 		return
 	}
 	defer func() {
+		// A panic in user filter code leaves err == nil, so keying the commit on
+		// err alone would durably persist the documents deleted before it — a torn
+		// bulk delete. Roll back, then re-panic.
+		if r := recover(); r != nil {
+			_ = tx.Rollback()
+			panic(r)
+		}
 		if err != nil {
 			_ = tx.Rollback()
-		} else {
-			err = tx.Commit()
+			return
+		}
+		if err = tx.Commit(); err == nil {
+			committed = true
 		}
 	}()
 
@@ -494,6 +534,18 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 		})
 	}
 
+	// Close-once: the plan must be closed before the delete loop below, but a
+	// panic in a user Filter inside Next() would skip that call and strand the
+	// cursors' pinned pages. See the matching comment in Update.
+	planClosed := false
+	closePlan := func() {
+		if !planClosed {
+			planClosed = true
+			plan.Close()
+		}
+	}
+	defer closePlan()
+
 	// Collect IDs to delete into a contiguous buffer (can't modify while iterating).
 	// Dedup multi-key entries so a doc matched on multiple array values
 	// isn't deleted twice / counted twice in the affected count.
@@ -503,7 +555,6 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	for {
 		_, docId, mk, iterErr := plan.Root.Next()
 		if iterErr != nil {
-			plan.Close()
 			err = iterErr
 			return
 		}
@@ -516,7 +567,7 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 		idOffsets = append(idOffsets, uint32(len(idBuf)))
 		idBuf = append(idBuf, docId...)
 	}
-	plan.Close()
+	closePlan()
 
 	// Build slice references into the contiguous buffer.
 	idsToDelete := make([][]byte, len(idOffsets))

--- a/tx_panic_test.go
+++ b/tx_panic_test.go
@@ -1,0 +1,264 @@
+package anystore
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/query"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// BUG-34: user code (a query.Modifier, a query.Filter) runs inside the write tx.
+// A panic there used to escape without a Rollback, leaking the btree write lock
+// — BeginWrite has no ctx-cancel escape, so every later write, and Close(),
+// blocked forever. The bulk paths were worse: their finalizer committed when
+// `err == nil`, which is exactly the state during a panic, durably persisting
+// the subset modified before it. A panic must roll back and re-panic.
+
+const panicMsg = "user bug in modifier"
+
+// panicModifier panics on the nth call to Modify (1-indexed), marking every
+// document it touches before that so a partial commit is observable.
+type panicModifier struct {
+	n     int
+	calls int
+}
+
+func (m *panicModifier) Modify(a *anyenc.Arena, v *anyenc.Value) (*anyenc.Value, bool, error) {
+	m.calls++
+	if m.calls >= m.n {
+		panic(panicMsg)
+	}
+	v.Set("touched", a.NewNumberInt(1))
+	return v, true, nil
+}
+
+// panicFilter panics on the nth call to Ok — the user-code panic surface on the
+// read/scan side (plan.Root.Next evaluates it).
+type panicFilter struct {
+	n     int
+	calls int
+}
+
+func (f *panicFilter) Ok(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	f.calls++
+	if f.calls >= f.n {
+		panic(panicMsg)
+	}
+	return true
+}
+
+func (f *panicFilter) IndexBounds(_ string, bs query.Bounds) query.Bounds { return bs }
+func (f *panicFilter) String() string                                     { return "panicFilter" }
+
+func openPanicDB(t *testing.T, dir string) DB {
+	db, err := Open(context.Background(), filepath.Join(dir, "store.db"), nil)
+	require.NoError(t, err)
+	return db
+}
+
+func fillDocs(t *testing.T, coll Collection, n int) {
+	t.Helper()
+	for i := 1; i <= n; i++ {
+		require.NoError(t, coll.Insert(context.Background(),
+			anyenc.MustParseJson(fmt.Sprintf(`{"id":%d,"grp":"x"}`, i))))
+	}
+}
+
+// requireNotWedged asserts the write lock was released: a write, and then
+// Close(), must both complete instead of blocking forever.
+func requireNotWedged(t *testing.T, db DB, coll Collection) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- coll.Insert(context.Background(), anyenc.MustParseJson(`{"id":9999}`))
+	}()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("DB is wedged: a write after the panic blocked — the write lock leaked")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- db.Close() }()
+	select {
+	case err := <-closed:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("db.Close() hangs after the panic — the write lock leaked")
+	}
+}
+
+// (a) single-doc modifier panic must not leak the write lock (doWriteTxModifiedW).
+func TestTxPanic_UpdateIdDoesNotWedgeDB(t *testing.T) {
+	ctx := context.Background()
+	db := openPanicDB(t, t.TempDir())
+
+	coll, err := db.Collection(ctx, "c")
+	require.NoError(t, err)
+	require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(`{"id":1,"v":1}`)))
+
+	assert.PanicsWithValue(t, panicMsg, func() {
+		_, _ = coll.UpdateId(ctx, 1, &panicModifier{n: 1})
+	})
+
+	// The rolled-back tx must have left the document untouched.
+	doc, err := coll.FindId(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, `{"id":1,"v":1}`, doc.Value().String())
+
+	requireNotWedged(t, db, coll)
+}
+
+func TestTxPanic_UpsertIdDoesNotWedgeDB(t *testing.T) {
+	ctx := context.Background()
+	db := openPanicDB(t, t.TempDir())
+
+	coll, err := db.Collection(ctx, "c")
+	require.NoError(t, err)
+
+	assert.PanicsWithValue(t, panicMsg, func() {
+		_, _ = coll.UpsertId(ctx, 1, &panicModifier{n: 1})
+	})
+
+	requireNotWedged(t, db, coll)
+}
+
+// (b) a modifier that panics mid-batch must not commit the already-modified
+// subset — the bulk finalizer used to take the commit branch because err == nil.
+func TestTxPanic_BulkUpdateIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db := openPanicDB(t, dir)
+
+	coll, err := db.Collection(ctx, "c")
+	require.NoError(t, err)
+	fillDocs(t, coll, 10)
+
+	// Panics on the 5th matched doc, after modifying 4.
+	assert.PanicsWithValue(t, panicMsg, func() {
+		_, _ = coll.Find(query.MustParseCondition(`{"grp":"x"}`)).Update(ctx, &panicModifier{n: 5})
+	})
+
+	touched, err := coll.Find(query.MustParseCondition(`{"touched":1}`)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, touched, "partial bulk update was committed")
+
+	require.NoError(t, db.Close())
+
+	// It must not have survived a reopen either.
+	db2 := openPanicDB(t, dir)
+	defer func() { _ = db2.Close() }()
+	coll2, err := db2.Collection(ctx, "c")
+	require.NoError(t, err)
+	touched, err = coll2.Find(query.MustParseCondition(`{"touched":1}`)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, touched, "partial bulk update survived restart")
+}
+
+// A filter that panics mid-scan must not commit the documents already deleted.
+func TestTxPanic_BulkDeleteIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	db := openPanicDB(t, t.TempDir())
+
+	coll, err := db.Collection(ctx, "c")
+	require.NoError(t, err)
+	fillDocs(t, coll, 10)
+
+	assert.PanicsWithValue(t, panicMsg, func() {
+		_, _ = coll.Find(&panicFilter{n: 5}).Delete(ctx)
+	})
+
+	count, err := coll.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 10, count, "partial bulk delete was committed")
+
+	requireNotWedged(t, db, coll)
+}
+
+// The read path: a panicking filter inside Count runs under doReadTx, which must
+// release the read tx. Left stranded, MaxReaders of these block every read and
+// hang Close().
+func TestTxPanic_ReadTxIsReleased(t *testing.T) {
+	ctx := context.Background()
+	db := openPanicDB(t, t.TempDir())
+
+	coll, err := db.Collection(ctx, "c")
+	require.NoError(t, err)
+	fillDocs(t, coll, 5)
+
+	for i := 0; i < 24; i++ {
+		assert.PanicsWithValue(t, panicMsg, func() {
+			_, _ = coll.Find(&panicFilter{n: 1}).Count(ctx)
+		})
+	}
+
+	// Reads must still work — the reader slots were not leaked.
+	done := make(chan error, 1)
+	go func() {
+		_, cErr := coll.Count(ctx)
+		done <- cErr
+	}()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("reads are blocked: the read tx leaked on the panic path")
+	}
+
+	requireNotWedged(t, db, coll)
+}
+
+// Inside a caller-managed tx the wrappers operate on a savepoint, so a panic must
+// roll back only that savepoint — discarding the documents the modifier touched
+// before it panicked — and leave the consumer's tx usable. The consumer still
+// owns the outer rollback.
+func TestTxPanic_NestedTxRollsBackOnlySavepoint(t *testing.T) {
+	ctx := context.Background()
+	db := openPanicDB(t, t.TempDir())
+
+	coll, err := db.Collection(ctx, "c")
+	require.NoError(t, err)
+	fillDocs(t, coll, 10)
+
+	tx, err := db.WriteTx(ctx)
+	require.NoError(t, err)
+
+	// A write made inside the consumer's tx, before the panicking one.
+	require.NoError(t, coll.Insert(tx.Context(), anyenc.MustParseJson(`{"id":99,"grp":"y"}`)))
+
+	// Panics on the 5th matched doc, after the modifier already touched 4 inside
+	// the savepoint's scope.
+	assert.PanicsWithValue(t, panicMsg, func() {
+		_, _ = coll.Find(query.MustParseCondition(`{"grp":"x"}`)).
+			Update(tx.Context(), &panicModifier{n: 5})
+	})
+
+	// Rolled back to the savepoint: none of the 4 touched docs survive...
+	touched, err := coll.Find(query.MustParseCondition(`{"touched":1}`)).Count(tx.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, touched, "savepoint rollback did not discard the partial update")
+
+	// ...but the consumer's own earlier write is intact, and its tx still commits.
+	count, err := coll.Find(query.MustParseCondition(`{"id":99}`)).Count(tx.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "the savepoint rollback aborted the consumer's tx")
+	require.NoError(t, tx.Commit())
+
+	touched, err = coll.Find(query.MustParseCondition(`{"touched":1}`)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, touched, "partial update committed with the consumer's tx")
+	count, err = coll.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 11, count)
+
+	requireNotWedged(t, db, coll)
+}


### PR DESCRIPTION
Fixes **BUG-34**. User code — a `query.Modifier`, a `query.Filter` — runs *inside* the write transaction, but the tx plumbing had no panic guard. An ordinary user bug in a modifier had two consequences:

- **Deadlock.** On `UpdateId`/`UpsertId` the panic escaped `doWriteTxModifiedW` without a `Rollback`, so the btree write lock stayed held. `BeginWrite` has no ctx-cancel escape, so every later write blocked forever — and `Close()` with them. One modifier bug wedged the DB permanently, even for a caller that recovered the panic.
- **Torn bulk update.** `Find().Update`'s finalizer committed whenever `err == nil` — which is exactly the state during a panic — durably persisting the documents modified before it. A half-applied batch that survived restart.

## What changed

**Panic guards on the auto-tx wrappers** (`doWriteTxW`, `doWriteTxModifiedW`, `doReadTx`): recover → release → re-panic, so the lock is freed and the caller still sees their bug. `doWriteTx`/`doWriteTxModified` delegate to the `W` variants, so two guards cover all four.

**The bulk `Update`/`Delete` finalizers** now commit on an explicit success flag rather than `err == nil`, and close their plan exactly once — before the write loop as before, but now also on the panic path, so the cursors' pinned pages are not stranded.

**The eight `maybeAutoCompactVectors` defers** are gated on a normal return too. This one is not cosmetic: `err == nil` also holds while a panic unwinds, and compaction opens *its own* write tx. It is harmless today only because the leaked lock blocks it — once the rollback above frees that lock, it would have run a real compaction transaction mid-panic, and a panic inside it (`vector: dimension mismatch` is reachable) would have replaced the user's original panic value. Fixing only the tx wrappers would have been strictly worse than the bug.

Inside a caller-managed tx the wrappers operate on a savepoint, so a panic rolls back only that scope and leaves the consumer's tx usable — the consumer still owns the outer rollback.

## Two notes for the reviewer

`doReadTx` releases with **`Commit`, not `Rollback`** — `ReadTx` has no `Rollback`; `readTx.Commit` is what rolls back the underlying btree tx. (The fix sketch in the bug doc said `Rollback` there; it does not compile.)

The guards deliberately **stop at `Commit`**. Both commit layers mark themselves done *before* doing any work — `writeTx.Commit` consumes its version CAS on entry and pools the `commonTx`, and `btree.WriteTx.Commit` sets `closed = true` before `pager.commit`. A guard armed across `Commit` would hit a failed CAS on a commit-time panic, return nil, and never release the lock: green tests, identical wedge. **A panic inside `Commit` still leaks the lock** — that needs the `writerLocksDone` release moved into a `defer` inside `btree.WriteTx.Commit`, which is BUG-14's territory and is tracked there.

## Tests

`tx_panic_test.go`. Five of the six fail or hang without this change:

| Test | Without the fix |
|---|---|
| `TestTxPanic_UpdateIdDoesNotWedgeDB` | wedges — a write after the panic blocks, `Close()` hangs |
| `TestTxPanic_UpsertIdDoesNotWedgeDB` | wedges |
| `TestTxPanic_BulkUpdateIsAtomic` | commits 4 of 10 docs; they survive a reopen |
| `TestTxPanic_NestedTxRollsBackOnlySavepoint` | the savepoint's partial update commits with the consumer's tx |
| `TestTxPanic_ReadTxIsReleased` | 24 panicking `Count`s strand every reader slot; hangs |
| `TestTxPanic_BulkDeleteIsAtomic` | *passes* — a regression guard, not a reproducer: no user code runs after the deletes begin, so the panic lands during the scan with nothing yet written |

Full suite green, plus `-race` on the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015c13BQ3FKnjeqHJTeqS7iY