### PR TITLE
query: typed sentinel for unknown filter operator

### DIFF
--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -169,7 +169,7 @@ func parseAnd(val *anyenc.Value) (res Filter, err error) {
 		}
 		if isOp {
 			if !isTopLevel(op) {
-				err = fmt.Errorf("unknow top level operator: %s", string(key))
+				err = fmt.Errorf("operator %s is not valid at the top level", string(key))
 				return
 			}
 
@@ -556,7 +556,7 @@ func isOperator(key []byte) (ok bool, op Operator, err error) {
 		case bytes.Equal(key, opBytesText):
 			return true, opText, nil
 		default:
-			return true, 0, fmt.Errorf("unknow operator: %s", string(key))
+			return true, 0, &UnknownOperatorError{Op: string(key)}
 		}
 	}
 	return false, 0, nil

--- a/query/cond_parse_test.go
+++ b/query/cond_parse_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,6 +182,39 @@ func TestParseCondition(t *testing.T) {
 			assert.Nil(t, f, i)
 		}
 	})
+}
+
+// TestUnknownOperator pins the unknown-operator contract: an operator outside
+// the grammar is reported as ErrUnknownOperator and names the operator it
+// choked on, so a caller parsing an untrusted filter can answer with a
+// bad-request that says which token was wrong.
+func TestUnknownOperator(t *testing.T) {
+	for _, q := range []string{
+		`{"tags": {"$contains": "x"}}`,
+		`{"$contains": "x"}`,
+		`{"$and": [{"a": {"$contains": 1}}]}`,
+		`{"a": {"$not": {"$contains": 1}}}`,
+	} {
+		f, err := ParseCondition(fastjson.MustParse(q))
+		require.Error(t, err, q)
+		assert.Nil(t, f, q)
+
+		assert.True(t, errors.Is(err, ErrUnknownOperator), q)
+
+		var uoe *UnknownOperatorError
+		require.True(t, errors.As(err, &uoe), q)
+		assert.Equal(t, "$contains", uoe.Op, q)
+	}
+}
+
+// A known operator in a position that does not accept it is a distinct fault
+// from an unrecognized one, and must not be reported as ErrUnknownOperator.
+func TestOperatorNotValidAtTopLevel(t *testing.T) {
+	f, err := ParseCondition(fastjson.MustParse(`{"$eq": 1}`))
+	require.Error(t, err)
+	assert.Nil(t, f)
+	assert.False(t, errors.Is(err, ErrUnknownOperator))
+	assert.Contains(t, err.Error(), "not valid at the top level")
 }
 
 func BenchmarkParseCondition(b *testing.B) {

--- a/query/errors.go
+++ b/query/errors.go
@@ -1,0 +1,27 @@
+package query
+
+import "errors"
+
+// ErrUnknownOperator is returned when a filter names an operator that is not
+// part of the grammar, e.g. {"tags": {"$contains": "x"}}. It is a client fault:
+// callers parsing untrusted filters can errors.Is it to answer with a bad-request
+// rather than an internal error.
+//
+// Use errors.As with *UnknownOperatorError to recover the offending operator and
+// name it back to the caller.
+var ErrUnknownOperator = errors.New("unknown operator")
+
+// UnknownOperatorError carries the operator that was not recognized. It wraps
+// ErrUnknownOperator, so errors.Is(err, ErrUnknownOperator) reports true.
+type UnknownOperatorError struct {
+	// Op is the unrecognized operator, including the leading '$'.
+	Op string
+}
+
+func (e *UnknownOperatorError) Error() string {
+	return "unknown operator: " + e.Op
+}
+
+func (e *UnknownOperatorError) Unwrap() error {
+	return ErrUnknownOperator
+}


### PR DESCRIPTION
Closes SYN-79. Unblocks SYN-80.

An unrecognized filter operator (`{"tags": {"$contains": "x"}}`) was reported as a bare `fmt.Errorf("unknow operator: %s")`. Downstream, `any` maps it to `500 internal` — a client-caused fault answered as a server fault — because it has no way to classify it short of matching the message text.

## Changes

- **`ErrUnknownOperator` + `UnknownOperatorError{Op}`** (new `query/errors.go`, the package's first sentinel). `errors.Is` classifies; `errors.As` recovers the offending operator so a caller can name the bad token back to the client. Propagates through `$and` / `$or` / `$not` nesting — pinned by test.
- **Typo:** `unknow` → `unknown`, via the sentinel's message.
- **Reworded the top-level operator error.** At that point `isOperator` has already recognized the key, so the branch fires for a *known* operator in a position that doesn't accept it (`{"$eq": 1}` at root), never for an unknown one — `unknow top level operator` named the wrong fault. Left as a plain error and pinned as **not** `ErrUnknownOperator`, since it's a distinct fault.

## Notes for the reviewer

- Only the v2 module (this branch). `any` also pins `any-store@v0.4.7`, which carries the same typo at `query/cond_parse.go:496` — but v2 is what serves the live `/query` path. Happy to send a separate PR against `main` if you want v1 aligned.
- Considered and left out: exporting the supported-operator list. `any` currently hardcodes it, and SYN-78 showed that list already drifting (its copy omits `$text`). An exported `SupportedOperators()` would kill that drift class, but it's new API surface — say the word and I'll add it here.

`go test ./query/` green, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)