### PR TITLE
fix(query,qplanner): verbs select the same documents — sorter on writes, stale filter cache, overlapping and misordered bounds

### DIFF
--- a/db.go
+++ b/db.go
@@ -1220,12 +1220,31 @@ func (db *db) persistAllDirtySketches(tx *btree.WriteTx) error {
 	return nil
 }
 
-// flushAllFtsPending flushes every open collection's full-text write-back buffer
-// into the B-tree. Called once per write-tx commit, BEFORE the btree commit, so
-// the buffered postings land in the SAME atomic transaction as the document
-// writes — preserving strong cross-process consistency (another process opening
-// a read tx after commit sees a complete, consistent index; a crash leaves no
-// doc without its postings). The buffer never survives the commit boundary.
+// flushAmbientFtsPending flushes buffered full-text postings into the write
+// tx carried by ctx, if any — so a $text READ inside that tx sees the tx's
+// own uncommitted writes, matching the flush newSavepointTx already performs
+// for the write verbs. A no-op outside an ambient write tx: nothing is
+// buffered at the start of a fresh write tx (resetAllFtsPending), and a
+// read-only ambient tx cannot have buffered anything.
+func (db *db) flushAmbientFtsPending(ctx context.Context) error {
+	ctxTx := ctx.Value(ctxKeyTx)
+	if ctxTx == nil {
+		return nil
+	}
+	wtx, ok := ctxTx.(WriteTx)
+	if !ok || wtx.Done() || wtx.instanceId() != db.instanceId {
+		return nil
+	}
+	return db.flushAllFtsPending(wtx.btreeWriteTx())
+}
+
+// flushAllFtsPending flushes every open collection's full-text write-back
+// buffer into the B-tree. Called once per write-tx commit, BEFORE the btree
+// commit, so the buffered postings land in the SAME atomic transaction as the
+// document writes — preserving strong cross-process consistency (another
+// process opening a read tx after commit sees a complete, consistent index; a
+// crash leaves no doc without its postings). The buffer never survives the
+// commit boundary.
 func (db *db) flushAllFtsPending(tx *btree.WriteTx) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()

--- a/db.go
+++ b/db.go
@@ -1226,16 +1226,30 @@ func (db *db) persistAllDirtySketches(tx *btree.WriteTx) error {
 // for the write verbs. A no-op outside an ambient write tx: nothing is
 // buffered at the start of a fresh write tx (resetAllFtsPending), and a
 // read-only ambient tx cannot have buffered anything.
+// Caveat (documented, same class as iterate-while-mutate being undefined):
+// the flush WRITES into the ambient tx, so a $text read performed while an
+// iterator on the same tx is mid-iteration restructures pages under that
+// iterator's cursors — collect results before issuing in-tx $text reads.
 func (db *db) flushAmbientFtsPending(ctx context.Context) error {
-	ctxTx := ctx.Value(ctxKeyTx)
-	if ctxTx == nil {
-		return nil
-	}
-	wtx, ok := ctxTx.(WriteTx)
-	if !ok || wtx.Done() || wtx.instanceId() != db.instanceId {
+	wtx, ok := db.ambientWriteTx(ctx)
+	if !ok {
 		return nil
 	}
 	return db.flushAllFtsPending(wtx.btreeWriteTx())
+}
+
+// ambientWriteTx extracts a usable write tx carried by ctx: present, not
+// done, and belonging to this db instance.
+func (db *db) ambientWriteTx(ctx context.Context) (WriteTx, bool) {
+	ctxTx := ctx.Value(ctxKeyTx)
+	if ctxTx == nil {
+		return nil, false
+	}
+	wtx, ok := ctxTx.(WriteTx)
+	if !ok || wtx.Done() || wtx.instanceId() != db.instanceId {
+		return nil, false
+	}
+	return wtx, true
 }
 
 // flushAllFtsPending flushes every open collection's full-text write-back

--- a/fulltext_query_ops_test.go
+++ b/fulltext_query_ops_test.go
@@ -214,3 +214,28 @@ func TestFtsPhrase_NoMatchAcrossArrayElements(t *testing.T) {
 	ids, _ = collectIter(t, coll.Find(`{"$text":{"$search":"\"aaa bbb\""}}`))
 	assert.Equal(t, []string{"d1"}, ids)
 }
+
+// Count must denote the same document set as Iter on the identical $text
+// query — including under Limit/Offset and with a residual predicate. Count
+// compiles a native FTS plan (no score sidecar, no public iterator); these
+// pin that it cannot drift from the read path.
+func TestFtsCount_MatchesIterAcrossWindows(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+
+	for name, q := range map[string]func() Query{
+		"plain":         func() Query { return coll.Find(`{"$text":{"$search":"tokyo"}}`) },
+		"limit":         func() Query { return coll.Find(`{"$text":{"$search":"tokyo"}}`).Limit(1) },
+		"offset":        func() Query { return coll.Find(`{"$text":{"$search":"tokyo"}}`).Offset(1) },
+		"limit_offset":  func() Query { return coll.Find(`{"$text":{"$search":"tokyo"}}`).Limit(2).Offset(1) },
+		"residual":      func() Query { return coll.Find(`{"$text":{"$search":"tokyo"},"id":{"$in":["a","d"]}}`) },
+		"match_nothing": func() Query { return coll.Find(`{"$text":{"$search":"zzznope"}}`) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			ids, _ := collectIter(t, q())
+			count, err := q().Count(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, len(ids), count, "Count and Iter must agree; iter=%v", ids)
+		})
+	}
+}

--- a/fulltext_query_ops_test.go
+++ b/fulltext_query_ops_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
 )
 
 // These tests exercise the Phase 1 query operators added on top of the v1
@@ -238,4 +240,47 @@ func TestFtsCount_MatchesIterAcrossWindows(t *testing.T) {
 			assert.Equal(t, len(ids), count, "Count and Iter must agree; iter=%v", ids)
 		})
 	}
+}
+
+
+// $text inside an open write tx must see the tx's own uncommitted full-text
+// writes — the same view on every verb — and a rollback must discard them.
+// Previously Count/Iter matched against stale committed postings while
+// Update/Delete (whose savepoint path flushes the pending buffer) matched
+// current ones: one predicate, contradictory answers within one tx.
+func TestFtsReadYourWrites_InsideWriteTx(t *testing.T) {
+	fx, coll := ftsOpsColl(t)
+	defer fx.finish()
+	const q = `{"$text":{"$search":"zanzibar"}}`
+
+	tx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.Insert(tx.Context(), anyenc.MustParseJson(`{"id":"z1","body":"zanzibar ferry"}`)))
+
+	// In-tx Iter sees the tx's own write.
+	iter, err := coll.Find(q).Iter(tx.Context())
+	require.NoError(t, err)
+	var ids []string
+	for iter.Next() {
+		doc, derr := iter.Doc()
+		require.NoError(t, derr)
+		ids = append(ids, doc.Value().GetString("id"))
+	}
+	require.NoError(t, iter.Err())
+	require.NoError(t, iter.Close())
+	assert.Equal(t, []string{"z1"}, ids, "in-tx $text Iter must see the tx's own write")
+
+	// In-tx Count agrees with in-tx Iter.
+	count, err := coll.Find(q).Count(tx.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "in-tx $text Count must agree with Iter")
+
+	require.NoError(t, tx.Rollback())
+
+	// Rollback discards the pending postings entirely.
+	after, _ := collectIter(t, coll.Find(q))
+	assert.Empty(t, after, "rollback must discard the pending postings")
+	count, err = coll.Find(q).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count)
 }

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -12,7 +12,6 @@ import (
 	"github.com/anyproto/any-store/v2/internal/fts"
 	"github.com/anyproto/any-store/v2/internal/qplanner"
 	"github.com/anyproto/any-store/v2/query"
-	"github.com/anyproto/any-store/v2/syncpool"
 )
 
 // fulltext_search.go implements the read/query side: BM25 ranking over the
@@ -954,7 +953,7 @@ func (q *collQuery) detectFtsQuery() (*qplanner.FtsQuerySpec, query.Filter, erro
 	fx := fxs[0]
 	spec := &qplanner.FtsQuerySpec{
 		Ordered:    true, // searchCandidates returns score-descending
-		NeedScores: true, // cleared by ftsScanPlan for Count/Update/Delete
+		NeedScores: true, // compilePlan sets this from planOpts (Iter only)
 		Search: func(tx *btree.ReadTx) (qplanner.FtsCandidateStream, error) {
 			return fx.searchCandidates(tx, text)
 		},
@@ -962,32 +961,6 @@ func (q *collQuery) detectFtsQuery() (*qplanner.FtsQuerySpec, query.Filter, erro
 	return spec, ftsResidualFilter(q.cond), nil
 }
 
-// ftsScanPlan builds the docId-producing plan for the non-Iter operations
-// (Count/Update/Delete/Explain) when the query is a $text query, or returns
-// ok=false to let the caller take its normal CBO path. It keeps those operations
-// correct for $text (the BM25 source drives; the residual filter runs
-// downstream) instead of falling through to a match-everything full scan.
-func (q *collQuery) ftsScanPlan(btx *btree.ReadTx, buf *syncpool.DocBuffer) (plan *qplanner.Plan, ok bool, err error) {
-	spec, residual, derr := q.detectFtsQuery()
-	if derr != nil {
-		return nil, false, derr
-	}
-	if spec == nil {
-		return nil, false, nil
-	}
-	spec.NeedScores = false // Count/Update/Delete never read Score()
-	plan = qplanner.BuildPlan(&qplanner.PlanParams{
-		Tx:     btx,
-		DataNs: q.c.ns,
-		Filter: residual,
-		Sorter: ftsSorter(q.sort),
-		Limit:  int(q.limit),
-		Offset: int(q.offset),
-		Buf:    buf,
-		Fts:    spec,
-	})
-	return plan, true, nil
-}
 
 // ftsSorter maps the query's sort to the planner's sorter for a $text query:
 // the default (nil) and the relevance projection {$meta:"textScore"} both yield

--- a/internal/qplanner/dedup.go
+++ b/internal/qplanner/dedup.go
@@ -54,3 +54,32 @@ func (d *DocDedup) Reset() {
 		delete(d.seen, k)
 	}
 }
+
+// ForEachDistinct drives root to exhaustion, invoking fn once per DISTINCT
+// document under the DocDedup contract (multiKey=false is a hard uniqueness
+// guarantee; multiKey=true entries are deduped by docId). docId is only valid
+// for the duration of fn — iterators reuse buffers — so fn must copy what it
+// retains.
+//
+// This is the batch twin of planIterator.Next's streaming pull loop
+// (iterator.go): the two must implement the identical Accept contract. Every
+// batch consumer (bulk Update/Delete id collection, Count's generic tail)
+// goes through here so the contract lives in one place.
+func ForEachDistinct(root Iterator, fn func(docId []byte) error) error {
+	var dedup DocDedup
+	for {
+		_, docId, mk, err := root.Next()
+		if err != nil {
+			return err
+		}
+		if docId == nil {
+			return nil
+		}
+		if !dedup.Accept(docId, mk) {
+			continue
+		}
+		if err = fn(docId); err != nil {
+			return err
+		}
+	}
+}

--- a/internal/qplanner/dedup_test.go
+++ b/internal/qplanner/dedup_test.go
@@ -97,3 +97,65 @@ func TestDocDedup_Reset(t *testing.T) {
 	assert.True(t, d.Accept([]byte("a"), true))
 	assert.True(t, d.Accept([]byte("b"), true))
 }
+
+// stubIter feeds ForEachDistinct a fixed (docId, multiKey) sequence, then EOI.
+type stubIter struct {
+	rows []stubRow
+	pos  int
+	err  error
+}
+
+type stubRow struct {
+	id string
+	mk bool
+}
+
+func (s *stubIter) Next() ([]byte, []byte, bool, error) {
+	if s.pos >= len(s.rows) {
+		if s.err != nil {
+			return nil, nil, false, s.err
+		}
+		return nil, nil, false, nil
+	}
+	r := s.rows[s.pos]
+	s.pos++
+	return nil, []byte(r.id), r.mk, nil
+}
+
+func (s *stubIter) Close()         {}
+func (s *stubIter) String() string { return "stub" }
+
+func TestForEachDistinct_ScalarPassthrough(t *testing.T) {
+	it := &stubIter{rows: []stubRow{{"a", false}, {"b", false}, {"a", false}}}
+	var got []string
+	require.NoError(t, ForEachDistinct(it, func(id []byte) error {
+		got = append(got, string(id))
+		return nil
+	}))
+	// multiKey=false is a hard uniqueness guarantee: no dedup is applied,
+	// exactly like planIterator.Next.
+	assert.Equal(t, []string{"a", "b", "a"}, got)
+}
+
+func TestForEachDistinct_MultiKeyDedup(t *testing.T) {
+	it := &stubIter{rows: []stubRow{{"a", true}, {"b", true}, {"a", true}, {"c", false}}}
+	var got []string
+	require.NoError(t, ForEachDistinct(it, func(id []byte) error {
+		got = append(got, string(id))
+		return nil
+	}))
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+func TestForEachDistinct_PropagatesErrors(t *testing.T) {
+	srcErr := assert.AnError
+	it := &stubIter{rows: []stubRow{{"a", false}}, err: srcErr}
+	var n int
+	err := ForEachDistinct(it, func([]byte) error { n++; return nil })
+	assert.ErrorIs(t, err, srcErr, "source error must surface")
+	assert.Equal(t, 1, n, "rows before the error are delivered")
+
+	it2 := &stubIter{rows: []stubRow{{"a", false}, {"b", false}}}
+	err = ForEachDistinct(it2, func([]byte) error { return assert.AnError })
+	assert.ErrorIs(t, err, assert.AnError, "fn error must stop the drive and surface")
+}

--- a/internal/qplanner/filter_iter.go
+++ b/internal/qplanner/filter_iter.go
@@ -39,6 +39,15 @@ func (it *FilterIter) Next() (key []byte, docId []byte, multiKey bool, err error
 	}()
 
 	for {
+		// The previous row's accepted document must not survive into this
+		// iteration: a source that never repopulates the slot (CoverIter has no
+		// FetchIter beneath it) would otherwise have the filter below evaluate
+		// the PREVIOUS row's document — accepting every subsequent row and
+		// handing a stale doc to SortIter/Doc(). Only a same-row producer
+		// (FetchIter, which runs inside Source.Next below) may fill it.
+		if it.Plan != nil {
+			it.Plan.DocParsed = nil
+		}
 		key, docId, multiKey, err = it.Source.Next()
 		if err != nil || docId == nil {
 			return nil, nil, false, err

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -1260,6 +1261,10 @@ func buildIndexSeekChain(params *PlanParams, idx *CBOIndex, needFilter, needSort
 	if len(idx.Bounds) > 0 {
 		idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
 	}
+	// Compound tuples only: see MergeOverlappingBounds for the gate rationale.
+	if idx.BoundFields > 1 {
+		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
+	}
 
 	// Determine reverse scan direction
 	reverse := shouldReverse(params.Sorter, idx)
@@ -1430,6 +1435,10 @@ func buildIndexScanChain(params *PlanParams, idx *CBOIndex, needFilter bool) Ite
 	// Applies to unique indexes too — see buildIndexSeekChain.
 	if len(idx.Bounds) > 0 {
 		idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
+	}
+	// Compound tuples only: see MergeOverlappingBounds for the gate rationale.
+	if idx.BoundFields > 1 {
+		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
 	}
 	// Pre-pad bounds for CanonicalKeyDedupIter (bare field values); padded
 	// bounds for IndexIter (full keys) — see buildIndexSeekChain.
@@ -2284,6 +2293,74 @@ func AdjustBoundsForNonUnique(bounds query.Bounds) query.Bounds {
 		}
 	}
 	return bounds
+}
+
+// boundsOverlap reports whether b intersects a in key space, given that a
+// sorts at or before b by Start. An empty End is +inf; an equal boundary key
+// is shared only when both sides include it.
+func boundsOverlap(a, b *query.Bound) bool {
+	if len(a.End) == 0 {
+		return true
+	}
+	switch c := bytes.Compare(b.Start, a.End); {
+	case c < 0:
+		return true
+	case c == 0:
+		return a.EndInclude && b.StartInclude
+	default:
+		return false
+	}
+}
+
+// MergeOverlappingBounds sorts key-space bounds ascending by Start and
+// coalesces every overlapping pair into its hull. IndexIter walks the bound
+// list sequentially and requires it ordered and pairwise disjoint — bounds
+// that are disjoint per FIELD can still overlap after compound-tuple
+// concatenation, because anyenc string encodings are not prefix-free across
+// the NUL escape (enc(v) is a byte-prefix of enc(v+"\x00…")): the 0xff pad
+// after a shorter tuple then covers keys the next tuple's range also selects,
+// and a shared entry is emitted twice (duplicate rows, double-applied
+// modifiers, ErrDocNotFound on delete). Coalescing only ever WIDENS a bound —
+// the residual filter rejects the extra keys; it can never drop one.
+//
+// Callers gate this on compound chains (BoundFields > 1): single-field bound
+// lists alias a shared window into BoundsResult.Bounds and must not be
+// reordered or compacted in place; they are also already disjoint (one bound
+// per family member, no concatenation, wrapped in CanonicalKeyDedupIter).
+func MergeOverlappingBounds(bounds query.Bounds) query.Bounds {
+	if len(bounds) < 2 {
+		return bounds
+	}
+	slices.SortStableFunc(bounds, func(a, b query.Bound) int {
+		return bytes.Compare(a.Start, b.Start)
+	})
+	out := bounds[:1]
+	for i := 1; i < len(bounds); i++ {
+		cur := &out[len(out)-1]
+		next := &bounds[i]
+		if !boundsOverlap(cur, next) {
+			out = append(out, *next)
+			continue
+		}
+		// Hull: Start stays cur's (sorted first; on equal Starts the include
+		// flags are OR-ed), End becomes the larger of the two.
+		if bytes.Equal(cur.Start, next.Start) {
+			cur.StartInclude = cur.StartInclude || next.StartInclude
+		}
+		switch {
+		case len(cur.End) == 0:
+			// already +inf
+		case len(next.End) == 0:
+			cur.End, cur.EndInclude = nil, false
+		default:
+			if c := bytes.Compare(next.End, cur.End); c > 0 {
+				cur.End, cur.EndInclude = next.End, next.EndInclude
+			} else if c == 0 {
+				cur.EndInclude = cur.EndInclude || next.EndInclude
+			}
+		}
+	}
+	return out
 }
 
 // IndexSortMatch checks if an index covers the sort fields.

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -1261,10 +1261,6 @@ func buildIndexSeekChain(params *PlanParams, idx *CBOIndex, needFilter, needSort
 	if len(idx.Bounds) > 0 {
 		idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
 	}
-	// Compound tuples only: see MergeOverlappingBounds for the gate rationale.
-	if idx.BoundFields > 1 {
-		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
-	}
 
 	// Determine reverse scan direction
 	reverse := shouldReverse(params.Sorter, idx)
@@ -1319,6 +1315,12 @@ func buildIndexSeekChain(params *PlanParams, idx *CBOIndex, needFilter, needSort
 	// applies HasExactFieldPrefix instead.)
 	dedupBounds := idx.Bounds
 	idx.Bounds = padBoundsForReverseTail(idx)
+	// After the pad: a reverse-tail bound Start is no longer a bare inverted
+	// prefix, so MergeOverlappingBounds' plain byte sort is stored-key order.
+	// Compound tuples only — see MergeOverlappingBounds for the gate rationale.
+	if idx.BoundFields > 1 {
+		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
+	}
 
 	// Use batched allocation for the common case: IndexIter + FetchIter + FilterIter.
 	// This replaces 5 separate heap allocations with 1.
@@ -1436,14 +1438,16 @@ func buildIndexScanChain(params *PlanParams, idx *CBOIndex, needFilter bool) Ite
 	if len(idx.Bounds) > 0 {
 		idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
 	}
-	// Compound tuples only: see MergeOverlappingBounds for the gate rationale.
-	if idx.BoundFields > 1 {
-		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
-	}
 	// Pre-pad bounds for CanonicalKeyDedupIter (bare field values); padded
 	// bounds for IndexIter (full keys) — see buildIndexSeekChain.
 	dedupBounds := idx.Bounds
 	idx.Bounds = padBoundsForReverseTail(idx)
+	// After the pad: a reverse-tail bound Start is no longer a bare inverted
+	// prefix, so MergeOverlappingBounds' plain byte sort is stored-key order.
+	// Compound tuples only — see MergeOverlappingBounds for the gate rationale.
+	if idx.BoundFields > 1 {
+		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
+	}
 	reverse := shouldReverse(params.Sorter, idx)
 
 	var root Iterator = &IndexIter{
@@ -2058,11 +2062,24 @@ func invertBytes(b []byte) []byte {
 // Inversion reverses byte order, so each bound's Start/End are inverted AND
 // swapped, and the inclusivity flags swap with them. An open ascending end
 // (empty End, +inf) becomes an open stored start (empty Start), and vice versa.
-// Because the per-bound Start keys change, the result is re-sorted/merged so
+// Because the per-bound Start keys change, the result is re-sorted so
 // IndexIter walks the bounds in cursor order (relevant for $in / $ne, which
 // produce multiple bounds). A FRESH slice is always returned — the input
 // (which aliases BoundsResult) is never mutated, so ascending-space readers
 // such as calculateSelectivity remain correct.
+//
+// The sort key is compareInvertedStart, NOT plain bytes.Compare: anyenc
+// encodings are prefix-free except across the NUL escape (enc(v) is a
+// byte-prefix of enc(v+"\x00…")), and bitwise inversion preserves the prefix
+// relation without reversing it. The v+"\x00…" continuation group lives at
+// inv(enc(v))‖0x00…, BELOW every key of the v group (which continues with a
+// byte >= 0x01) — so the bound with the LONGER inverted Start selects the
+// SMALLER stored keys and must be walked first, the opposite of what a plain
+// byte compare on bare Starts yields. The input arrives merged (ascending
+// SortAndMerge upstream) and inversion preserves disjointness, so no merge
+// pass is needed — and Bounds.SortAndMerge must not run here, since its
+// bytes.Compare ordering is exactly the wrong order for prefix-related
+// Starts.
 func transformReverseBounds(bs query.Bounds) query.Bounds {
 	if len(bs) == 0 {
 		return bs
@@ -2076,7 +2093,35 @@ func transformReverseBounds(bs query.Bounds) query.Bounds {
 			EndInclude:   b.StartInclude,
 		})
 	}
-	return out.SortAndMerge()
+	slices.SortStableFunc(out, func(a, b query.Bound) int {
+		return compareInvertedStart(a.Start, b.Start)
+	})
+	return out
+}
+
+// compareInvertedStart orders inverted-space bound Starts in stored-key order.
+// An empty Start is -inf. For prefix-related Starts the longer one selects the
+// smaller stored keys (the escape-continuation group sorts below the base
+// value's own entries in inverted space) and therefore comes first; diverging
+// Starts compare bytewise as usual.
+func compareInvertedStart(a, b []byte) int {
+	switch {
+	case len(a) == 0 && len(b) == 0:
+		return 0
+	case len(a) == 0:
+		return -1
+	case len(b) == 0:
+		return 1
+	}
+	if len(a) != len(b) {
+		if bytes.HasPrefix(b, a) {
+			return 1 // a is the shorter prefix: its group starts above b's
+		}
+		if bytes.HasPrefix(a, b) {
+			return -1
+		}
+	}
+	return bytes.Compare(a, b)
 }
 
 // padReverseBounds makes inverted-space bounds exact in the presence of
@@ -2232,6 +2277,17 @@ func computeIndexBounds(idx *IndexInfo, lookup func(string) (query.Bounds, bool,
 				} else {
 					off := len(arena)
 					arena = append(arena, prev.Start...)
+					// A bare prev.Start ending in an INVERTED field encoding
+					// admits that value's escape-continuation group, which
+					// lives at inv(enc(v))‖0x00… — ascending values GREATER
+					// than v that this tuple's range must not select. Append
+					// 0x01 to start above the continuations while keeping the
+					// whole v group (every v key continues with a byte >=
+					// 0x01) — the same rule padReverseBounds applies to a
+					// reverse tail and CoverIter applies to its seek prefix.
+					if i-1 < len(idx.Reverse) && idx.Reverse[i-1] && len(prev.Start) > 0 {
+						arena = append(arena, 0x01)
+					}
 					n := len(arena) - off
 					arena = append(arena, 0)
 					eb.Start = anyenc.Tuple(arena[off : off+n : off+n+1])

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -1313,14 +1313,7 @@ func buildIndexSeekChain(params *PlanParams, idx *CBOIndex, needFilter, needSort
 	// values, which the +0x01 Start pad would wrongly exclude. (CoverIter
 	// above does not take padded bounds either — it seeks the raw prefix and
 	// applies HasExactFieldPrefix instead.)
-	dedupBounds := idx.Bounds
-	idx.Bounds = padBoundsForReverseTail(idx)
-	// After the pad: a reverse-tail bound Start is no longer a bare inverted
-	// prefix, so MergeOverlappingBounds' plain byte sort is stored-key order.
-	// Compound tuples only — see MergeOverlappingBounds for the gate rationale.
-	if idx.BoundFields > 1 {
-		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
-	}
+	dedupBounds := finalizeIndexBounds(idx)
 
 	// Use batched allocation for the common case: IndexIter + FetchIter + FilterIter.
 	// This replaces 5 separate heap allocations with 1.
@@ -1440,14 +1433,7 @@ func buildIndexScanChain(params *PlanParams, idx *CBOIndex, needFilter bool) Ite
 	}
 	// Pre-pad bounds for CanonicalKeyDedupIter (bare field values); padded
 	// bounds for IndexIter (full keys) — see buildIndexSeekChain.
-	dedupBounds := idx.Bounds
-	idx.Bounds = padBoundsForReverseTail(idx)
-	// After the pad: a reverse-tail bound Start is no longer a bare inverted
-	// prefix, so MergeOverlappingBounds' plain byte sort is stored-key order.
-	// Compound tuples only — see MergeOverlappingBounds for the gate rationale.
-	if idx.BoundFields > 1 {
-		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
-	}
+	dedupBounds := finalizeIndexBounds(idx)
 	reverse := shouldReverse(params.Sorter, idx)
 
 	var root Iterator = &IndexIter{
@@ -2148,6 +2134,28 @@ func compareInvertedStart(a, b []byte) int {
 // Only the LAST chained field of an index bound may be padded: earlier
 // (fixed, equality) fields are used as exact byte prefixes that later field
 // bounds are concatenated to.
+
+// finalizeIndexBounds applies the bound-normalization sequence every scanning
+// chain must share — seek and scan plans have to select identical rows for
+// the same query, so this order lives in exactly one place:
+//
+//	pad the reverse tail (escape-exact full keys for IndexIter), then
+//	coalesce overlapping compound tuples (MergeOverlappingBounds; only after
+//	the pad is its plain byte sort stored-key order — a bare inverted Start
+//	is a byte-prefix of its escape-continuation group and would sort wrongly).
+//
+// Returns the PRE-pad bounds for consumers that test bare field values
+// (CanonicalKeyDedupIter; the +0x01 Start pad would wrongly exclude them) and
+// leaves the padded, merged bounds on idx.Bounds for IndexIter.
+func finalizeIndexBounds(idx *CBOIndex) (dedupBounds query.Bounds) {
+	dedupBounds = idx.Bounds
+	idx.Bounds = padBoundsForReverseTail(idx)
+	if idx.BoundFields > 1 {
+		idx.Bounds = MergeOverlappingBounds(idx.Bounds)
+	}
+	return dedupBounds
+}
+
 // padBoundsForReverseTail applies padReverseBounds when the final field of the
 // bound chain is reverse-flagged. Call it only for the CHOSEN index, after
 // AdjustBoundsForNonUnique and after PointLookup/sketch estimation (both read
@@ -2383,6 +2391,13 @@ func boundsOverlap(a, b *query.Bound) bool {
 // lists alias a shared window into BoundsResult.Bounds and must not be
 // reordered or compacted in place; they are also already disjoint (one bound
 // per family member, no concatenation, wrapped in CanonicalKeyDedupIter).
+//
+// Deliberately NOT query.Bounds.SortAndMerge: that operates on ascending
+// VALUE-space bounds and differs at shared boundaries (it keeps the first
+// bound's EndInclude on equal Ends instead of OR-ing, and merges
+// touching-adjacent bounds — which here would widen a half-open pair into
+// covering a key neither side selects). This one runs on padded KEY-space
+// tuples and coalesces only genuine overlaps.
 func MergeOverlappingBounds(bounds query.Bounds) query.Bounds {
 	if len(bounds) < 2 {
 		return bounds

--- a/iterator.go
+++ b/iterator.go
@@ -66,7 +66,10 @@ func (pi *planIterator) Next() bool {
 		// Skip duplicates emitted by multi-key sources (e.g. an
 		// $in over an array index where a doc matches multiple bounds).
 		// multiKey=false is a hard guarantee from upstream; the helper
-		// bypasses the seen-set entirely in that case.
+		// bypasses the seen-set entirely in that case. This streaming pull
+		// loop is the twin of qplanner.ForEachDistinct (the batch consumer
+		// behind bulk writes and the generic count) — both must implement
+		// the identical Accept contract.
 		if !pi.dedup.Accept(docId, mk) {
 			continue
 		}

--- a/query.go
+++ b/query.go
@@ -146,9 +146,26 @@ func (q *collQuery) reportCandidates(btx *btree.ReadTx, opts planOpts) []qplanne
 // the row sink).
 type planOpts struct {
 	countOnly      bool // Count: PlanParams.CountOnly, Sorter forced nil (a count is order-invariant)
+	forWrite       bool // Update/Delete: unbounded-sort elision + vector write guard
 	needScores     bool // Iter only: keep the BM25 sidecar for Iterator.Score()
 	exactTotalDocs bool // Explain only: docCountExact (human-facing TotalDocs)
 	wantCandidates bool // Explain only: return the CBO candidate report even on fts/vector paths
+}
+
+// writeSorter applies the write-verb sorter rule: ordering decides WHICH
+// documents a Limit/Offset window selects, so a BOUNDED write must plan with
+// the sorter exactly like the equivalent read. Without a window the selected
+// set is order-invariant, and the sorter would only add a full
+// materialize-and-sort inside the write transaction — so it is elided.
+// Trade-off (deliberate): the order an unbounded Update applies its modifier
+// in is left to the plan, so transient unique-index collisions under e.g.
+// {$inc} are not caller-controllable; a caller that needs a deterministic
+// application order must bound the write.
+func (q *collQuery) writeSorter(opts planOpts) query.Sort {
+	if opts.countOnly || (opts.forWrite && q.limit == 0 && q.offset == 0) {
+		return nil
+	}
+	return q.sort
 }
 
 // compilePlan is the single query compiler shared by the verbs. It owns
@@ -182,12 +199,9 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 			return nil, nil, err
 		}
 		ftsSpec.NeedScores = opts.needScores
-		sorter := ftsSorter(q.sort)
-		if opts.countOnly {
-			// Sound without ordering: FtsIter emits one aggregate per doc
-			// (duplicate-free), and the distinct count is order-invariant.
-			sorter = nil
-		}
+		// countOnly is sound without ordering: FtsIter emits one aggregate per
+		// doc (duplicate-free), and the distinct count is order-invariant.
+		sorter := ftsSorter(q.writeSorter(opts))
 		plan = qplanner.BuildPlan(&qplanner.PlanParams{
 			Tx:        btx,
 			DataNs:    q.c.ns,
@@ -210,10 +224,15 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		return nil, nil, err
 	}
 	if vspec != nil {
-		sorter := q.sort
-		if opts.countOnly {
-			sorter = nil
-		} else if sorter == nil && !vspec.Ordered {
+		// A vector clause denotes an ANN candidate WINDOW, not a predicate: an
+		// unbounded write would mutate however many candidates the (tunable)
+		// search happens to yield. Until the $knn operator makes k part of the
+		// clause, a vector-clause Update/Delete must state its blast radius.
+		if opts.forWrite && q.limit == 0 {
+			return nil, nil, ErrVectorWriteWithoutLimit
+		}
+		sorter := q.writeSorter(opts)
+		if sorter == nil && !opts.countOnly && !vspec.Ordered {
 			// No explicit sort and the source isn't already distance-ordered
 			// (brute-force): order by distance ascending. When the ANN source
 			// is ordered, we leave sorter nil so the planner skips a redundant
@@ -238,10 +257,7 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 	// CBO path. Bounds and candidates are built against btx: the
 	// multikey-flag probe gating tight seek bounds must read the same
 	// snapshot the scan executes on.
-	sorter := q.sort
-	if opts.countOnly {
-		sorter = nil
-	}
+	sorter := q.writeSorter(opts)
 	idxs := q.c.loadIndexes()
 	br := q.buildBoundsResult(idxs)
 	cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, btx)
@@ -395,7 +411,7 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	// the equivalent Iter returns — same sorter, same access-path detection
 	// ($text AND vector; an invalid vector clause errors here like it does on
 	// Iter instead of degrading to a literal filter).
-	plan, _, ferr := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{})
+	plan, _, ferr := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{forWrite: true})
 	if ferr != nil {
 		err = ferr
 		return
@@ -542,7 +558,7 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	// the equivalent Iter returns — same sorter, same access-path detection
 	// ($text AND vector; an invalid vector clause errors here like it does on
 	// Iter instead of degrading to a literal filter).
-	plan, _, ferr := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{})
+	plan, _, ferr := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{forWrite: true})
 	if ferr != nil {
 		err = ferr
 		return

--- a/query.go
+++ b/query.go
@@ -598,27 +598,6 @@ func (q *collQuery) Count(ctx context.Context) (count int, err error) {
 		q.cond = query.All{}
 	}
 
-	// $text counts by iterating the full-text plan (respecting any residual
-	// predicate and offset/limit). Iter() builds the Fts plan; counting its
-	// results is the simplest correct path.
-	if _, hasText, terr := findTextFilter(q.cond); terr != nil {
-		return 0, terr
-	} else if hasText {
-		iter, ierr := q.Iter(ctx)
-		if ierr != nil {
-			return 0, ierr
-		}
-		defer func() {
-			if cerr := iter.Close(); cerr != nil && err == nil {
-				err = cerr
-			}
-		}()
-		for iter.Next() {
-			count++
-		}
-		return count, iter.Err()
-	}
-
 	// Fast path: filter provably matches no documents (e.g. $in:[]). Skip
 	// the planner, the read tx, and the index walk entirely — the answer
 	// is unconditionally zero. See isUnsatisfiable.
@@ -647,72 +626,56 @@ func (q *collQuery) Count(ctx context.Context) (count int, err error) {
 		return
 	}
 
-	idxs := q.c.loadIndexes()
-
 	err = q.c.db.doReadTx(ctx, func(tx *btree.ReadTx) error {
 		buf := q.c.db.syncPool.GetDocBuf()
 		defer q.c.db.syncPool.ReleaseDocBuf(buf)
 
-		// Bounds and CBO candidates are built INSIDE the read tx: the
-		// multikey-flag probe gating tight seek bounds must read the same
-		// snapshot the scan executes on.
-		br := q.buildBoundsResult(idxs)
-		var cboBuf [8]qplanner.CBOIndex
-		cboIndexes := q.buildCBOIndexesInto(cboBuf[:0], &br, idxs, tx)
-
-		plan := qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:          tx,
-			DataNs:      q.c.ns,
-			Filter:      q.cond,
-			Sorter:      nil, // no sort needed for count
-			IDBounds:    idBounds,
-			PrimaryKey:  q.c.primaryKey,
-			Limit:       int(q.limit),
-			Offset:      int(q.offset),
-			Buf:         buf,
-			TotalDocs:   q.docCountForPlan(tx, idxs),
-			Indexes:     cboIndexes,
-			IndexHints:  q.buildIndexHints(),
-			CountOnly:   true,
-			FieldBounds: &br,
-		})
-
-		// Limit/Offset cutoffs must apply to DISTINCT docs, not raw entry
-		// rows: over a multi-key index LimitIter.Next skips/caps entries that
-		// later collapse in dedup, diverging from Iter (known-issues I-07).
-		// CountDistinct deduplicates before the cutoff.
-		if li, ok := plan.Root.(*qplanner.LimitIter); ok {
-			n, cerr := li.CountDistinct()
-			plan.Close()
-			if cerr != nil {
-				return cerr
-			}
-			count = n
-			return nil
+		// The shared compiler, in count mode: CountOnly enables the covering
+		// fast paths, the sorter is dropped (a count is order-invariant), and
+		// $text/vector queries count their native plans — the same document
+		// set Iter yields, without the score sidecar or a public iterator.
+		plan, _, perr := q.compilePlan(tx, buf, idBounds, planOpts{countOnly: true})
+		if perr != nil {
+			return perr
 		}
-		// Use batch counting if the root iterator supports it (covering index
-		// count). IndexIter.CountEntries handles the multi-bound + multi-key
-		// dedup internally via the per-entry value byte; consumers don't need
-		// to layer another dedup on top.
-		if ci, ok := plan.Root.(qplanner.CountableIterator); ok {
-			n, cerr := ci.CountEntries()
-			plan.Close() // release cursor resources held by CountEntries
-			if cerr != nil {
-				return cerr
-			}
-			count = n
-			return nil
+		n, cerr := countPlanRoot(plan)
+		if cerr != nil {
+			return cerr
 		}
-		// Generic distinct-doc count: a doc whose array values match multiple
-		// bounds is counted once.
-		cerr := qplanner.ForEachDistinct(plan.Root, func([]byte) error {
-			count++
-			return nil
-		})
-		plan.Close()
-		return cerr
+		count = n
+		return nil
 	})
 	return
+}
+
+// countPlanRoot consumes a CountOnly plan and returns the distinct-doc count,
+// closing the plan. Dispatch order matters:
+//
+//  1. LimitIter first: the Limit/Offset cutoffs must apply to DISTINCT docs,
+//     not raw entry rows — over a multi-key index LimitIter.Next skips/caps
+//     entries that later collapse in dedup, diverging from Iter
+//     (known-issues I-07). CountDistinct deduplicates before the cutoff.
+//  2. The covering batch count (IndexIter.CountEntries) handles multi-bound +
+//     multi-key dedup internally via the per-entry value byte.
+//  3. Otherwise the shared generic distinct loop.
+func countPlanRoot(plan *qplanner.Plan) (int, error) {
+	if li, ok := plan.Root.(*qplanner.LimitIter); ok {
+		n, err := li.CountDistinct()
+		plan.Close()
+		return n, err
+	}
+	if ci, ok := plan.Root.(qplanner.CountableIterator); ok {
+		n, err := ci.CountEntries()
+		plan.Close() // release cursor resources held by CountEntries
+		return n, err
+	}
+	n := 0
+	err := qplanner.ForEachDistinct(plan.Root, func([]byte) error {
+		n++
+		return nil
+	})
+	plan.Close()
+	return n, err
 }
 
 // collectDistinctIDs materializes a plan's distinct docIds into slices backed

--- a/query.go
+++ b/query.go
@@ -716,38 +716,21 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 	buf := q.c.db.syncPool.GetDocBuf()
 	defer q.c.db.syncPool.ReleaseDocBuf(buf)
 
-	idxs := q.c.loadIndexes()
-
 	err = q.c.db.doReadTx(ctx, func(tx *btree.ReadTx) error {
 		if aErr := q.c.alive(); aErr != nil {
 			return aErr
 		}
-		// Built inside the read tx so the multikey-flag probe sees the same
-		// snapshot the (hypothetical) scan would — Explain must report the
-		// bounds the real query would use.
-		br := q.buildBoundsResult(idxs)
-		cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, tx)
-
-		plan, isFts, ferr := q.ftsScanPlan(tx, buf)
-		if ferr != nil {
-			return ferr
-		}
-		if !isFts {
-			plan = qplanner.BuildPlan(&qplanner.PlanParams{
-				Tx:          tx,
-				DataNs:      q.c.ns,
-				Filter:      q.cond,
-				Sorter:      q.sort,
-				IDBounds:    qb.idBounds,
-				PrimaryKey:  q.c.primaryKey,
-				Limit:       int(q.limit),
-				Offset:      int(q.offset),
-				Buf:         buf,
-				TotalDocs:   q.docCountExact(tx, idxs),
-				Indexes:     cboIndexes,
-				IndexHints:  q.buildIndexHints(),
-				FieldBounds: &br,
-			})
+		// The shared compiler, in report mode: exact TotalDocs (a human reads
+		// it), and the CBO candidate list is returned even on the fts/vector
+		// paths so the index report never silently shrinks. Vector queries
+		// are honestly explained as their ANN plan now, exactly what Iter and
+		// the write verbs execute.
+		plan, cboIndexes, perr := q.compilePlan(tx, buf, qb.idBounds, planOpts{
+			exactTotalDocs: true,
+			wantCandidates: true,
+		})
+		if perr != nil {
+			return perr
 		}
 		explain.Sql = plan.String()
 		explain.Plan = plan.ExplainString()

--- a/query.go
+++ b/query.go
@@ -337,6 +337,11 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 			Tx:          btx,
 			DataNs:      q.c.ns,
 			Filter:      q.cond,
+			// The sorter decides WHICH documents a Limit/Offset window selects,
+			// so a bounded write must plan with it exactly like the equivalent
+			// read — otherwise the window slices an unordered stream and the
+			// wrong documents are written.
+			Sorter:      q.sort,
 			IDBounds:    qb.idBounds,
 			PrimaryKey:  q.c.primaryKey,
 			Limit:       int(q.limit),
@@ -522,6 +527,11 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 			Tx:          btx,
 			DataNs:      q.c.ns,
 			Filter:      q.cond,
+			// The sorter decides WHICH documents a Limit/Offset window selects,
+			// so a bounded write must plan with it exactly like the equivalent
+			// read — otherwise the window slices an unordered stream and the
+			// wrong documents are written.
+			Sorter:      q.sort,
 			IDBounds:    qb.idBounds,
 			PrimaryKey:  q.c.primaryKey,
 			Limit:       int(q.limit),

--- a/query.go
+++ b/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/anyproto/any-store/v2/internal/btree"
 	"github.com/anyproto/any-store/v2/internal/qplanner"
 	"github.com/anyproto/any-store/v2/query"
+	"github.com/anyproto/any-store/v2/syncpool"
 )
 
 // ModifyResult represents the result of a modification operation.
@@ -127,6 +128,141 @@ func (q *collQuery) Sort(sorts ...any) Query {
 	return q
 }
 
+// reportCandidates builds the CBO candidate list for Explain's index report
+// on the fts/vector paths, where compilation never consults the CBO. Nil for
+// every other verb.
+func (q *collQuery) reportCandidates(btx *btree.ReadTx, opts planOpts) []qplanner.CBOIndex {
+	if !opts.wantCandidates {
+		return nil
+	}
+	idxs := q.c.loadIndexes()
+	br := q.buildBoundsResult(idxs)
+	return q.buildCBOIndexesInto(nil, &br, idxs, btx)
+}
+
+// planOpts are the only per-verb compilation knobs. Everything else about
+// access-path selection is shared — a divergence here needs written rationale
+// (the SQLite shape: one WHERE/ORDER BY code generator, verb-specific only at
+// the row sink).
+type planOpts struct {
+	countOnly      bool // Count: PlanParams.CountOnly, Sorter forced nil (a count is order-invariant)
+	needScores     bool // Iter only: keep the BM25 sidecar for Iterator.Score()
+	exactTotalDocs bool // Explain only: docCountExact (human-facing TotalDocs)
+	wantCandidates bool // Explain only: return the CBO candidate report even on fts/vector paths
+}
+
+// compilePlan is the single query compiler shared by the verbs. It owns
+// $text detection (detectFtsQuery + ftsSorter), vector detection
+// (detectVectorQuery + the default distance-sort rule), and CBO input
+// assembly (buildBoundsResult, buildCBOIndexesInto, buildIndexHints,
+// docCountForPlan/docCountExact) — so every verb selects the same documents
+// for the same query by construction.
+//
+// btx MUST be the snapshot the plan executes on: the multikey-flag probe in
+// buildCBOIndexesInto and the bounds interpolation read it. The caller owns
+// alive()/unsatisfiable() gating, tx and buf lifetimes, and the sink. cbo is
+// non-nil only when opts.wantCandidates (Explain's index report).
+func (q *collQuery) compilePlan(btx *btree.ReadTx, buf *syncpool.DocBuffer,
+	idBounds query.Bounds, opts planOpts) (plan *qplanner.Plan, cbo []qplanner.CBOIndex, err error) {
+
+	// $text drives the query when present (CBO bypassed). The residual filter
+	// runs as a downstream FilterIter; a relevance/textScore sort is the
+	// FtsIter's intrinsic order, a real-field sort inserts a SortIter.
+	ftsSpec, ftsResidual, err := q.detectFtsQuery()
+	if err != nil {
+		return nil, nil, err
+	}
+	if ftsSpec != nil {
+		ftsSpec.NeedScores = opts.needScores
+		sorter := ftsSorter(q.sort)
+		if opts.countOnly {
+			// Sound without ordering: FtsIter emits one aggregate per doc
+			// (duplicate-free), and the distinct count is order-invariant.
+			sorter = nil
+		}
+		plan = qplanner.BuildPlan(&qplanner.PlanParams{
+			Tx:        btx,
+			DataNs:    q.c.ns,
+			Filter:    ftsResidual,
+			Sorter:    sorter,
+			Limit:     int(q.limit),
+			Offset:    int(q.offset),
+			Buf:       buf,
+			CountOnly: opts.countOnly,
+			Fts:       ftsSpec,
+		})
+		return plan, q.reportCandidates(btx, opts), nil
+	}
+
+	// Vector query: detect `{vectorField: [..]}` against the collection's
+	// vector indexes. When matched, build a vector plan (ANN source) and
+	// ignore all other indexes; the residual filter + sort run downstream.
+	vspec, residual, err := q.detectVectorQuery()
+	if err != nil {
+		return nil, nil, err
+	}
+	if vspec != nil {
+		sorter := q.sort
+		if opts.countOnly {
+			sorter = nil
+		} else if sorter == nil && !vspec.Ordered {
+			// No explicit sort and the source isn't already distance-ordered
+			// (brute-force): order by distance ascending. When the ANN source
+			// is ordered, we leave sorter nil so the planner skips a redundant
+			// SortIter and streams the already-closest-first candidates
+			// straight to LimitIter.
+			sorter, _ = query.ParseSort(qplanner.DistanceField)
+		}
+		plan = qplanner.BuildPlan(&qplanner.PlanParams{
+			Tx:        btx,
+			DataNs:    q.c.ns,
+			Filter:    residual,
+			Sorter:    sorter,
+			Limit:     int(q.limit),
+			Offset:    int(q.offset),
+			Buf:       buf,
+			CountOnly: opts.countOnly,
+			Vector:    vspec,
+		})
+		return plan, q.reportCandidates(btx, opts), nil
+	}
+
+	// CBO path. Bounds and candidates are built against btx: the
+	// multikey-flag probe gating tight seek bounds must read the same
+	// snapshot the scan executes on.
+	sorter := q.sort
+	if opts.countOnly {
+		sorter = nil
+	}
+	idxs := q.c.loadIndexes()
+	br := q.buildBoundsResult(idxs)
+	cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, btx)
+	totalDocs := q.docCountForPlan(btx, idxs)
+	if opts.exactTotalDocs {
+		totalDocs = q.docCountExact(btx, idxs)
+	}
+	plan = qplanner.BuildPlan(&qplanner.PlanParams{
+		Tx:          btx,
+		DataNs:      q.c.ns,
+		Filter:      q.cond,
+		Sorter:      sorter,
+		IDBounds:    idBounds,
+		PrimaryKey:  q.c.primaryKey,
+		Limit:       int(q.limit),
+		Offset:      int(q.offset),
+		Buf:         buf,
+		TotalDocs:   totalDocs,
+		Indexes:     cboIndexes,
+		IndexHints:  q.buildIndexHints(),
+		CountOnly:   opts.countOnly,
+		FieldBounds: &br,
+	})
+	if opts.wantCandidates {
+		cbo = cboIndexes
+	}
+	return plan, cbo, nil
+}
+
 func (q *collQuery) Iter(ctx context.Context) (iter Iterator, err error) {
 	if err = q.c.alive(); err != nil {
 		return
@@ -161,91 +297,13 @@ func (q *collQuery) Iter(ctx context.Context) (iter Iterator, err error) {
 	buf := q.c.db.syncPool.GetDocBuf()
 	btx := tx.btreeReadTx()
 
-	// $text query: the BM25 search drives the query (CBO bypassed). The residual
-	// filter runs as a downstream FilterIter; a relevance/textScore sort is the
-	// FtsIter's intrinsic order, a real-field sort inserts a SortIter.
-	ftsSpec, ftsResidual, ferr := q.detectFtsQuery()
-	if ferr != nil {
+	plan, _, err := q.compilePlan(btx, buf, qb.idBounds, planOpts{needScores: true})
+	if err != nil {
 		q.c.db.syncPool.ReleaseDocBuf(buf)
 		_ = tx.Commit()
 		qb.Close()
-		return nil, ferr
+		return nil, err
 	}
-	if ftsSpec != nil {
-		plan := qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:     btx,
-			DataNs: q.c.ns,
-			Filter: ftsResidual,
-			Sorter: ftsSorter(q.sort),
-			Limit:  int(q.limit),
-			Offset: int(q.offset),
-			Buf:    buf,
-			Fts:    ftsSpec,
-		})
-		return &planIterator{
-			plan: plan,
-			tx:   tx,
-			buf:  buf,
-			qb:   qb,
-			data: &qplanner.CursorSource{Tx: btx, Ns: q.c.ns},
-		}, nil
-	}
-
-	// Vector query: detect `{vectorField: [..]}` against the collection's vector
-	// indexes. When matched, build a vector plan (ANN source) and ignore all
-	// other indexes; the residual filter + sort run as downstream stages.
-	vspec, residual, verr := q.detectVectorQuery()
-	if verr != nil {
-		q.c.db.syncPool.ReleaseDocBuf(buf)
-		_ = tx.Commit()
-		qb.Close()
-		return nil, verr
-	}
-	if vspec != nil {
-		sorter := q.sort
-		if sorter == nil && !vspec.Ordered {
-			// No explicit sort and the source isn't already distance-ordered
-			// (brute-force): order by distance ascending. When the ANN source is
-			// ordered, we leave sorter nil so the planner skips a redundant SortIter
-			// and streams the already-closest-first candidates straight to LimitIter.
-			sorter, _ = query.ParseSort(qplanner.DistanceField)
-		}
-		plan := qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:     btx,
-			DataNs: q.c.ns,
-			Filter: residual,
-			Sorter: sorter,
-			Limit:  int(q.limit),
-			Offset: int(q.offset),
-			Buf:    buf,
-			Vector: vspec,
-		})
-		return &planIterator{
-			plan: plan,
-			tx:   tx,
-			buf:  buf,
-			qb:   qb,
-			data: &qplanner.CursorSource{Tx: btx, Ns: q.c.ns},
-		}, nil
-	}
-
-	idxs := q.c.loadIndexes()
-	br := q.buildBoundsResult(idxs)
-	plan := qplanner.BuildPlan(&qplanner.PlanParams{
-		Tx:          btx,
-		DataNs:      q.c.ns,
-		Filter:      q.cond,
-		Sorter:      q.sort,
-		IDBounds:    qb.idBounds,
-		PrimaryKey:  q.c.primaryKey,
-		Limit:       int(q.limit),
-		Offset:      int(q.offset),
-		Buf:         buf,
-		TotalDocs:   q.docCountForPlan(btx, idxs),
-		Indexes:     q.buildCBOIndexesInto(nil, &br, idxs, btx),
-		IndexHints:  q.buildIndexHints(),
-		FieldBounds: &br,
-	})
 
 	return &planIterator{
 		plan: plan,

--- a/query.go
+++ b/query.go
@@ -369,39 +369,15 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	}
 	defer closePlan()
 
-	// Collect all matching docIds into a contiguous buffer to avoid
-	// per-ID allocations and cursor invalidation during updates. Dedup
-	// multi-key entries so an UpdateMany over an array-indexed $in
-	// query doesn't apply the modifier twice to the same doc.
-	var idBuf []byte       // contiguous buffer for all IDs
-	var idOffsets []uint32 // start offsets of each ID in idBuf
-	var dedup qplanner.DocDedup
-	for {
-		_, docId, mk, iterErr := plan.Root.Next()
-		if iterErr != nil {
-			err = iterErr
-			return
-		}
-		if docId == nil {
-			break
-		}
-		if !dedup.Accept(docId, mk) {
-			continue
-		}
-		idOffsets = append(idOffsets, uint32(len(idBuf)))
-		idBuf = append(idBuf, docId...)
+	// Materialize the distinct target ids, then release the plan's cursors
+	// BEFORE mutating ("can't modify while iterating"). Dedup ensures a bulk
+	// update over an array-indexed $in query doesn't apply the modifier twice
+	// to the same doc.
+	idsToUpdate, err := collectDistinctIDs(plan.Root)
+	if err != nil {
+		return
 	}
 	closePlan()
-
-	// Build slice references into the contiguous buffer.
-	idsToUpdate := make([][]byte, len(idOffsets))
-	for i, off := range idOffsets {
-		end := len(idBuf)
-		if i+1 < len(idOffsets) {
-			end = int(idOffsets[i+1])
-		}
-		idsToUpdate[i] = idBuf[off:end]
-	}
 
 	modBuf := q.c.db.syncPool.GetDocBuf()
 	defer q.c.db.syncPool.ReleaseDocBuf(modBuf)
@@ -556,38 +532,14 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	}
 	defer closePlan()
 
-	// Collect IDs to delete into a contiguous buffer (can't modify while iterating).
-	// Dedup multi-key entries so a doc matched on multiple array values
-	// isn't deleted twice / counted twice in the affected count.
-	var idBuf []byte
-	var idOffsets []uint32
-	var dedup qplanner.DocDedup
-	for {
-		_, docId, mk, iterErr := plan.Root.Next()
-		if iterErr != nil {
-			err = iterErr
-			return
-		}
-		if docId == nil {
-			break
-		}
-		if !dedup.Accept(docId, mk) {
-			continue
-		}
-		idOffsets = append(idOffsets, uint32(len(idBuf)))
-		idBuf = append(idBuf, docId...)
+	// Materialize the distinct target ids, then release the plan's cursors
+	// BEFORE mutating ("can't modify while iterating"). Dedup ensures a doc
+	// matched on multiple array values isn't deleted twice / counted twice.
+	idsToDelete, err := collectDistinctIDs(plan.Root)
+	if err != nil {
+		return
 	}
 	closePlan()
-
-	// Build slice references into the contiguous buffer.
-	idsToDelete := make([][]byte, len(idOffsets))
-	for i, off := range idOffsets {
-		end := len(idBuf)
-		if i+1 < len(idOffsets) {
-			end = int(idOffsets[i+1])
-		}
-		idsToDelete[i] = idBuf[off:end]
-	}
 
 	// Now delete collected docs
 	for _, id := range idsToDelete {
@@ -731,24 +683,41 @@ func (q *collQuery) Count(ctx context.Context) (count int, err error) {
 			count = n
 			return nil
 		}
-		// Generic Next-loop count: dedup multi-key entries so a doc whose
-		// array values match multiple bounds is counted once.
-		var dedup qplanner.DocDedup
-		for {
-			_, docId, mk, iterErr := plan.Root.Next()
-			if iterErr != nil {
-				return iterErr
-			}
-			if docId == nil {
-				break
-			}
-			if dedup.Accept(docId, mk) {
-				count++
-			}
-		}
-		return nil
+		// Generic distinct-doc count: a doc whose array values match multiple
+		// bounds is counted once.
+		cerr := qplanner.ForEachDistinct(plan.Root, func([]byte) error {
+			count++
+			return nil
+		})
+		plan.Close()
+		return cerr
 	})
 	return
+}
+
+// collectDistinctIDs materializes a plan's distinct docIds into slices backed
+// by one contiguous arena: one allocation curve, and the ids stay valid after
+// plan.Close — bulk writes must release the plan's cursors before mutating,
+// and iterators reuse their docId buffers between rows.
+func collectDistinctIDs(root qplanner.Iterator) ([][]byte, error) {
+	var idBuf []byte       // contiguous buffer for all ids
+	var idOffsets []uint32 // start offset of each id in idBuf
+	if err := qplanner.ForEachDistinct(root, func(docId []byte) error {
+		idOffsets = append(idOffsets, uint32(len(idBuf)))
+		idBuf = append(idBuf, docId...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	ids := make([][]byte, len(idOffsets))
+	for i, off := range idOffsets {
+		end := len(idBuf)
+		if i+1 < len(idOffsets) {
+			end = int(idOffsets[i+1])
+		}
+		ids[i] = idBuf[off:end]
+	}
+	return ids, nil
 }
 
 func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {

--- a/query.go
+++ b/query.go
@@ -383,33 +383,14 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	buf := q.c.db.syncPool.GetDocBuf()
 	defer q.c.db.syncPool.ReleaseDocBuf(buf)
 
-	plan, isFts, ferr := q.ftsScanPlan(btx, buf)
+	// The shared compiler: a bounded write must select exactly the documents
+	// the equivalent Iter returns — same sorter, same access-path detection
+	// ($text AND vector; an invalid vector clause errors here like it does on
+	// Iter instead of degrading to a literal filter).
+	plan, _, ferr := q.compilePlan(btx, buf, qb.idBounds, planOpts{})
 	if ferr != nil {
 		err = ferr
 		return
-	}
-	if !isFts {
-		idxs := q.c.loadIndexes()
-		br := q.buildBoundsResult(idxs)
-		plan = qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:          btx,
-			DataNs:      q.c.ns,
-			Filter:      q.cond,
-			// The sorter decides WHICH documents a Limit/Offset window selects,
-			// so a bounded write must plan with it exactly like the equivalent
-			// read — otherwise the window slices an unordered stream and the
-			// wrong documents are written.
-			Sorter:      q.sort,
-			IDBounds:    qb.idBounds,
-			PrimaryKey:  q.c.primaryKey,
-			Limit:       int(q.limit),
-			Offset:      int(q.offset),
-			Buf:         buf,
-			TotalDocs:   q.docCountForPlan(btx, idxs),
-			Indexes:     q.buildCBOIndexesInto(nil, &br, idxs, btx),
-			IndexHints:  q.buildIndexHints(),
-			FieldBounds: &br,
-		})
 	}
 
 	// Close-once: the plan must be closed before the write loop below (see the
@@ -549,33 +530,14 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	buf := q.c.db.syncPool.GetDocBuf()
 	defer q.c.db.syncPool.ReleaseDocBuf(buf)
 
-	plan, isFts, ferr := q.ftsScanPlan(btx, buf)
+	// The shared compiler: a bounded write must select exactly the documents
+	// the equivalent Iter returns — same sorter, same access-path detection
+	// ($text AND vector; an invalid vector clause errors here like it does on
+	// Iter instead of degrading to a literal filter).
+	plan, _, ferr := q.compilePlan(btx, buf, qb.idBounds, planOpts{})
 	if ferr != nil {
 		err = ferr
 		return
-	}
-	if !isFts {
-		idxs := q.c.loadIndexes()
-		br := q.buildBoundsResult(idxs)
-		plan = qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:          btx,
-			DataNs:      q.c.ns,
-			Filter:      q.cond,
-			// The sorter decides WHICH documents a Limit/Offset window selects,
-			// so a bounded write must plan with it exactly like the equivalent
-			// read — otherwise the window slices an unordered stream and the
-			// wrong documents are written.
-			Sorter:      q.sort,
-			IDBounds:    qb.idBounds,
-			PrimaryKey:  q.c.primaryKey,
-			Limit:       int(q.limit),
-			Offset:      int(q.offset),
-			Buf:         buf,
-			TotalDocs:   q.docCountForPlan(btx, idxs),
-			Indexes:     q.buildCBOIndexesInto(nil, &br, idxs, btx),
-			IndexHints:  q.buildIndexHints(),
-			FieldBounds: &br,
-		})
 	}
 
 	// Close-once: the plan must be closed before the delete loop below, but a

--- a/query.go
+++ b/query.go
@@ -162,7 +162,7 @@ type planOpts struct {
 // buildCBOIndexesInto and the bounds interpolation read it. The caller owns
 // alive()/unsatisfiable() gating, tx and buf lifetimes, and the sink. cbo is
 // non-nil only when opts.wantCandidates (Explain's index report).
-func (q *collQuery) compilePlan(btx *btree.ReadTx, buf *syncpool.DocBuffer,
+func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syncpool.DocBuffer,
 	idBounds query.Bounds, opts planOpts) (plan *qplanner.Plan, cbo []qplanner.CBOIndex, err error) {
 
 	// $text drives the query when present (CBO bypassed). The residual filter
@@ -173,6 +173,14 @@ func (q *collQuery) compilePlan(btx *btree.ReadTx, buf *syncpool.DocBuffer,
 		return nil, nil, err
 	}
 	if ftsSpec != nil {
+		// Read-your-writes: inside an ambient write tx the pending full-text
+		// postings buffer is flushed before the search, so a $text read sees
+		// the tx's own uncommitted writes — the same view the savepoint path
+		// gives the write verbs. One entry point, one visibility rule; a
+		// rollback still discards everything (resetAllFtsPending).
+		if err = q.c.db.flushAmbientFtsPending(ctx); err != nil {
+			return nil, nil, err
+		}
 		ftsSpec.NeedScores = opts.needScores
 		sorter := ftsSorter(q.sort)
 		if opts.countOnly {
@@ -297,7 +305,7 @@ func (q *collQuery) Iter(ctx context.Context) (iter Iterator, err error) {
 	buf := q.c.db.syncPool.GetDocBuf()
 	btx := tx.btreeReadTx()
 
-	plan, _, err := q.compilePlan(btx, buf, qb.idBounds, planOpts{needScores: true})
+	plan, _, err := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{needScores: true})
 	if err != nil {
 		q.c.db.syncPool.ReleaseDocBuf(buf)
 		_ = tx.Commit()
@@ -387,7 +395,7 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	// the equivalent Iter returns — same sorter, same access-path detection
 	// ($text AND vector; an invalid vector clause errors here like it does on
 	// Iter instead of degrading to a literal filter).
-	plan, _, ferr := q.compilePlan(btx, buf, qb.idBounds, planOpts{})
+	plan, _, ferr := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{})
 	if ferr != nil {
 		err = ferr
 		return
@@ -534,7 +542,7 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	// the equivalent Iter returns — same sorter, same access-path detection
 	// ($text AND vector; an invalid vector clause errors here like it does on
 	// Iter instead of degrading to a literal filter).
-	plan, _, ferr := q.compilePlan(btx, buf, qb.idBounds, planOpts{})
+	plan, _, ferr := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{})
 	if ferr != nil {
 		err = ferr
 		return
@@ -634,7 +642,7 @@ func (q *collQuery) Count(ctx context.Context) (count int, err error) {
 		// fast paths, the sorter is dropped (a count is order-invariant), and
 		// $text/vector queries count their native plans — the same document
 		// set Iter yields, without the score sidecar or a public iterator.
-		plan, _, perr := q.compilePlan(tx, buf, idBounds, planOpts{countOnly: true})
+		plan, _, perr := q.compilePlan(ctx, tx, buf, idBounds, planOpts{countOnly: true})
 		if perr != nil {
 			return perr
 		}
@@ -725,7 +733,7 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 		// paths so the index report never silently shrinks. Vector queries
 		// are honestly explained as their ANN plan now, exactly what Iter and
 		// the write verbs execute.
-		plan, cboIndexes, perr := q.compilePlan(tx, buf, qb.idBounds, planOpts{
+		plan, cboIndexes, perr := q.compilePlan(ctx, tx, buf, qb.idBounds, planOpts{
 			exactTotalDocs: true,
 			wantCandidates: true,
 		})

--- a/query_compound_bounds_test.go
+++ b/query_compound_bounds_test.go
@@ -1,0 +1,115 @@
+package anystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// Compound-tuple bounds can overlap in key space even when the per-field
+// bounds are disjoint: anyenc strings are not prefix-free across the NUL
+// escape, so with two selected values in one escape family ("u1" and
+// "u1\x00z") and an OPEN range on the NEXT index field, the 0xff pad after
+// the shorter tuple covers keys the longer tuple's own range also selects.
+// IndexIter then emits the shared entries twice: duplicate rows on Iter,
+// a double-applied modifier on Update, and ErrDocNotFound (rolling back the
+// whole batch) on Delete.
+
+func compoundBoundsColl(t *testing.T, unique bool) Collection {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "compound_bounds")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ub", Fields: []string{"u", "b"}, Unique: unique}))
+	docs := []string{
+		`{"id":1,"u":"u1","b":1,"n":0}`,
+		`{"id":2,"u":"u1\u0000z","b":2,"n":0}`,
+		`{"id":3,"u":"u1\u0000z","b":3,"n":0}`,
+		`{"id":4,"u":"u2","b":4,"n":0}`,
+	}
+	for _, d := range docs {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	return coll
+}
+
+const compoundBoundsFilter = `{"u":{"$in":["u1","u1\u0000z"]},"b":{"$gt":-1}}`
+
+var compoundBoundsHint = IndexHint{IndexName: "ub", Boost: 1_000_000}
+
+func requireCompoundIndexPlan(t *testing.T, q Query) {
+	t.Helper()
+	ex, err := q.Explain(ctx)
+	require.NoError(t, err)
+	require.Contains(t, ex.Sql, "ub", "test premise: the compound index must drive the plan\nplan: %s", ex.Sql)
+	require.NotContains(t, ex.Sql, "FullScan", "test premise: not a FullScan\nplan: %s", ex.Sql)
+}
+
+func TestCompoundBounds_NulFamilyOpenRange_NoDuplicateRows(t *testing.T) {
+	coll := compoundBoundsColl(t, false)
+	q := coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint)
+	requireCompoundIndexPlan(t, q)
+
+	ids := writeOrderIterIds(t, coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint))
+	assert.ElementsMatch(t, []int{1, 2, 3}, ids, "each matching doc exactly once")
+
+	count, err := coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestCompoundBounds_NulFamilyOpenRange_UpdateAppliesOnce(t *testing.T) {
+	coll := compoundBoundsColl(t, false)
+	res, err := coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint).
+		Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Modified)
+
+	for _, id := range []int{1, 2, 3} {
+		doc, err := coll.FindId(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, 1, doc.Value().GetInt("n"), "doc %d: $inc must apply exactly once", id)
+	}
+}
+
+func TestCompoundBounds_NulFamilyOpenRange_DeleteSucceeds(t *testing.T) {
+	coll := compoundBoundsColl(t, false)
+	res, err := coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint).Delete(ctx)
+	require.NoError(t, err, "a duplicate id in the delete set fails the second DeleteId and rolls back the batch")
+	assert.Equal(t, 3, res.Modified)
+	assert.Equal(t, map[int]struct{}{4: {}}, writeOrderSurvivors(t, coll))
+}
+
+func TestCompoundBounds_UniqueCompoundOverlap(t *testing.T) {
+	coll := compoundBoundsColl(t, true)
+	q := coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint)
+	requireCompoundIndexPlan(t, q)
+
+	ids := writeOrderIterIds(t, coll.Find(compoundBoundsFilter).IndexHint(compoundBoundsHint))
+	assert.ElementsMatch(t, []int{1, 2, 3}, ids)
+}
+
+func TestCompoundBounds_NegativeControls(t *testing.T) {
+	// Shapes the trigger rule excludes: the bounds diverge at a type tag and
+	// stay disjoint, so behavior must be identical before and after the merge.
+	coll := compoundBoundsColl(t, false)
+	for name, filter := range map[string]string{
+		"two_sided_range_on_next": `{"u":{"$in":["u1","u1\u0000z"]},"b":{"$gt":-1,"$lt":100}}`,
+		"equality_on_next":        `{"u":{"$in":["u1\u0000z"]},"b":2}`,
+		"nul_free_family":         `{"u":{"$in":["u1","u2"]},"b":{"$gt":-1}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ids := writeOrderIterIds(t, coll.Find(filter).IndexHint(compoundBoundsHint))
+			count, err := coll.Find(filter).IndexHint(compoundBoundsHint).Count(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, len(ids), count, "Count and Iter agree")
+			seen := map[int]bool{}
+			for _, id := range ids {
+				assert.False(t, seen[id], "no duplicates")
+				seen[id] = true
+			}
+		})
+	}
+}

--- a/query_coverlookup_filter_test.go
+++ b/query_coverlookup_filter_test.go
@@ -1,0 +1,105 @@
+package anystore
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// The unique-index point-lookup chain (CoverLookup) has no FetchIter, so the
+// residual FilterIter is the only stage that parses the document. A stale
+// per-query doc cache there made the filter evaluate the PREVIOUS row's
+// document from the second bound on — accepting rows the filter excludes and
+// handing stale docs to Sort/Doc(). These tests pin the chain via Explain so
+// a planner change routing them elsewhere fails loudly instead of silently
+// passing.
+
+func coverLookupColl(t *testing.T) Collection {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "cover_filter")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "email", Fields: []string{"email"}, Unique: true}))
+	for i := 1; i <= 6; i++ {
+		// active alternates: e1,e3,e5 active; e2,e4,e6 inactive
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(fmt.Sprintf(
+			`{"id":%d,"email":"e%d","active":%t,"rank":%d}`, i, i, i%2 == 1, 7-i))))
+	}
+	return coll
+}
+
+func requireCoverLookup(t *testing.T, coll Collection, q Query) {
+	t.Helper()
+	ex, err := q.Explain(ctx)
+	require.NoError(t, err)
+	require.Contains(t, ex.Sql, "CoverLookup", "test premise: plan must route through CoverLookup\nplan: %s", ex.Sql)
+}
+
+const coverFilter = `{"email":{"$in":["e1","e2","e3","e4"]},"active":true}`
+
+func TestCoverLookupResidualFilter_AppliedToEveryRow(t *testing.T) {
+	coll := coverLookupColl(t)
+	requireCoverLookup(t, coll, coll.Find(coverFilter))
+
+	// Matching docs: e1, e3 (active). e2/e4 must be rejected by the residual.
+	ids := writeOrderIterIds(t, coll.Find(coverFilter))
+	assert.ElementsMatch(t, []int{1, 3}, ids)
+
+	count, err := coll.Find(coverFilter).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCoverLookupResidualFilter_DeleteRemovesOnlyMatching(t *testing.T) {
+	coll := coverLookupColl(t)
+	requireCoverLookup(t, coll, coll.Find(coverFilter))
+
+	res, err := coll.Find(coverFilter).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Modified)
+
+	survivors := writeOrderSurvivors(t, coll)
+	assert.Contains(t, survivors, 2, "inactive doc must survive a filtered delete")
+	assert.Contains(t, survivors, 4, "inactive doc must survive a filtered delete")
+	assert.NotContains(t, survivors, 1)
+	assert.NotContains(t, survivors, 3)
+}
+
+func TestCoverLookupSort_OrdersByDocumentNotStaleCache(t *testing.T) {
+	coll := coverLookupColl(t)
+	q := coll.Find(`{"email":{"$in":["e1","e3","e5"]}}`).Sort("rank")
+	requireCoverLookup(t, coll, q)
+
+	// rank: e1→6, e3→4, e5→2; ascending rank → ids [5, 3, 1].
+	ids := writeOrderIterIds(t, coll.Find(`{"email":{"$in":["e1","e3","e5"]}}`).Sort("rank"))
+	assert.Equal(t, []int{5, 3, 1}, ids)
+}
+
+func TestCoverLookupSingleBound_Unaffected(t *testing.T) {
+	// Control: one bound means no previous row to leak from.
+	coll := coverLookupColl(t)
+	ids := writeOrderIterIds(t, coll.Find(`{"email":"e2","active":true}`))
+	assert.Empty(t, ids)
+	ids = writeOrderIterIds(t, coll.Find(`{"email":"e1","active":true}`))
+	assert.Equal(t, []int{1}, ids)
+}
+
+func TestCoverLookupIterDoc_ReturnsOwnDocument(t *testing.T) {
+	coll := coverLookupColl(t)
+	it, err := coll.Find(`{"email":{"$in":["e1","e3"]}}`).Iter(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, it.Close()) }()
+	var emails []string
+	for it.Next() {
+		doc, err := it.Doc()
+		require.NoError(t, err)
+		emails = append(emails, doc.Value().GetString("email"))
+	}
+	require.NoError(t, it.Err())
+	assert.True(t, strings.HasPrefix(emails[0], "e"), "sanity")
+	assert.ElementsMatch(t, []string{"e1", "e3"}, emails)
+}

--- a/query_reverse_bounds_test.go
+++ b/query_reverse_bounds_test.go
@@ -1,0 +1,154 @@
+package anystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// A reverse-declared index field stores bitwise-inverted encodings, and anyenc
+// strings are prefix-free EXCEPT across the NUL escape: enc("a") is a
+// byte-prefix of enc("a\x00b"), and inversion preserves that relation. The
+// escape-continuation group therefore sorts BELOW the base value's own entries
+// in stored space, so multi-bound lists ($in, $or of equalities) must be
+// walked with the longer inverted Start first — a plain byte sort of bare
+// Starts emits whole runs out of order. With ExactSort claimed (no SortIter to
+// repair it) the wrong ORDER selects the wrong DOCUMENTS under Limit, and on
+// compound indexes an unpadded concatenated Start additionally overlaps the
+// continuation group's range: duplicate rows, double-applied modifiers,
+// ErrDocNotFound on delete.
+
+func requireIndexOrderedPlan(t *testing.T, q Query, indexName string) {
+	t.Helper()
+	ex, err := q.Explain(ctx)
+	require.NoError(t, err)
+	require.Contains(t, ex.Sql, indexName, "test premise: index must drive the plan\nplan: %s", ex.Sql)
+	require.NotContains(t, ex.Sql, "Sort", "test premise: order must come from the index walk, not a SortIter\nplan: %s", ex.Sql)
+	require.NotContains(t, ex.Sql, "TopK", "test premise: order must come from the index walk, not a TopK\nplan: %s", ex.Sql)
+}
+
+func TestReverseIndexNulFamily_InSortedBothDirections(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "rev_family")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "v", Fields: []string{"-v"}}))
+	for _, d := range []string{
+		`{"id":1,"v":"a"}`,
+		`{"id":2,"v":"a\u0000b"}`,
+		`{"id":3,"v":"b"}`,
+	} {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	const filter = `{"v":{"$in":["a","a\u0000b","b"]}}`
+	hint := IndexHint{IndexName: "v", Boost: 1_000_000}
+
+	asc := coll.Find(filter).IndexHint(hint).Sort("v")
+	requireIndexOrderedPlan(t, asc, "v")
+	assert.Equal(t, []int{1, 2, 3}, writeOrderIterIds(t, coll.Find(filter).IndexHint(hint).Sort("v")),
+		`ascending: "a" < "a\x00b" < "b"`)
+
+	assert.Equal(t, []int{3, 2, 1}, writeOrderIterIds(t, coll.Find(filter).IndexHint(hint).Sort("-v")),
+		"descending is the exact mirror")
+}
+
+func TestReverseIndexNulFamily_LimitSelectsSortHead(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "rev_limit")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "u", Fields: []string{"-u"}, Unique: true}))
+	for _, d := range []string{
+		`{"id":1,"u":"u7","n":0}`,
+		`{"id":2,"u":"u7\u0000z","n":0}`,
+		`{"id":3,"u":"u10\u0000z","n":0}`,
+	} {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	const filter = `{"u":{"$in":["u7","u7\u0000z","u10\u0000z"]}}`
+
+	// Ascending u: "u10\x00z" < "u7" < "u7\x00z" → the 2-head is ids [3, 1].
+	got := writeOrderIterIds(t, coll.Find(filter).Sort("u").Limit(2))
+	assert.Equal(t, []int{3, 1}, got)
+
+	// The bounded sorted write must touch exactly that head.
+	res, err := coll.Find(filter).Sort("u").Limit(2).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Modified)
+	touched := writeOrderIterIds(t, coll.Find(`{"n":1}`))
+	assert.ElementsMatch(t, []int{3, 1}, touched)
+}
+
+func TestReverseLeadCompound_NulFamilyOpenRange_NoDuplicates(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "rev_compound")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ab", Fields: []string{"-a", "b"}}))
+	for _, d := range []string{
+		`{"id":1,"a":"y","b":1,"n":0}`,
+		`{"id":2,"a":"y\u0000z","b":2,"n":0}`,
+		`{"id":3,"a":"y\u0000z","b":3,"n":0}`,
+	} {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	const filter = `{"a":{"$in":["y","y\u0000z"]},"b":{"$lte":5}}`
+	hint := IndexHint{IndexName: "ab", Boost: 1_000_000}
+
+	ids := writeOrderIterIds(t, coll.Find(filter).IndexHint(hint))
+	assert.ElementsMatch(t, []int{1, 2, 3}, ids, "each matching doc exactly once")
+
+	res, err := coll.Find(filter).IndexHint(hint).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Modified)
+	for _, id := range []int{1, 2, 3} {
+		doc, err := coll.FindId(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, 1, doc.Value().GetInt("n"), "doc %d: $inc exactly once", id)
+	}
+
+	_, err = coll.Find(filter).IndexHint(hint).Delete(ctx)
+	require.NoError(t, err, "duplicate ids in the delete set roll back the whole batch")
+}
+
+func TestReverseTailCompound_NulFamilyAfterEqualityPrefix(t *testing.T) {
+	// The shape unmasked by the equality-prefix ExactSort fix: {c,-a} now
+	// plans an index-ordered scan instead of falling back to FullScan+Sort.
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "rev_tail")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ca", Fields: []string{"c", "-a"}}))
+	for _, d := range []string{
+		`{"id":1,"c":1,"a":"y"}`,
+		`{"id":2,"c":1,"a":"y\u0000z"}`,
+		`{"id":3,"c":2,"a":"y"}`,
+	} {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	const filter = `{"c":1,"a":{"$in":["y","y\u0000z"]}}`
+	hint := IndexHint{IndexName: "ca", Boost: 1_000_000}
+
+	assert.ElementsMatch(t, []int{1, 2}, writeOrderIterIds(t, coll.Find(filter).IndexHint(hint)))
+	assert.Equal(t, []int{2, 1}, writeOrderIterIds(t, coll.Find(filter).IndexHint(hint).Sort("-a")),
+		`descending a: "y\x00z" > "y"`)
+	assert.Equal(t, []int{2}, writeOrderIterIds(t, coll.Find(filter).IndexHint(hint).Sort("-a").Limit(1)))
+}
+
+func TestReverseIndexGuards_NulFreeAndNumericUnaffected(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "rev_guards")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "v", Fields: []string{"-v"}}))
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "m", Fields: []string{"-m"}}))
+	for _, d := range []string{
+		`{"id":1,"v":"a","m":1}`,
+		`{"id":2,"v":"b","m":2}`,
+		`{"id":3,"v":"c","m":3}`,
+	} {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	assert.Equal(t, []int{1, 2, 3},
+		writeOrderIterIds(t, coll.Find(`{"v":{"$in":["a","b","c"]}}`).IndexHint(IndexHint{IndexName: "v", Boost: 1 << 20}).Sort("v")))
+	assert.Equal(t, []int{3, 2, 1},
+		writeOrderIterIds(t, coll.Find(`{"m":{"$in":[1,2,3]}}`).IndexHint(IndexHint{IndexName: "m", Boost: 1 << 20}).Sort("-m")))
+}

--- a/query_vector_verbs_test.go
+++ b/query_vector_verbs_test.go
@@ -107,3 +107,25 @@ func TestVectorClauseCount_MatchesIter(t *testing.T) {
 		})
 	}
 }
+
+func TestVectorClauseUnboundedWrite_Rejected(t *testing.T) {
+	// A vector clause denotes an ANN candidate window, not a predicate: an
+	// unbounded write must state its blast radius. Before the seam this call
+	// was a silent no-op (the clause degraded to a literal filter); executing
+	// the ANN plan unbounded would instead mutate the whole candidate set —
+	// both silently wrong, so it errors until $knn makes k part of the clause.
+	coll := vectorVerbColl(t)
+
+	_, err := coll.Find(vectorVerbClause).Delete(ctx)
+	require.ErrorIs(t, err, ErrVectorWriteWithoutLimit)
+	_, err = coll.Find(vectorVerbClause).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.ErrorIs(t, err, ErrVectorWriteWithoutLimit)
+
+	remaining, err := coll.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 20, remaining, "collection intact")
+
+	// Reads stay unbounded-legal.
+	ids := writeOrderIterIds(t, coll.Find(vectorVerbClause))
+	assert.NotEmpty(t, ids)
+}

--- a/query_vector_verbs_test.go
+++ b/query_vector_verbs_test.go
@@ -1,0 +1,94 @@
+package anystore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// A vector clause must denote the same document set on every verb. Before the
+// shared compiler, only Iter ran detectVectorQuery: a valid clause was a
+// silent no-op on Update/Delete (matched nothing as a literal filter), and an
+// invalid one degraded to a scalar comparison. Now the write verbs compile
+// through the same seam as Iter.
+
+func vectorVerbColl(t *testing.T) Collection {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "vec_verbs")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+		Name: "v", Kind: IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: 3, Metric: VectorL2, EfSearch: 64},
+	}))
+	for i := 0; i < 20; i++ {
+		doc := fmt.Sprintf(`{"id":%d,"v":[%d,1,2],"n":0}`, i, i)
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(doc)))
+	}
+	return coll
+}
+
+const vectorVerbClause = `{"v":[3,1,2]}`
+
+func TestVectorClauseDelete_RemovesExactlyIterSelection(t *testing.T) {
+	coll := vectorVerbColl(t)
+
+	want := writeOrderIterIds(t, coll.Find(vectorVerbClause).Limit(5))
+	require.Len(t, want, 5, "test premise: the ANN query returns a bounded candidate set")
+
+	res, err := coll.Find(vectorVerbClause).Limit(5).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 5, res.Modified, "a valid vector clause must not be a silent no-op on Delete")
+
+	survivors := writeOrderSurvivors(t, coll)
+	for _, id := range want {
+		assert.NotContains(t, survivors, id, "doc %d was in Iter's selection and must be deleted", id)
+	}
+	assert.Len(t, survivors, 15)
+}
+
+func TestVectorClauseUpdate_ModifiesExactlyIterSelection(t *testing.T) {
+	coll := vectorVerbColl(t)
+
+	want := writeOrderIterIds(t, coll.Find(vectorVerbClause).Limit(4))
+	require.Len(t, want, 4)
+
+	res, err := coll.Find(vectorVerbClause).Limit(4).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 4, res.Modified, "a valid vector clause must not be a silent no-op on Update")
+
+	touched := writeOrderIterIds(t, coll.Find(`{"n":1}`))
+	assert.ElementsMatch(t, want, touched)
+}
+
+func TestVectorClauseInvalid_WriteVerbsAgreeWithIter(t *testing.T) {
+	// Whatever Iter decides about a malformed vector query — reject or treat
+	// as an ordinary (never-matching) filter — the write verbs must decide
+	// identically, and the collection must stay intact either way.
+	coll := vectorVerbColl(t)
+	for _, cond := range []string{
+		`{"v":{"$gt":1}}`,
+		`{"v":[1,2]}`, // wrong dimension
+	} {
+		iterOK := true
+		if it, ierr := coll.Find(cond).Iter(ctx); ierr != nil {
+			iterOK = false
+		} else {
+			require.NoError(t, it.Close())
+		}
+
+		res, derr := coll.Find(cond).Delete(ctx)
+		assert.Equal(t, iterOK, derr == nil,
+			"cond=%s: Delete's accept/reject decision must match Iter's (iterOK=%v, deleteErr=%v)", cond, iterOK, derr)
+		if derr == nil {
+			assert.Zero(t, res.Modified, "cond=%s matches no documents", cond)
+		}
+
+		remaining, err := coll.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 20, remaining, "cond=%s: collection must be intact", cond)
+	}
+}

--- a/query_vector_verbs_test.go
+++ b/query_vector_verbs_test.go
@@ -92,3 +92,18 @@ func TestVectorClauseInvalid_WriteVerbsAgreeWithIter(t *testing.T) {
 		assert.Equal(t, 20, remaining, "cond=%s: collection must be intact", cond)
 	}
 }
+
+func TestVectorClauseCount_MatchesIter(t *testing.T) {
+	coll := vectorVerbColl(t)
+	for name, q := range map[string]func() Query{
+		"plain": func() Query { return coll.Find(vectorVerbClause) },
+		"limit": func() Query { return coll.Find(vectorVerbClause).Limit(5) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			ids := writeOrderIterIds(t, q())
+			count, err := q().Count(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, len(ids), count, "Count and Iter must denote the same set")
+		})
+	}
+}

--- a/query_write_order_test.go
+++ b/query_write_order_test.go
@@ -126,3 +126,23 @@ func TestCollQuery_UnsortedLimitWrite_CardinalityOnly(t *testing.T) {
 	assert.Equal(t, 4, res.Modified)
 	assert.Len(t, writeOrderSurvivors(t, coll), 6)
 }
+
+func TestUnboundedSortedWrite_TouchesFullMatchedSet(t *testing.T) {
+	// With no Limit/Offset the selected set is order-invariant, so the write
+	// plans WITHOUT the sorter (no materialize-and-sort inside the write tx)
+	// and must still touch every matching document exactly once.
+	coll := writeOrderColl(t, 10)
+
+	res, err := coll.Find(`{"seq":{"$gte":4}}`).Sort("-seq").
+		Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 7, res.Modified, "seq 4..10 = 7 docs")
+
+	touched := writeOrderIterIds(t, coll.Find(`{"n":1}`))
+	assert.Len(t, touched, 7)
+
+	res, err = coll.Find(nil).Sort("seq").Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 10, res.Modified)
+	assert.Empty(t, writeOrderSurvivors(t, coll))
+}

--- a/query_write_order_test.go
+++ b/query_write_order_test.go
@@ -1,0 +1,128 @@
+package anystore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// A Limit/Offset window on a write verb must select the documents in the
+// query's sort order — the exact set the equivalent Iter yields — not in
+// whatever order the chosen plan happens to scan.
+
+func writeOrderColl(t *testing.T, n int) Collection {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "write_order")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "seq", Fields: []string{"seq"}}))
+	// seq is a shuffled permutation of 1..n (i*7 mod 11, n=10) so that NEITHER
+	// sort direction coincides with any plan's natural scan order (pk or
+	// insertion) — every case below is order-sensitive.
+	require.Equal(t, 10, n, "seq permutation below assumes n=10")
+	for i := 1; i <= n; i++ {
+		require.NoError(t, coll.Insert(ctx,
+			anyenc.MustParseJson(fmt.Sprintf(`{"id":%d,"seq":%d,"n":0}`, i, i*7%11))))
+	}
+	return coll
+}
+
+func writeOrderIterIds(t *testing.T, q Query) []int {
+	it, err := q.Iter(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, it.Close()) }()
+	var ids []int
+	for it.Next() {
+		doc, err := it.Doc()
+		require.NoError(t, err)
+		ids = append(ids, doc.Value().GetInt("id"))
+	}
+	require.NoError(t, it.Err())
+	return ids
+}
+
+func writeOrderSurvivors(t *testing.T, coll Collection) map[int]struct{} {
+	ids := map[int]struct{}{}
+	for _, id := range writeOrderIterIds(t, coll.Find(nil)) {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
+func TestCollQuery_SortLimitDelete_RemovesSameDocsAsIter(t *testing.T) {
+	// Retention shape: "delete the 3 oldest". The docs Iter selects under the
+	// same sort+limit are the only ones Delete may remove.
+	coll := writeOrderColl(t, 10)
+
+	wantGone := writeOrderIterIds(t, coll.Find(nil).Sort("seq").Limit(3))
+	require.Equal(t, []int{8, 5, 2}, wantGone)
+
+	res, err := coll.Find(nil).Sort("seq").Limit(3).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Modified)
+
+	survivors := writeOrderSurvivors(t, coll)
+	for _, id := range wantGone {
+		assert.NotContains(t, survivors, id, "doc %d should have been deleted", id)
+	}
+	assert.Len(t, survivors, 7)
+}
+
+func TestCollQuery_SortDescLimitDelete_RemovesNewest(t *testing.T) {
+	coll := writeOrderColl(t, 10)
+
+	res, err := coll.Find(nil).Sort("-seq").Limit(2).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Modified)
+
+	// -seq: highest seq values are 10 (id 3) and 9 (id 6).
+	survivors := writeOrderSurvivors(t, coll)
+	assert.NotContains(t, survivors, 3)
+	assert.NotContains(t, survivors, 6)
+	assert.Contains(t, survivors, 8)
+}
+
+func TestCollQuery_SortLimitUpdate_ModifiesSameDocsAsIter(t *testing.T) {
+	coll := writeOrderColl(t, 10)
+
+	wantTouched := writeOrderIterIds(t, coll.Find(nil).Sort("-seq").Limit(3))
+	require.Equal(t, []int{3, 6, 9}, wantTouched)
+
+	res, err := coll.Find(nil).Sort("-seq").Limit(3).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Modified)
+
+	touched := writeOrderIterIds(t, coll.Find(`{"n":1}`))
+	assert.ElementsMatch(t, wantTouched, touched)
+}
+
+func TestCollQuery_SortOffsetDelete_SkipsSameDocsAsIter(t *testing.T) {
+	coll := writeOrderColl(t, 10)
+
+	wantGone := writeOrderIterIds(t, coll.Find(nil).Sort("seq").Offset(7))
+	require.Equal(t, []int{9, 6, 3}, wantGone)
+
+	res, err := coll.Find(nil).Sort("seq").Offset(7).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Modified)
+
+	survivors := writeOrderSurvivors(t, coll)
+	for _, id := range wantGone {
+		assert.NotContains(t, survivors, id)
+	}
+	assert.Len(t, survivors, 7)
+}
+
+func TestCollQuery_UnsortedLimitWrite_CardinalityOnly(t *testing.T) {
+	// Guard against over-reach: with no sort, a bounded write promises only
+	// HOW MANY documents it touches, not which ones.
+	coll := writeOrderColl(t, 10)
+
+	res, err := coll.Find(nil).Limit(4).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 4, res.Modified)
+	assert.Len(t, writeOrderSurvivors(t, coll), 6)
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -538,6 +538,14 @@ var ErrMultipleVectorClauses = errors.New("any-store: query has multiple vector 
 // the index's dimension, e.g. {embedding: [..dim floats..]}.
 var ErrInvalidVectorQuery = errors.New("any-store: invalid vector query clause")
 
+// ErrVectorWriteWithoutLimit rejects an Update/Delete whose filter is a vector
+// clause but which carries no Limit. A vector clause denotes an ANN candidate
+// WINDOW (its size depends on tunable search parameters), not a predicate — an
+// unbounded write would mutate however many candidates the search happens to
+// yield. State the blast radius with .Limit(k); the planned $knn operator
+// moves k into the clause itself.
+var ErrVectorWriteWithoutLimit = errors.New("any-store: a vector-clause Update/Delete requires an explicit Limit")
+
 // ErrDistanceWithoutVector is returned when the synthetic _distance field is used
 // in a filter or sort but the query has no vector clause to produce it.
 var ErrDistanceWithoutVector = errors.New("any-store: _distance is only available in a vector query")


### PR DESCRIPTION
Two stages on one branch, every commit separable and green on the full suite plus the any-store-tests differential fuzz.

## Stage 1 — four point fixes (verbs must select the same documents)

1. **Bounded writes select documents in sort order** (79100fe). Update/Delete built PlanParams without the Sorter while keeping Limit/Offset — a retention delete could remove the newest rows instead of the oldest (1277/1650 fuzz mismatches). Fix: forward `q.sort` in both write paths; Count keeps `Sorter: nil` (order-invariant). Matches SQLite's single WHERE/ORDER BY generator.
2. **FilterIter must not evaluate the previous row's document** (a667e8f). `Plan.DocParsed` was cleared only on rejection; on the CoverLookup chain (no FetchIter to repopulate) the residual filter evaluated the previous row's doc from the second bound on — over-counts, deletes of excluded docs, stale Sort/Doc(). Fix: clear at loop top.
3. **Overlapping compound-tuple bounds coalesced** (3fa8a2a). anyenc strings are not prefix-free across the NUL escape, so compound concatenation + an open follower bound made ranges overlap: duplicate rows, double `$inc`, `ErrDocNotFound` rolling back whole Delete batches. Fix: `MergeOverlappingBounds` (hull, widening-only), gated to compound chains.
4. **Reverse-field bounds walk in stored-key order** (ea7e4bb). Inversion preserves the NUL-escape prefix relation; the continuation group sorts BELOW the base value, so plain byte sort emitted multi-bound lists out of order (wrong docs under Limit, ExactSort claimed). Fix: `compareInvertedStart` + a `0x01` pad on the bare open-Start concatenation; the merge from (3) moved after `padBoundsForReverseTail`.

## Stage 2 — the shared selection seam (the structural fix)

The four bugs above (and the BUG-32 family) all grew from the same duplication: five hand-copied `BuildPlan` literals and four DocDedup consumer loops, drifting independently. This branch ends that:

5. **`qplanner.ForEachDistinct` + `collectDistinctIDs`** (2fd57f0) — one distinct-doc consumer for the batch verbs; `planIterator.Next` cross-referenced as its streaming twin.
6. **`compilePlan`** (c970f2a) — the single query compiler: $text detection, vector detection, CBO assembly. Per-verb variation confined to `planOpts{countOnly, needScores, exactTotalDocs, wantCandidates}`. Iter ported first, byte-identical PlanParams (it is the fuzz's reference).
7. **Update/Delete ported** (49c4e5d) — write verbs inherit vector detection: a valid vector clause is ANN-driven (id-set == Iter's; previously a silent no-op), a malformed one gets Iter's accept/reject decision.
8. **Count ported** (c6eb81b) — pre-plan fast paths untouched (page-header, unsatisfiable, Has-probe); sink factored into `countPlanRoot` (CountDistinct → CountEntries → generic). The $text count-via-public-Iter detour is deleted (native FTS count plan, strictly cheaper); vector Count goes native. `Count == len(Iter)` pinned for $text and vector across limit/offset/residual windows.
9. **Explain ported; `ftsScanPlan` deleted** (e82e73b) — vector queries explained as their real ANN plan; the index report never silently shrinks; "Explain is not a witness for the write path" is no longer true.
10. **$text read-your-writes inside a write tx** (c2f33fa) — compilePlan's FTS branch flushes the ambient write tx's pending postings (the same flush the savepoint path performs), so Count/Iter/Update/Delete all see the tx's own uncommitted $text writes; rollback still discards them. Previously documented as undefined behavior.

## Verification

- Every fix red-test-verified in-repo (write-order, coverlookup-filter, compound-bounds, reverse-bounds, vector-verbs, fts-count-parity, fts-read-your-writes suites), with Explain guards pinning the plan shapes the bugs need.
- `go test ./... -short`: green (18 packages); `-race` clean on the touched fts/query paths.
- any-store-tests differential fuzz green; the known-open registry is down to the two deferred design-pass families (compound-multikey dedup 24/25, $in-null 27). The retired entries and the write-plan attribution model update are in anyproto/any-store-tests@7a662dd..d0eec7a.
- benchstat vs origin/btree (Find/InQuery/count benches): time ±noise, B/op −26% on filtered counts (the deleted $text detour and Count literal).

Next (separate PR, on top of this): the `$knn` operator — BUG-32 Increment 2, decided design in `docs/plans/2026-07-13-bug32-knn-operator.md`; with the seam it is a one-function change in the detection internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)