### PR TITLE
feat!: the $knn operator — one vector query, one denoted set, six verbs (BUG-32 Increment 2 + 1c)

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -109,9 +109,13 @@ func (q *aggQuery) prefixQuery() (*collQuery, aggregate.Pipeline, error) {
 //     done by the FTS scan that the planner builds), so a $match with $text
 //     that did not reach the access planner would match every row instead of
 //     searching.
-//   - a vector (ANN) clause — an equality against a dim-sized numeric array
-//     on a vector-indexed field, exactly the shape detectVectorQuery turns
-//     into an ANN search — would degrade to a literal array comparison.
+//   - query.Knn is a ranked source, not a predicate (Ok fails closed), so a
+//     $match with $knn that did not reach the access planner would match no
+//     row instead of searching.
+//   - a legacy bare-array ANN clause degrades to a literal array comparison
+//     here (0 rows on packed storage); it is a hard error on every path, and
+//     an in-pipeline $match — which compilePlan's guard never sees, because
+//     only the pushdown prefix reaches the compiler — must reject it itself.
 func (q *aggQuery) validateInPipelineStages(rest aggregate.Pipeline) error {
 	var (
 		vidxs  []*vectorIndex
@@ -125,51 +129,22 @@ func (q *aggQuery) validateInPipelineStages(rest aggregate.Pipeline) error {
 		if containsText(m.Filter) {
 			return errAggTextNotInPrefix
 		}
+		if query.ContainsKnn(m.Filter) {
+			return errAggVectorNotInPrefix
+		}
 		if !loaded {
 			vidxs, loaded = q.c.loadVectorIndexes(), true
 		}
-		if len(vidxs) > 0 && hasVectorClause(m.Filter, vidxs) {
-			return errAggVectorNotInPrefix
+		if err := rejectLegacyVectorClause(m.Filter, vidxs); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-// hasVectorClause mirrors detectVectorQuery's clause detection — a top-level
-// (or direct $and member) equality on a vector-indexed field whose value is a
-// valid dim-sized numeric array. Anything else on such a field stays a plain
-// literal comparison, exactly like Find's residual filters.
-func hasVectorClause(f query.Filter, vidxs []*vectorIndex) bool {
-	var clauses []query.Filter
-	switch ft := f.(type) {
-	case query.And:
-		clauses = ft
-	default:
-		clauses = []query.Filter{f}
-	}
-	for _, cl := range clauses {
-		k, isKey := cl.(query.Key)
-		if !isKey {
-			continue
-		}
-		vi := findVectorIndexByField(vidxs, strings.Join(k.Path, "."))
-		if vi == nil {
-			continue
-		}
-		comp, isComp := k.Filter.(*query.Comp)
-		if !isComp || comp.CompOp != query.CompOpEq {
-			continue
-		}
-		if _, err := decodeVectorValue(comp.EqValue, vi.dim); err == nil {
-			return true
-		}
-	}
-	return false
-}
-
 var (
 	errAggTextNotInPrefix   = errors.New("any-store: aggregate: $text is only supported in the leading $match stages (the pushdown prefix)")
-	errAggVectorNotInPrefix = errors.New("any-store: aggregate: a vector (ANN) clause is only supported in the leading $match stages (the pushdown prefix)")
+	errAggVectorNotInPrefix = errors.New("any-store: aggregate: a vector ($knn) clause is only supported in the leading $match stages (the pushdown prefix)")
 )
 
 func (q *aggQuery) Iter(ctx context.Context) (Iterator, error) {

--- a/anyenc/type.go
+++ b/anyenc/type.go
@@ -20,8 +20,11 @@ const (
 	TypeCompressedObjectS2 = Type(9)
 	// TypeVectorF32 stores a packed little-endian []float32 embedding as a single
 	// length-prefixed blob (4 bytes/dim) instead of a generic number array — far
-	// smaller on disk and decoded zero-copy. Vectors are not orderable, so they
-	// never appear in range/sort index keys (no inverted form needed).
+	// smaller on disk and decoded zero-copy. Vectors are not orderable (query
+	// Rule V: ordering ops against one are always false), but they DO appear in
+	// range/sort index keys — an index on a vector-valued field marshals the
+	// value into the key, and a descending index stores the inverted form (see
+	// iTypeVectorF32 below).
 	TypeVectorF32 = Type(10)
 	// TypeObjectID stores a 12-byte ObjectID as a fixed-width, memcmp-orderable
 	// value: the tag followed by the 12 raw big-endian bytes (no length prefix),

--- a/cmd/any-store-cli2/commands.js
+++ b/cmd/any-store-cli2/commands.js
@@ -16,6 +16,22 @@ function Vector(values) {
     return {"$vector": values};
 }
 
+// Knn builds the $knn ANN clause for a vector-indexed field:
+//   db.docs.find({emb: Knn([0.1, 0.2], 10)})
+//   db.docs.find({emb: Knn(vec, 10, {ef: 200, index: "emb"})})
+// A bare Vector([...]) equality on a vector-indexed field is no longer an ANN
+// query (it errors, ErrLegacyVectorClause) — the k must be stated.
+function Knn(queryVec, k, opts) {
+    const clause = {"$query": queryVec, "$k": k};
+    if (opts && opts.ef !== undefined) {
+        clause["$ef"] = opts.ef;
+    }
+    if (opts && opts.index !== undefined) {
+        clause["$index"] = opts.index;
+    }
+    return {"$knn": clause};
+}
+
 function DB() {}
 
 DB.prototype.createCollection = function (name) {

--- a/collection_rename_lifecycle_test.go
+++ b/collection_rename_lifecycle_test.go
@@ -219,7 +219,7 @@ func TestRename_AllIndexKindsSurviveReopen(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, cnt, "fts index")
 	// Vector: nearest neighbour of [1,0,0,0] is doc 1.
-	iter, err := reopened.Find(`{"v":[1,0,0,0]}`).Limit(1).Iter(ctx)
+	iter, err := reopened.Find(`{"v":{"$knn":{"$query":[1,0,0,0],"$k":1}}}`).Iter(ctx)
 	require.NoError(t, err)
 	require.True(t, iter.Next(), "vector index returned no hits")
 	doc, err := iter.Doc()

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -30,7 +30,7 @@ any JSON-marshalable Go value.
 
 | Stage | Form | Notes |
 |---|---|---|
-| `$match` | `{"$match": <filter>}` | The full `Find()` filter language, including `$text` and vector clauses. |
+| `$match` | `{"$match": <filter>}` | The full `Find()` filter language, including `$text` and `$knn` clauses. |
 | `$sort` | `{"$sort": {"a": 1, "b.c": -1}}` | 1 ascending, -1 descending; anyenc value order across types; missing sorts as null. Stable. |
 | `$skip` / `$limit` | `{"$skip": 10}` / `{"$limit": 5}` | |
 | `$count` | `{"$count": "n"}` | Terminal: emits the single document `{"n": <count>}`. |
@@ -48,7 +48,7 @@ can be added compatibly later.
 
 Inside `$project`/`$addFields` values, `$group` keys and accumulator arguments:
 
-- **Field references** — `"$a.b.c"` (dot paths into the document; FTS/vector
+- **Field references** — `"$a.b.c"` (dot paths into the document; FTS/$knn
   virtual fields work too: `"$_score"`, `"$_distance"`).
 - **Literals** — any non-`$` value; `{"$literal": "$kept-verbatim"}` escapes a
   literal that starts with `$`.
@@ -95,8 +95,10 @@ hands it to the regular query planner. That means:
 - an indexed `$match`+`$sort` prefix runs as an index seek/scan with
   index-order sorting and cursor-level offset skips, exactly like `Find()`;
 - a `$match` containing `$text` makes the BM25 search drive the pipeline
-  source (`_score` available downstream), a vector clause makes the ANN index
-  drive it (`_distance` available downstream);
+  source (`_score` available downstream), a `$knn` clause makes the ANN index
+  drive it (`_distance` available downstream). With `$k` in the clause, the
+  prefix denotes at most `$k` documents — downstream `$group`/`$count` stages
+  aggregate exactly that page, never a silently `ef`-truncated stream;
 - `{"$match": {"x": {"$in": []}}}` short-circuits to an empty source with no
   I/O.
 
@@ -105,12 +107,15 @@ or any out-of-canonical-order stage; the remainder runs in-pipeline. An
 in-pipeline `$sort` directly followed by `$skip`/`$limit` keeps only the top
 `skip+limit` rows (heap + packed arena, O(K) memory).
 
-`$text` and vector (ANN) clauses are valid **only inside the pushdown
-prefix** — they are executed by the index sources the planner builds, not by
-the streaming `$match` operator. A `$match` containing them after the prefix
-ends (e.g. after `$unwind`/`$group`, or preceded by `$skip`/`$limit`) fails
+`$text` and `$knn` clauses are valid **only inside the pushdown prefix** —
+they are executed by the index sources the planner builds, not by the
+streaming `$match` operator. A `$match` containing them after the prefix ends
+(e.g. after `$unwind`/`$group`, or preceded by `$skip`/`$limit`) fails
 `Iter`/`Count`/`Explain` with a descriptive error instead of silently
-matching everything ($text) or comparing arrays literally (vector).
+matching everything ($text) or matching nothing ($knn). The legacy bare-array
+ANN spelling is likewise rejected in-pipeline (`ErrLegacyVectorClause`). This
+is final: `AggQuery` has no `Delete`/`Update`, so the rejection costs
+expressiveness, never data.
 
 `AggQuery.Explain` shows the split:
 

--- a/docs/query-filter-contract.md
+++ b/docs/query-filter-contract.md
@@ -39,3 +39,36 @@ under `-race`), `TestFilterOkAllocFree`, and
 
 Note: the contract covers filters only. `Sort`/modifier values are cheap to
 build per query and carry no such guarantee.
+
+5. **Source filters do not evaluate.** `Text` and `Knn` are SOURCE filters:
+   matching is performed by an index scan the executor builds, not by `Ok`.
+   Their `Ok` is a fail-direction choice, not a predicate: `Text.Ok` returns
+   `true` unconditionally (fail-open), `Knn.Ok` returns `false` (fail-closed —
+   a leaked `$knn` must match nothing rather than everything, because the
+   query verbs include `Delete`). External consumers that post-filter by
+   calling `Filter.Ok` directly (the subscription pattern) MUST reject filters
+   containing either — detect them with `query.ContainsSourceFilter` (walks
+   the whole tree).
+
+6. **`TypeVectorF32` is not orderable (Rule V).** In `Comp`, an ordering op
+   (`$gt`/`$gte`/`$lt`/`$lte`) evaluates to `false` whenever either side is a
+   packed vector — including vector-vs-vector. `$eq` is byte equality, `$ne`
+   its negation. The parser additionally rejects an ordering op whose OPERAND
+   is a `$vector` literal (`ErrVectorNotOrderable`), which also keeps it out
+   of `$not`. Consequence (deliberate, Mongo-style type bracketing):
+   `{"v":{"$not":{"$gt":1}}}` matches a vector-valued `v` — `$not` of an
+   unsatisfiable comparison is true.
+
+7. **`$vector`, `$oid` and `$binary` are forbidden as option-key names**
+   inside any operator's options object. anyenc decodes a single-key
+   `{"$vector":[…]}` (et al.) object into a typed VALUE before the query
+   parser sees it, so an options object whose sole key were one of these
+   would change type depending on which other options are present. This is
+   why `$knn`'s payload key is `$query`.
+
+8. **A filter overriding `Ok`'s truth direction must be checked against
+   `GuaranteesPresence`.** It probes the inner filter's `Ok` directly
+   (`!Ok(nil) && !Ok(null)` ⇒ "guarantees presence") — a fail-closed `Ok`
+   reads as the AGGRESSIVE answer and feeds sparse-index selection. Source
+   filters get explicit `false` arms there; any future `Ok`-overriding filter
+   needs the same.

--- a/docs/query-filter-contract.md
+++ b/docs/query-filter-contract.md
@@ -50,6 +50,17 @@ build per query and carry no such guarantee.
    containing either — detect them with `query.ContainsSourceFilter` (walks
    the whole tree).
 
+   Corollary for CUSTOM `Filter` implementations: **never embed a source
+   filter inside one.** The detection/rejection walks descend only the
+   package's own node types (`And`/`Or`/`Nor`/`Not`/`Key`, value and pointer
+   forms alike) — a foreign type is structurally opaque, so an embedded `Knn`
+   silently matches nothing (fail-closed inherited through a pass-through
+   wrapper) and an embedded `Text` silently matches everything, on every
+   verb, `err == nil`. A custom filter that INVERTS its inner `Ok` reflects
+   fail-closed into match-all, exactly like `Not` would — that is arbitrary
+   user matching code, outside what any walk can guard. Pinned by
+   `TestKnn_InsideCustomFilterFailsClosed`.
+
 6. **`TypeVectorF32` is not orderable (Rule V).** In `Comp`, an ordering op
    (`$gt`/`$gte`/`$lt`/`$lte`) evaluates to `false` whenever either side is a
    packed vector — including vector-vs-vector. `$eq` is byte equality, `$ne`

--- a/docs/vector-engine.md
+++ b/docs/vector-engine.md
@@ -5,8 +5,8 @@
 any-store is an **embedded, btree-resident document store** (MVCC, WAL, crash-safe,
 multi-process-safe) with **built-in approximate-nearest-neighbour (ANN) vector
 search**. Embeddings live in ordinary documents and are queried through the normal
-`Find()` pipeline — a vector clause selects candidates, ordinary filters/sorts apply
-on top, and each result carries its `_distance`. There is no separate vector server
+`Find()` pipeline — a `$knn` clause selects the k nearest documents, ordinary
+filters/sorts apply on top, and each result carries its `_distance`. There is no separate vector server
 or in-memory index to manage: the index **lives in the same btree as the data**, so
 it inherits the store's durability, snapshot isolation, and cross-process semantics.
 

--- a/docs/vector-search.md
+++ b/docs/vector-search.md
@@ -2,16 +2,18 @@
 
 any-store has a built-in vector (embedding) index for approximate nearest-neighbour
 (ANN) search, implemented as a btree-resident HNSW graph. It integrates with the
-normal `Find()` query pipeline: a vector clause selects candidates, ordinary
-filters and sorting apply on top, and each result carries its distance to the
-query.
+normal `Find()` query pipeline: a `$knn` clause selects the k nearest documents,
+ordinary filters and sorting apply on top, and each result carries its distance
+to the query.
 
 - **Storage-resident** — the graph lives in the btree, so it's crash-safe,
   MVCC-consistent across readers, and multiprocess-safe for writes. No separate
   in-memory index to build or invalidate.
 - **Queried through `Find()`** — there is no separate search call; you express the
-  query as `Find({ <vectorField>: [...] })` and combine it with any other filter,
-  sort, limit, and offset.
+  query as `Find({ <vectorField>: {"$knn": {"$query": [...], "$k": 10}} })` and
+  combine it with any other filter, sort, limit, and offset. Every verb —
+  `Iter`, `Count`, `Update`, `Delete`, `Explain`, and an `Aggregate` `$match`
+  prefix — denotes the same k-bounded document set for the same query.
 
 ## 1. Create a vector index
 
@@ -96,22 +98,66 @@ across documents and call `arena.Reset()` between batches to avoid allocations.
 Inserts are batched: pass many documents to one `Insert(...)` call so they share a
 single transaction.
 
-## 3. Query
+## 3. Query: the `$knn` operator
 
-A query becomes a vector search when a top-level clause is an equality between a
-**vector-indexed field** and a `Dim`-sized array:
-
-```go
-// k nearest neighbours, closest first (the default order).
-iter, err := coll.Find(`{"embedding":[0.1, 0.2, ...]}`).Limit(10).Iter(ctx)
-```
-
-Everything else in the filter is applied as a normal predicate on the candidates:
+A query becomes a vector search when a **vector-indexed field** carries a `$knn`
+clause:
 
 ```go
-// ANN + ordinary filters.
-coll.Find(`{"embedding":[...], "lang":"en", "year":{"$gt":2020}}`).Limit(10).Iter(ctx)
+// The 10 nearest neighbours, closest first (the default order).
+iter, err := coll.Find(`{"embedding":{"$knn":{"$query":[0.1, 0.2, ...], "$k":10}}}`).Iter(ctx)
 ```
+
+`$knn` takes an options object — this is the only accepted form:
+
+| Option | | |
+|---|---|---|
+| `$query` | **required** | the query vector: a plain number array or a packed `{"$vector":[...]}` value |
+| `$k` | **required** | how many neighbours to select, `1..10000` |
+| `$ef` | optional | ANN candidate/beam depth (`numCandidates`), `$k..65536`; default auto-sizes from the index and over-fetches ×10 when a residual filter is present |
+| `$index` | optional | vector index name — required only when the field has more than one vector index |
+
+Programmatic consumers build the clause with `query.NewKnn(vec, k, opts...)`
+wrapped in a `query.Key` naming the field — no JSON involved:
+
+```go
+filter := query.Key{Path: []string{"embedding"}, Filter: query.NewKnn(vec, 10)}
+iter, err := coll.Find(filter).Iter(ctx)
+```
+
+Everything else in the filter is applied as a residual predicate **before** the
+k-cut — the query denotes the k nearest *matching* documents (hybrid search):
+
+```go
+// ANN + ordinary filters: the 10 nearest docs among those matching lang/year.
+coll.Find(`{"embedding":{"$knn":{"$query":[...], "$k":10}}, "lang":"en", "year":{"$gt":2020}}`).Iter(ctx)
+```
+
+### `$knn` is a ranked source, not a predicate
+
+"Is this document one of the k nearest?" is a property of the whole candidate
+set, not of a document, so `$knn` does not behave like a predicate:
+
+- **`$k` selects. `Sort` orders. `Limit` paginates.** The clause denotes at most
+  `$k` documents; `Sort` reorders that set; `Limit`/`Offset` page within it.
+  `Limit(20)` over `"$k":10` returns 10 rows; `Offset` at or past `$k` returns
+  none.
+- **`Count` returns the size of that page** (≤ `$k`) — not "how many documents
+  match", because `$knn` has no match set.
+- **`Delete`/`Update` mutate exactly the k nearest** — the blast radius is `$k`,
+  a number you typed. "Delete everything near X" is unrepresentable.
+- **The result is approximate** (recall < 1) except in brute-force mode. With a
+  selective residual filter you may get fewer than `$k` rows; the escape valve
+  is raising `$ef` (or `$k`).
+- **The set is not stable across index churn** (compaction, tombstones, a
+  different `$ef`). For exact determinism use brute-force mode, or collect ids
+  from `Iter` and act by id.
+- `$knn` is legal at the top level or under `$and` (any depth), once per query.
+  `$or`/`$nor`/`$not`, a second `$knn`, or combining with `$text` are errors.
+
+Non-`$knn` operators on a vector-indexed field (`$exists`, `$type`, `$eq`
+against a packed `{"$vector":[...]}` value, `$size`, …) stay **ordinary
+filters** on every verb.
 
 ### Distance: the `_distance` field
 
@@ -126,38 +172,40 @@ for iter.Next() {
     _ = doc; _ = d
 }
 
-// Filter by a distance threshold:
-coll.Find(`{"embedding":[...], "_distance":{"$lt":0.35}}`).Iter(ctx)
+// Filter by a distance threshold — note this is a threshold WITHIN the k
+// nearest (a residual filter over the $knn candidates), NOT "all documents
+// within 0.35": there is no radius search at any layer.
+coll.Find(`{"embedding":{"$knn":{"$query":[...], "$k":100}}, "_distance":{"$lt":0.35}}`).Iter(ctx)
 
 // Sort by distance (ascending is the default when no Sort is given):
-coll.Find(`{"embedding":[...]}`).Sort("_distance").Iter(ctx)        // closest first
-coll.Find(`{"embedding":[...]}`).Sort("-_distance").Iter(ctx)       // farthest first
+coll.Find(`{"embedding":{"$knn":{...}}}`).Sort("_distance").Iter(ctx)   // closest first
+coll.Find(`{"embedding":{"$knn":{...}}}`).Sort("-_distance").Iter(ctx)  // farthest first
 
 // Multi-key sort: distance, then a tie-breaker field:
-coll.Find(`{"a":{"$gt":42}, "embedding":[...]}`).Sort("_distance", "-name").Iter(ctx)
+coll.Find(`{"a":{"$gt":42}, "embedding":{"$knn":{...}}}`).Sort("_distance", "-name").Iter(ctx)
 ```
 
 `Iterator.Distance()` returns the row's distance (0 for non-vector queries).
 
 `_distance` is a reserved synthetic field: on a vector query it is injected into
 each result (shadowing any stored field of that name), and referencing it in a
-filter or sort *without* a vector clause is an error (`ErrDistanceWithoutVector`).
+filter or sort *without* a `$knn` clause is an error (`ErrDistanceWithoutVector`).
 
 ### Limit, offset, and candidate set size
 
-`Limit`/`Offset` apply over the distance-ordered results. The ANN candidate list
-is auto-sized to cover `Offset+Limit`, and over-fetched further when a residual
-filter is selective so the page still fills. `VectorEf(n)` overrides the
-candidate-list size (recall/speed trade-off):
+`Limit`/`Offset` paginate over the (sorted) k-set — they never change *which*
+documents `$knn` denotes. The ANN candidate list (`ef`) is a pure function of
+the clause: the index default, raised to `$k` (over-fetched ×10 when a residual
+filter is present, capped at ~4096 but never below `$k`). An explicit `$ef` is
+used verbatim and never capped:
 
 ```go
-coll.Find(`{"embedding":[...], "lang":"en"}`).Limit(20).VectorEf(200).Iter(ctx)
+coll.Find(`{"embedding":{"$knn":{"$query":[...], "$k":20, "$ef":200}}, "lang":"en"}`).Iter(ctx)
 ```
 
-The auto-sized candidate list is capped (~4096) to bound a runaway search, so very
-deep pagination (`Offset+Limit` beyond that) or a very large `Limit` returns fewer
-rows than requested unless you set `VectorEf(n)` explicitly — an explicit `VectorEf`
-is never capped.
+Because `ef` never depends on `Limit`/`Offset`/`Sort` or the verb, every verb
+walks the same beam and denotes the same set — `Count == len(Iter)` by
+construction.
 
 ## 4. Errors for malformed queries
 
@@ -165,10 +213,20 @@ Mistakes are reported rather than silently returning wrong results:
 
 | Query | Error |
 |---|---|
-| Wrong-dimension array on a vector field — `{"embedding":[1,2,3]}` (dim 768) | `ErrInvalidVectorQuery` |
-| Non-array / non-equality on a vector field — `{"embedding":"x"}`, `{"embedding":{"$gt":[...]}}` | `ErrInvalidVectorQuery` |
-| Two vector clauses in one query | `ErrMultipleVectorClauses` |
-| `_distance` in a filter or sort with no vector clause | `ErrDistanceWithoutVector` |
+| The pre-`$knn` spelling: a bare `Dim`-sized array equality on a vector-indexed field — `{"embedding":[...768 floats...]}` | `ErrLegacyVectorClause` |
+| Malformed `$knn`: wrong-dimension / empty / non-finite `$query`, out-of-range `$k` or `$ef` | `ErrInvalidVectorQuery` |
+| `$knn` on a field with no vector index (or `$index` names none) | `ErrNoVectorIndex` |
+| `$knn` on a field with several vector indexes and no `$index` | `ErrAmbiguousVectorIndex` |
+| `$knn` under `$or`/`$nor`/`$not`, nested, bare, or unstrippable | `ErrKnnBadPlacement` |
+| `$knn` and `$text` in one query | `ErrKnnWithText` |
+| Two `$knn` clauses in one query | `ErrMultipleVectorClauses` |
+| `_distance` in a filter or sort with no `$knn` clause | `ErrDistanceWithoutVector` |
+
+All of these fire identically on every verb (`Iter`/`Count`/`Update`/`Delete`/
+`Explain`/`Aggregate`), for JSON and programmatically-built filters alike.
+Ordinary predicates on a vector field are NOT errors — `{"embedding":"x"}` or a
+wrong-dimension array are literal field filters that simply match what they
+match.
 
 ## 5. Updates, deletes, compaction
 
@@ -252,7 +310,7 @@ O(live); for very large indexes prefer `0` and schedule
 ### Other knobs
 
 - **`EfSearch`** — query-time candidate list; higher = more recall, slower. ~64 is
-  the knee (recall ~0.96 at ~1 ms for dim 768). Override per-query with `VectorEf`.
+  the knee (recall ~0.96 at ~1 ms for dim 768). Override per-query with `$ef`.
 - **`EfConstruction` / `M`** — bigger graph, slower build, marginally better
   recall; raise for build-once / query-often.
 - **Per-batch insert cache** — repeatedly-read graph vectors are served from a
@@ -309,8 +367,8 @@ coll.Insert(ctx,
     mkDoc(3, "fr", []float32{0.0, 0.1, 0.9, 0.7}),
 )
 
-iter, _ := coll.Find(`{"embedding":[0.85,0.15,0.05,0.15], "lang":"en"}`).
-    Sort("_distance").Limit(2).Iter(ctx)
+iter, _ := coll.Find(`{"embedding":{"$knn":{"$query":[0.85,0.15,0.05,0.15],"$k":2}}, "lang":"en"}`).
+    Sort("_distance").Iter(ctx)
 defer iter.Close()
 
 for iter.Next() {

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -952,6 +952,7 @@ func (q *collQuery) detectFtsQuery() (*qplanner.FtsQuerySpec, query.Filter, erro
 	}
 	fx := fxs[0]
 	spec := &qplanner.FtsQuerySpec{
+		IndexName:  fx.info.Name,
 		Ordered:    true, // searchCandidates returns score-descending
 		NeedScores: true, // compilePlan sets this from planOpts (Iter only)
 		Search: func(tx *btree.ReadTx) (qplanner.FtsCandidateStream, error) {

--- a/index.go
+++ b/index.go
@@ -21,9 +21,10 @@ type IndexKind uint8
 const (
 	// IndexKindRange is the default B-tree range/equality index.
 	IndexKindRange IndexKind = iota
-	// IndexKindVector is an HNSW approximate-nearest-neighbour index over a
-	// vector (embedding) field. Queried via Find() with a `{field: [vector]}`
-	// clause; results carry a synthetic _distance field (see docs/vector-search.md).
+	// IndexKindVector is an approximate-nearest-neighbour index over a vector
+	// (embedding) field. Queried via Find() with a
+	// `{field: {"$knn": {"$query": [...], "$k": N}}}` clause; results carry a
+	// synthetic _distance field (see docs/vector-search.md).
 	IndexKindVector
 	// IndexKindFulltext is an inverted full-text index over one or more text
 	// fields, queried with the $text operator and ranked by BM25. See

--- a/internal/qplanner/fts_iter.go
+++ b/internal/qplanner/fts_iter.go
@@ -42,6 +42,8 @@ type FtsSearchFunc func(tx *btree.ReadTx) (FtsCandidateStream, error)
 // predicate must drive the query).
 type FtsQuerySpec struct {
 	Search FtsSearchFunc
+	// IndexName is the driving full-text index, reported by Explain.
+	IndexName string
 	// Ordered is true when Search streams candidates already sorted by score
 	// descending (always the case for BM25). The planner can then skip the
 	// SortIter for the default relevance order and stream straight to LimitIter;

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -694,14 +694,22 @@ func BuildPlan(params *PlanParams) *Plan {
 	return plan
 }
 
-// buildVectorPlan builds the iterator chain for a vector query:
+// buildVectorPlan builds the iterator chain for a $knn query:
 //
-//	VectorIter -> [FilterIter(residual)] -> [SortIter] -> [LimitIter]
+//	VectorIter(ef) -> [FilterIter(residual)] -> LimitIter{Limit:K} -> [SortIter] -> [LimitIter{Offset,Limit}]
 //
-// The ANN search is the only source. The residual filter (everything except the
-// vector clause — including any _distance threshold and additional field
-// predicates) and the sort run as ordinary downstream stages over the
-// _distance-decorated candidate documents.
+// The ANN search is the only source. The semantics are filter → cut-to-k →
+// sort → page: the residual filter (everything except the $knn clause —
+// including any _distance threshold and additional field predicates) runs over
+// the _distance-decorated candidates in the source's (distance, docId) order,
+// the k-cut then bounds the denoted set to the K nearest survivors, and only
+// that set is sorted and paginated. The k-cut sits BEFORE the user sort by
+// design — "k selects, Sort orders, Limit paginates" — so the same K documents
+// are denoted regardless of presentation order, on every verb.
+//
+// (LimitIter is not an offsetSkipper, so no pushed-down skip can corrupt the
+// k-cut; Count's LimitIter.CountDistinct fast path computes correctly over the
+// stacked shape.)
 func buildVectorPlan(params *PlanParams) *Plan {
 	needSort := params.Sorter != nil
 	needFilter := params.Filter != nil && !isAllFilter(params.Filter)
@@ -714,6 +722,9 @@ func buildVectorPlan(params *PlanParams) *Plan {
 	}
 	if needFilter {
 		root = &FilterIter{Source: root, Data: dataCS, Filter: params.Filter, Buf: params.Buf}
+	}
+	if params.Vector.K > 0 {
+		root = &LimitIter{Source: root, Limit: params.Vector.K}
 	}
 	if needSort {
 		root = &SortIter{
@@ -728,7 +739,7 @@ func buildVectorPlan(params *PlanParams) *Plan {
 		root = &LimitIter{Source: root, Limit: params.Limit, Offset: params.Offset}
 	}
 
-	plan := &Plan{Root: root, Name: "VectorSearch"}
+	plan := &Plan{Root: root, Name: "KnnSearch", IndexName: params.Vector.IndexName}
 	setPlanRef(root, plan)
 	return plan
 }
@@ -769,7 +780,7 @@ func buildFtsPlan(params *PlanParams) *Plan {
 		root = &LimitIter{Source: root, Limit: params.Limit, Offset: params.Offset}
 	}
 
-	plan := &Plan{Root: root, Name: "FtsSearch"}
+	plan := &Plan{Root: root, Name: "FtsSearch", IndexName: params.Fts.IndexName}
 	setPlanRef(root, plan)
 	return plan
 }

--- a/internal/qplanner/vector_iter.go
+++ b/internal/qplanner/vector_iter.go
@@ -31,11 +31,14 @@ type VectorQuerySpec struct {
 	Query  []float32
 	Ef     int
 	Search VectorSearchFunc
-	// Ordered is true when Search returns candidates already sorted closest-first
-	// (the ANN path). The planner can then skip the SortIter for the default
-	// distance-ascending order. Brute-force search leaves it false (its candidates
-	// come back in document order), so a distance SortIter is always applied.
-	Ordered bool
+	// TotallyOrdered is true when Search returns candidates in (distance, docId)
+	// ascending order — a TOTAL order, ties included. All three backends (HNSW,
+	// IVF, brute-force) enforce it at the source; the planner then skips the
+	// SortIter for the default distance order and streams straight through. It
+	// must be total, not merely closest-first: the k-cut and pagination windows
+	// slice this sequence, so an under-specified tie order would make different
+	// verbs page different documents.
+	TotallyOrdered bool
 }
 
 // VectorIter is the source iterator for a vector query. On first Next it runs

--- a/internal/qplanner/vector_iter.go
+++ b/internal/qplanner/vector_iter.go
@@ -25,12 +25,24 @@ type VectorCandidate struct {
 // vindex dependency.
 type VectorSearchFunc func(tx *btree.ReadTx, query []float32, ef int) ([]VectorCandidate, error)
 
-// VectorQuerySpec directs BuildPlan to build a vector-search plan. When present
-// it is the SOLE source — all range-index/CBO selection is bypassed.
+// VectorQuerySpec directs BuildPlan to build a vector-search ($knn) plan. When
+// present it is the SOLE source — all range-index/CBO selection is bypassed.
 type VectorQuerySpec struct {
-	Query  []float32
-	Ef     int
-	Search VectorSearchFunc
+	Query []float32
+	// K is the $knn clause's mandatory neighbour count: the k-cut
+	// (LimitIter{Limit:K}) sits after the residual filter and before any user
+	// sort, bounding the denoted set to at most K documents on every verb.
+	K  int
+	Ef int
+	// IndexName is the resolved vector index, reported by Explain.
+	IndexName string
+	Search    VectorSearchFunc
+	// NeedDistances gates ONLY the Plan.Distances sidecar (Iterator.Distance()
+	// on the read verb). injectDistance is unconditional: the residual filter
+	// reads _distance from Plan.DocParsed on every verb, so gating the
+	// injection would turn a {"_distance":{"$lt":x}} residual into match-all
+	// (Comp.Ok(nil) is true for $lt against null) on Count/Update/Delete.
+	NeedDistances bool
 	// TotallyOrdered is true when Search returns candidates in (distance, docId)
 	// ascending order — a TOTAL order, ties included. All three backends (HNSW,
 	// IVF, brute-force) enforce it at the source; the planner then skips the
@@ -64,11 +76,13 @@ func (it *VectorIter) Next() (key []byte, docId []byte, multiKey bool, err error
 		if err != nil {
 			return nil, nil, false, err
 		}
-		if it.Plan != nil && it.Plan.Distances == nil {
-			it.Plan.Distances = &FloatSidecar{}
-		}
-		for _, c := range it.candidates {
-			if it.Plan != nil {
+		// The sidecar (public Distance()) is kept only when the verb asked for
+		// it; injectDistance below stays UNCONDITIONAL — see NeedDistances.
+		if it.Spec.NeedDistances && it.Plan != nil {
+			if it.Plan.Distances == nil {
+				it.Plan.Distances = &FloatSidecar{}
+			}
+			for _, c := range it.candidates {
 				it.Plan.Distances.Set(c.DocId, float64(c.Distance))
 			}
 		}
@@ -110,5 +124,5 @@ func injectDistance(arena *anyenc.Arena, doc *anyenc.Value, dist float32) {
 func (it *VectorIter) Close() {}
 
 func (it *VectorIter) String() string {
-	return fmt.Sprintf("VectorSearch(ef=%d)", it.Spec.Ef)
+	return fmt.Sprintf("KnnSearch(k=%d,ef=%d)", it.Spec.K, it.Spec.Ef)
 }

--- a/internal/qplanner/vector_iter_test.go
+++ b/internal/qplanner/vector_iter_test.go
@@ -1,0 +1,192 @@
+package qplanner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/internal/btree"
+	"github.com/anyproto/any-store/v2/query"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// vectorTestDB builds a data namespace with n docs {"id":i,"p":i%3} keyed by
+// the encoded id, plus a Search stub returning the given candidates.
+func vectorTestDB(t *testing.T, n int) (*btree.ReadTx, *btree.Namespace, func(int) []byte) {
+	t.Helper()
+	db, err := btree.Open(":memory:", btree.Options{InMemory: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	wtx, err := db.BeginWrite()
+	require.NoError(t, err)
+	ns, err := wtx.CreateNamespace("data")
+	require.NoError(t, err)
+	idOf := func(i int) []byte { return anyenc.AppendAnyValue(nil, i) }
+	a := &anyenc.Arena{}
+	for i := 0; i < n; i++ {
+		a.Reset()
+		obj := a.NewObject()
+		obj.Set("id", a.NewNumberInt(i))
+		obj.Set("p", a.NewNumberInt(i%3))
+		require.NoError(t, wtx.Put(ns, idOf(i), obj.MarshalTo(nil)))
+	}
+	require.NoError(t, wtx.Commit())
+	rtx, err := db.BeginRead()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rtx.Rollback() })
+	return rtx, ns, idOf
+}
+
+func knnSpec(idOf func(int) []byte, k int, cands ...int) *VectorQuerySpec {
+	return &VectorQuerySpec{
+		Query:          []float32{1},
+		K:              k,
+		Ef:             len(cands),
+		IndexName:      "emb",
+		TotallyOrdered: true,
+		Search: func(tx *btree.ReadTx, q []float32, ef int) ([]VectorCandidate, error) {
+			out := make([]VectorCandidate, 0, len(cands))
+			for rank, id := range cands {
+				out = append(out, VectorCandidate{DocId: idOf(id), Distance: float32(rank) / 10})
+			}
+			return out, nil
+		},
+	}
+}
+
+// TestBuildVectorPlan_KCutBeforeSort pins the plan shape: the k-cut LimitIter
+// sits AFTER the residual filter and BEFORE the user sort, with pagination
+// outermost — "k selects, Sort orders, Limit paginates".
+func TestBuildVectorPlan_KCutBeforeSort(t *testing.T) {
+	rtx, ns, idOf := vectorTestDB(t, 10)
+	buf := syncpool.NewSyncPool(0).GetDocBuf()
+	sorter, err := query.ParseSort("-p")
+	require.NoError(t, err)
+
+	plan := BuildPlan(&PlanParams{
+		Tx:     rtx,
+		DataNs: ns,
+		Filter: query.MustParseCondition(`{"p":{"$gte":0}}`),
+		Sorter: sorter,
+		Limit:  3,
+		Offset: 1,
+		Buf:    buf,
+		Vector: knnSpec(idOf, 5, 0, 1, 2, 3, 4, 5, 6, 7),
+	})
+	assert.Equal(t, "KnnSearch", plan.Name)
+	assert.Equal(t, "emb", plan.IndexName)
+	assert.Equal(t,
+		"KnnSearch(k=5,ef=8) -> Filter -> Limit(5) -> TopK(4) -> Limit(offset=1,limit=3)",
+		plan.String(), "filter → cut-to-k → sort (bounded to offset+limit) → page")
+	plan.Close()
+
+	// Without residual/sort/paging the k-cut is still present.
+	plan = BuildPlan(&PlanParams{
+		Tx: rtx, DataNs: ns, Buf: buf,
+		Vector: knnSpec(idOf, 5, 0, 1, 2),
+	})
+	assert.Equal(t, "KnnSearch(k=5,ef=3) -> Limit(5)", plan.String())
+	plan.Close()
+}
+
+// TestVectorIter_KCutAndOrder: the source order (TotallyOrdered at the
+// backend) streams through, the k-cut truncates AFTER the residual filter, and
+// the pagination window slices the sorted k-set.
+func TestVectorIter_KCutAndOrder(t *testing.T) {
+	rtx, ns, idOf := vectorTestDB(t, 12)
+	buf := syncpool.NewSyncPool(0).GetDocBuf()
+
+	collect := func(plan *Plan) []string {
+		defer plan.Close()
+		var out []string
+		for {
+			_, docId, _, err := plan.Root.Next()
+			require.NoError(t, err)
+			if docId == nil {
+				return out
+			}
+			out = append(out, string(docId))
+		}
+	}
+
+	// k=3 cut of an 8-candidate stream: first 3 in source (distance) order.
+	plan := BuildPlan(&PlanParams{
+		Tx: rtx, DataNs: ns, Buf: buf,
+		Vector: knnSpec(idOf, 3, 7, 5, 3, 1, 0, 2, 4, 6),
+	})
+	want := []string{string(idOf(7)), string(idOf(5)), string(idOf(3))}
+	assert.Equal(t, want, collect(plan), "k-cut keeps the k nearest in source order")
+
+	// Residual filter (p==1 → ids 1,4,7,10) runs BEFORE the cut: the k=2 set
+	// is the 2 nearest SURVIVORS, not survivors of the 2 nearest.
+	plan = BuildPlan(&PlanParams{
+		Tx: rtx, DataNs: ns, Buf: buf,
+		Filter: query.MustParseCondition(`{"p":1}`),
+		Vector: knnSpec(idOf, 2, 0, 1, 2, 3, 4, 5, 6, 7),
+	})
+	want = []string{string(idOf(1)), string(idOf(4))}
+	assert.Equal(t, want, collect(plan), "filter, THEN cut — hybrid search would be destroyed otherwise")
+
+	// Offset beyond k → empty.
+	plan = BuildPlan(&PlanParams{
+		Tx: rtx, DataNs: ns, Buf: buf,
+		Offset: 3,
+		Vector: knnSpec(idOf, 3, 0, 1, 2, 3, 4),
+	})
+	assert.Empty(t, collect(plan), "Offset >= k pages past the denoted set")
+}
+
+// TestVectorIter_InjectDistanceUnconditional pins the T2.6 gating rule:
+// NeedDistances gates ONLY the sidecar; the _distance injection into the
+// in-flight document is unconditional, because the residual filter reads it
+// from Plan.DocParsed on every verb. If injection were gated, a
+// {"_distance":{"$lt":x}} residual would evaluate Comp.Ok(nil) == true
+// (number tag > null tag) — match-all — and a bounded Delete would remove all
+// k instead of the thresholded subset.
+func TestVectorIter_InjectDistanceUnconditional(t *testing.T) {
+	rtx, ns, idOf := vectorTestDB(t, 6)
+	buf := syncpool.NewSyncPool(0).GetDocBuf()
+
+	// Distances are rank/10 = 0.0, 0.1, 0.2, ... — threshold 0.15 keeps 2.
+	mk := func(needDistances bool) *Plan {
+		spec := knnSpec(idOf, 5, 0, 1, 2, 3, 4)
+		spec.NeedDistances = needDistances
+		return BuildPlan(&PlanParams{
+			Tx: rtx, DataNs: ns, Buf: buf,
+			Filter: query.MustParseCondition(`{"_distance":{"$lt":0.15}}`),
+			Vector: spec,
+		})
+	}
+
+	for _, needDistances := range []bool{false, true} {
+		plan := mk(needDistances)
+		var n int
+		for {
+			_, docId, _, err := plan.Root.Next()
+			require.NoError(t, err)
+			if docId == nil {
+				break
+			}
+			n++
+		}
+		assert.Equal(t, 2, n,
+			"needDistances=%v: the _distance residual must threshold the stream", needDistances)
+		if needDistances {
+			assert.NotNil(t, plan.Distances, "sidecar kept for the read verb")
+		} else {
+			assert.Nil(t, plan.Distances, "sidecar skipped when nothing reads Distance()")
+		}
+		plan.Close()
+	}
+}
+
+// TestVectorIter_String pins the explain fragment (k and ef are the two
+// numbers a human needs to reason about an ANN result).
+func TestVectorIter_String(t *testing.T) {
+	it := &VectorIter{Spec: &VectorQuerySpec{K: 10, Ef: 100}}
+	assert.Equal(t, "KnnSearch(k=10,ef=100)", it.String())
+	assert.Equal(t, "KnnSearch(k=10,ef=100)", fmt.Sprintf("%s", it))
+}

--- a/internal/vindex/heap.go
+++ b/internal/vindex/heap.go
@@ -6,9 +6,18 @@ type candidate struct {
 	label uint32
 }
 
-// cheap is a binary heap of candidates; min-heap (closest at root) when max is
-// false, max-heap (farthest at root) when true. Backing slice is reused across
-// the search via the searcher.
+// candLess orders candidates by (dist, label). The label tie-break makes the
+// beam's ef-cut membership deterministic among exact-distance ties (the result
+// set becomes the unique (dist,label)-smallest ef of the visited nodes) — a
+// requirement of query verb coherence, where every verb must rank the same
+// candidate set.
+func candLess(a, b candidate) bool {
+	return a.dist < b.dist || (a.dist == b.dist && a.label < b.label)
+}
+
+// cheap is a binary heap of candidates ordered by (dist, label); min-heap
+// (closest at root) when max is false, max-heap (farthest at root) when true.
+// Backing slice is reused across the search via the searcher.
 type cheap struct {
 	s   []candidate
 	max bool
@@ -23,9 +32,9 @@ func (h *cheap) len() int { return len(h.s) }
 
 func (h *cheap) less(i, j int) bool {
 	if h.max {
-		return h.s[i].dist > h.s[j].dist
+		return candLess(h.s[j], h.s[i])
 	}
-	return h.s[i].dist < h.s[j].dist
+	return candLess(h.s[i], h.s[j])
 }
 
 func (h *cheap) push(c candidate) {

--- a/internal/vindex/search.go
+++ b/internal/vindex/search.go
@@ -1,7 +1,10 @@
 package vindex
 
 import (
+	"bytes"
+	"cmp"
 	"fmt"
+	"slices"
 
 	"github.com/anyproto/any-store/v2/internal/btree"
 )
@@ -13,10 +16,13 @@ type Candidate struct {
 }
 
 // SearchCandidates runs the ANN beam search and returns up to ef live
-// candidates with their distances. Unlike Search it does NOT rank/truncate to k
-// — the query pipeline's sort+limit own the final ordering ("drop heap"). The
-// returned order is whatever the layer search produced (closest-first); callers
-// must not rely on it.
+// candidates with their distances, in (distance, docId) ascending order — a
+// TOTAL order, so identical queries on identical snapshots return identical
+// sequences (query verb coherence). Membership of the ef-cut is likewise
+// deterministic: the beam admits at the boundary by (dist, label), so the
+// result is the unique (dist,label)-smallest ef of the visited set. Unlike
+// Search it does NOT rank/truncate to k — the query pipeline's k-cut/sort/limit
+// own the final windowing.
 func (ix *Index) SearchCandidates(rtx *btree.ReadTx, query []float32, ef int) ([]Candidate, error) {
 	if len(query) != ix.dim {
 		return nil, fmt.Errorf("vindex: dim mismatch: got %d want %d", len(query), ix.dim)
@@ -85,6 +91,16 @@ func (ix *Index) SearchCandidates(rtx *btree.ReadTx, query []float32, ef int) ([
 		}
 		out = append(out, Candidate{DocID: append([]byte(nil), docID...), Distance: c.dist})
 	}
+	// found arrives (dist, label)-ascending from the beam; re-sort ties by docId
+	// so the returned sequence is the (distance, docId) total order the query
+	// layer's TotallyOrdered contract promises (labels are insertion-ordered,
+	// docIds are not — the two tie orders differ).
+	slices.SortFunc(out, func(a, b Candidate) int {
+		if a.Distance != b.Distance {
+			return cmp.Compare(a.Distance, b.Distance)
+		}
+		return bytes.Compare(a.DocID, b.DocID)
+	})
 	return out, nil
 }
 
@@ -548,7 +564,12 @@ func (s *searcher) searchLayer(ep uint32, ef int, layer int32) ([]candidate, err
 			if err != nil {
 				return nil, err
 			}
-			if s.res.len() >= ef && d >= s.res.peek().dist {
+			// Admission at the ef boundary is (dist, label)-lexicographic, not
+			// distance-only: on an exact-distance tie with the current worst
+			// result, the smaller label wins. This makes the result MEMBERSHIP
+			// the unique (dist,label)-smallest ef of the visited set, instead of
+			// an arbitrary tie subset dependent on traversal order.
+			if s.res.len() >= ef && !candLess(candidate{d, nb}, s.res.peek()) {
 				continue
 			}
 			s.cand.push(candidate{d, nb})

--- a/internal/vivf/store.go
+++ b/internal/vivf/store.go
@@ -791,22 +791,40 @@ func (ix *StoreIndex) SearchCandidates(rtx *btree.ReadTx, q []float32, ef int) (
 		s.docOff = append(s.docOff, [2]int{start, len(backing)})
 		out = append(out, Candidate{Distance: dist})
 	}
-	// backing is final now — slice docIDs out of it, then sort closest-first. Sorting
-	// the ~ef re-ranked survivors here (and marking the spec Ordered) is measurably
-	// cheaper than returning them unordered and letting the pipeline's SortIter
-	// collect+heap+fetch: with Ordered set the planner skips the SortIter for the
-	// default distance order and streams straight to LimitIter (~19% faster end to
-	// end). An explicit multi-key Sort still goes through SortIter regardless.
+	// backing is final now — slice docIDs out of it, then sort (distance, docId)
+	// ascending. Sorting the ~ef re-ranked survivors here (and marking the spec
+	// TotallyOrdered) is measurably cheaper than returning them unordered and
+	// letting the pipeline's SortIter collect+heap+fetch: the planner skips the
+	// SortIter for the default distance order and streams straight to LimitIter
+	// (~19% faster end to end). An explicit multi-key Sort still goes through
+	// SortIter regardless. The docId tie-break makes the output a TOTAL order, so
+	// every verb pages the same sequence through identical ties.
 	for i := range out {
 		out[i].DocID = backing[s.docOff[i][0]:s.docOff[i][1]]
 	}
-	slices.SortFunc(out, func(a, b Candidate) int { return cmpF32(a.Distance, b.Distance) })
+	slices.SortFunc(out, func(a, b Candidate) int {
+		if c := cmpF32(a.Distance, b.Distance); c != 0 {
+			return c
+		}
+		return bytes.Compare(a.DocID, b.DocID)
+	})
 	return out, nil
 }
 
-// selectSmallest partitions cs in place so the k smallest by dist occupy cs[:k]
-// (in arbitrary order). Quickselect (Hoare partition, median-of-three pivot),
-// O(n) average — used instead of a full sort when only the ef best are needed.
+// candLess orders candidates by (dist, label). The label tie-break is what makes
+// the ef-cut deterministic: s.cands arrives from dedup.collect in SLOT order — a
+// function of the pooled searcher's table size, i.e. of its history — so a
+// distance-only cut selects an arbitrary subset of an exact-tie group straddling
+// the boundary, and two verbs of the same query can rank different candidate
+// sets. With the tie-break, cs[:ef] is the unique (dist,label)-smallest ef.
+func candLess(a, b cand) bool {
+	return a.dist < b.dist || (a.dist == b.dist && a.label < b.label)
+}
+
+// selectSmallest partitions cs in place so the k smallest by (dist, label)
+// occupy cs[:k] (in arbitrary order). Quickselect (Hoare partition,
+// median-of-three pivot), O(n) average — used instead of a full sort when only
+// the ef best are needed.
 func selectSmallest(cs []cand, k int) {
 	lo, hi := 0, len(cs)-1
 	for lo < hi {
@@ -822,25 +840,25 @@ func selectSmallest(cs []cand, k int) {
 	}
 }
 
-// partitionDist partitions cs[lo:hi+1] around a median-of-three pivot by dist,
-// returning the final pivot index.
+// partitionDist partitions cs[lo:hi+1] around a median-of-three pivot by
+// (dist, label), returning the final pivot index.
 func partitionDist(cs []cand, lo, hi int) int {
 	mid := lo + (hi-lo)/2
 	// median-of-three (lo, mid, hi) → move median to hi-1 as pivot
-	if cs[mid].dist < cs[lo].dist {
+	if candLess(cs[mid], cs[lo]) {
 		cs[lo], cs[mid] = cs[mid], cs[lo]
 	}
-	if cs[hi].dist < cs[lo].dist {
+	if candLess(cs[hi], cs[lo]) {
 		cs[lo], cs[hi] = cs[hi], cs[lo]
 	}
-	if cs[hi].dist < cs[mid].dist {
+	if candLess(cs[hi], cs[mid]) {
 		cs[mid], cs[hi] = cs[hi], cs[mid]
 	}
-	pivot := cs[mid].dist
+	pivot := cs[mid]
 	cs[mid], cs[hi-1] = cs[hi-1], cs[mid]
 	i := lo
 	for j := lo; j < hi-1; j++ {
-		if cs[j].dist < pivot {
+		if candLess(cs[j], pivot) {
 			cs[i], cs[j] = cs[j], cs[i]
 			i++
 		}

--- a/internal/vivf/store_test.go
+++ b/internal/vivf/store_test.go
@@ -1,6 +1,7 @@
 package vivf
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math/rand"
 	"path/filepath"
@@ -376,4 +377,94 @@ func TestStoreIVFPQRecallReal(t *testing.T) {
 	r := sum / float64(len(queries))
 	t.Logf("btree-resident IVF-PQ recall@%d = %.4f (nlist=256 M=96 assign=4 nprobe=16 ef=%d) — HNSW=0.970", k, r, ef)
 	require.GreaterOrEqual(t, r, 0.95, "btree IVF-PQ must preserve prototype recall")
+}
+
+// TestStoreEfCutIsDeterministic pins the (dist, label) tie-break on the ef-cut
+// and the (distance, docId) total order of the output.
+//
+// The hazard: dedup.collect walks the pooled searcher's open-addressed table in
+// SLOT order, so the permutation handed to the quickselect is a function of the
+// table's SIZE — i.e. of the searcher's history, not of the query. With a
+// distance-only cut, an exact-distance tie group straddling the ef boundary has
+// its membership chosen arbitrarily per searcher: a cold (1024-slot) and a
+// pre-grown (16384-slot) searcher select different candidates for the same
+// query on the same snapshot, and Rows(Q) is not well-defined across verbs.
+// The (dist, label) tie-break makes cs[:ef] the unique smallest ef.
+func TestStoreEfCutIsDeterministic(t *testing.T) {
+	const (
+		n   = 300
+		dim = 32
+		ef  = 20
+	)
+	// 10 docs near the query at distinct distances + 290 byte-identical docs
+	// (identical vectors ⇒ identical PQ codes ⇒ exact ADC ties). ef=20 needs
+	// 10 of the 290 ties: the cut lands inside the tie group.
+	query := make([]float32, dim)
+	for d := range query {
+		query[d] = float32(d) / dim
+	}
+	tie := make([]float32, dim)
+	for d := range tie {
+		tie[d] = query[d] + 0.5
+	}
+	vecs := make([][]float32, n)
+	for i := 0; i < 10; i++ {
+		v := make([]float32, dim)
+		for d := range v {
+			v[d] = query[d] + float32(i+1)*0.01
+		}
+		vecs[i] = v
+	}
+	for i := 10; i < n; i++ {
+		vecs[i] = tie
+	}
+	db := openMem(t)
+	p := StoreParams{Dim: dim, NList: 4, M: 8, Assign: 1, NProbe: 4, Seed: 1}
+	buildStore(t, db, p, vecs)
+
+	rtx, err := db.BeginRead()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rtx.Rollback()) }()
+
+	search := func(ix *StoreIndex) []Candidate {
+		out, serr := ix.SearchCandidates(rtx, query, ef)
+		require.NoError(t, serr)
+		require.Len(t, out, ef)
+		return out
+	}
+
+	// Cold: a fresh StoreIndex, so its pooled searcher starts at the initial
+	// 1024-slot dedup table.
+	ixCold, err := OpenTx(rtx, "ivf")
+	require.NoError(t, err)
+	cold := search(ixCold)
+
+	// Warm: a fresh StoreIndex whose pooled searcher is deliberately pre-grown
+	// past 8192 slots (as a label-heavy earlier query would leave it), changing
+	// the slot-order permutation dedup.collect emits.
+	ixWarm, err := OpenTx(rtx, "ivf")
+	require.NoError(t, err)
+	s := ixWarm.getSearcher()
+	s.dedup.reset()
+	for i := uint32(0); i < 8192; i++ {
+		s.dedup.putMin(i, 0)
+	}
+	require.GreaterOrEqual(t, len(s.dedup.key), 8192, "pre-grow must actually grow the table")
+	ixWarm.putSearcher(s)
+	warm := search(ixWarm)
+
+	for i := range cold {
+		require.Equal(t, cold[i].DocID, warm[i].DocID,
+			"ef-cut membership/order diverged at rank %d between cold and pre-grown searchers", i)
+		require.Equal(t, cold[i].Distance, warm[i].Distance)
+	}
+	// The output is the (distance, docId) TOTAL order — ties broken by docId.
+	for i := 1; i < len(cold); i++ {
+		if cold[i-1].Distance == cold[i].Distance {
+			require.Negative(t, bytes.Compare(cold[i-1].DocID, cold[i].DocID),
+				"exact-distance ties must be docId-ascending")
+		} else {
+			require.Less(t, cold[i-1].Distance, cold[i].Distance)
+		}
+	}
 }

--- a/iterator.go
+++ b/iterator.go
@@ -47,6 +47,7 @@ type planIterator struct {
 	docId      []byte
 	closed     bool
 	dedup      qplanner.DocDedup // lazy-allocated when upstream emits multiKey=true
+	distArena  anyenc.Arena      // _distance re-injection on the post-sort re-fetch path
 }
 
 func (pi *planIterator) Next() bool {
@@ -150,6 +151,17 @@ func (pi *planIterator) Doc() (Doc, error) {
 		if perr != nil {
 			return nil, perr
 		}
+		// Re-decorate the synthetic _distance on the re-fetch path: SortIter
+		// clears DocParsed on emit, so a sorted $knn result would otherwise
+		// hand back the raw stored document with the documented _distance
+		// field missing. The sidecar always exists on the read verb (the only
+		// verb with a Doc()), keyed by docId.
+		if pi.plan.Distances != nil {
+			if d, ok := pi.plan.Distances.Get(pi.docId); ok {
+				pi.distArena.Reset()
+				doc.Set(qplanner.DistanceField, pi.distArena.NewNumberFloat64(d))
+			}
+		}
 	}
 	return pi.qb.coll.newItem(doc)
 }
@@ -202,7 +214,7 @@ func (e *emptyIter) Doc() (Doc, error) {
 func (e *emptyIter) Distance() float32 { return 0 }
 
 func (e *emptyIter) Score() float64 { return 0 }
-func (e *emptyIter) Err() error        { return nil }
+func (e *emptyIter) Err() error     { return nil }
 func (e *emptyIter) Close() error {
 	if e.closed {
 		return ErrIterClosed

--- a/query.go
+++ b/query.go
@@ -34,11 +34,6 @@ type Query interface {
 	// IndexHint adds or removes boost for some indexes
 	IndexHint(hints ...IndexHint) Query
 
-	// VectorEf overrides the ANN candidate-list size (numCandidates) for a
-	// vector query. 0 (default) auto-sizes it: the index default, raised to
-	// cover the limit and over-fetched when a residual filter is present.
-	VectorEf(ef uint) Query
-
 	// Iter executes the query and returns an Iterator for the results.
 	Iter(ctx context.Context) (Iterator, error)
 
@@ -85,10 +80,6 @@ type collQuery struct {
 
 	indexHints []IndexHint
 
-	// vectorEf overrides the ANN candidate-list size (numCandidates) for a
-	// vector query; 0 = auto (index default, raised to cover limit/over-fetch).
-	vectorEf uint
-
 	err error
 }
 
@@ -112,11 +103,6 @@ func (q *collQuery) Offset(offset uint) Query {
 
 func (q *collQuery) IndexHint(hints ...IndexHint) Query {
 	q.indexHints = hints
-	return q
-}
-
-func (q *collQuery) VectorEf(ef uint) Query {
-	q.vectorEf = ef
 	return q
 }
 
@@ -146,10 +132,42 @@ func (q *collQuery) reportCandidates(btx *btree.ReadTx, opts planOpts) []qplanne
 // the row sink).
 type planOpts struct {
 	countOnly      bool // Count: PlanParams.CountOnly, Sorter forced nil (a count is order-invariant)
-	forWrite       bool // Update/Delete: unbounded-sort elision + vector write guard
-	needScores     bool // Iter only: keep the BM25 sidecar for Iterator.Score()
+	forWrite       bool // Update/Delete: unbounded-sort elision
+	needSidecars   bool // Iter only: keep the BM25/_distance sidecars for Iterator.Score()/Distance()
 	exactTotalDocs bool // Explain only: docCountExact (human-facing TotalDocs)
 	wantCandidates bool // Explain only: return the CBO candidate report even on fts/vector paths
+}
+
+// validateSources runs the source-detection guards that need no transaction:
+// the legacy-clause rejection, the _distance placement rule, the $knn/$text
+// exclusion, and the full $knn detection walk (placement, argument validation,
+// index resolution, dim check — detection is the ONLY validation programmatic
+// consumers ever see).
+//
+// The verbs call this BEFORE their unsatisfiable() short-circuit: an invalid
+// source must error identically on every verb, not return 0/nil wherever an
+// unrelated $in:[] happens to make the filter unsatisfiable.
+func (q *collQuery) validateSources() error {
+	vidxs := q.c.loadVectorIndexes()
+	if err := rejectLegacyVectorClause(q.cond, vidxs); err != nil {
+		return err
+	}
+	hasKnn := query.ContainsKnn(q.cond)
+	// _distance is synthetic and only produced by a $knn search: referencing it
+	// with no $knn (in filter or sort) is an error rather than a silent
+	// match-everything / sort-on-nothing.
+	if !hasKnn && (filterRefsField(q.cond, qplanner.DistanceField) || sortRefsField(q.sort, qplanner.DistanceField)) {
+		return ErrDistanceWithoutVector
+	}
+	if hasKnn {
+		if containsText(q.cond) {
+			return ErrKnnWithText
+		}
+		if _, _, err := q.detectKnnQuery(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // writeSorter applies the write-verb sorter rule: ordering decides WHICH
@@ -168,12 +186,13 @@ func (q *collQuery) writeSorter(opts planOpts) query.Sort {
 	return q.sort
 }
 
-// compilePlan is the single query compiler shared by the verbs. It owns
-// $text detection (detectFtsQuery + ftsSorter), vector detection
-// (detectVectorQuery + the default distance-sort rule), and CBO input
-// assembly (buildBoundsResult, buildCBOIndexesInto, buildIndexHints,
+// compilePlan is the single query compiler shared by the verbs. It owns the
+// source guards (validateSources), $text detection (detectFtsQuery +
+// ftsSorter), $knn detection (detectKnnQuery), and CBO input assembly
+// (buildBoundsResult, buildCBOIndexesInto, buildIndexHints,
 // docCountForPlan/docCountExact) — so every verb selects the same documents
-// for the same query by construction.
+// for the same query by construction. A source not reachable from here is not
+// reachable at all.
 //
 // btx MUST be the snapshot the plan executes on: the multikey-flag probe in
 // buildCBOIndexesInto and the bounds interpolation read it. The caller owns
@@ -181,6 +200,13 @@ func (q *collQuery) writeSorter(opts planOpts) query.Sort {
 // non-nil only when opts.wantCandidates (Explain's index report).
 func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syncpool.DocBuffer,
 	idBounds query.Bounds, opts planOpts) (plan *qplanner.Plan, cbo []qplanner.CBOIndex, err error) {
+
+	// The unconditional source guards. The verbs already ran these (before
+	// their unsatisfiable() short-circuit); re-run here so compilePlan is safe
+	// for any future caller — the guards are cheap tree walks.
+	if err = q.validateSources(); err != nil {
+		return nil, nil, err
+	}
 
 	// $text drives the query when present (CBO bypassed). The residual filter
 	// runs as a downstream FilterIter; a relevance/textScore sort is the
@@ -198,7 +224,7 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		if err = q.c.db.flushAmbientFtsPending(ctx); err != nil {
 			return nil, nil, err
 		}
-		ftsSpec.NeedScores = opts.needScores
+		ftsSpec.NeedScores = opts.needSidecars
 		// countOnly is sound without ordering: FtsIter emits one aggregate per
 		// doc (duplicate-free), and the distinct count is order-invariant.
 		sorter := ftsSorter(q.writeSorter(opts))
@@ -216,30 +242,23 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		return plan, q.reportCandidates(btx, opts), nil
 	}
 
-	// Vector query: detect `{vectorField: [..]}` against the collection's
-	// vector indexes. When matched, build a vector plan (ANN source) and
-	// ignore all other indexes; the residual filter + sort run downstream.
-	vspec, residual, err := q.detectVectorQuery()
+	// $knn drives the query when present (CBO bypassed): the ANN search is the
+	// sole source on EVERY verb — filter → cut-to-k → sort → page. The blast
+	// radius of a write is k, a number the caller typed into the clause, so no
+	// verb rejects $knn. No default distance SortIter: the source is
+	// TotallyOrdered ((distance, docId) ascending), so with no explicit sort
+	// the k-cut streams straight through.
+	vspec, residual, err := q.detectKnnQuery()
 	if err != nil {
 		return nil, nil, err
 	}
 	if vspec != nil {
-		// A vector clause denotes an ANN candidate WINDOW, not a predicate: an
-		// unbounded write would mutate however many candidates the (tunable)
-		// search happens to yield. Until the $knn operator makes k part of the
-		// clause, a vector-clause Update/Delete must state its blast radius.
-		if opts.forWrite && q.limit == 0 {
-			return nil, nil, ErrVectorWriteWithoutLimit
-		}
-		// No default distance SortIter: every ANN source is TotallyOrdered —
-		// it streams (distance, docId) ascending at the source — so with no
-		// explicit sort the planner streams candidates straight to LimitIter.
-		sorter := q.writeSorter(opts)
+		vspec.NeedDistances = opts.needSidecars
 		plan = qplanner.BuildPlan(&qplanner.PlanParams{
 			Tx:        btx,
 			DataNs:    q.c.ns,
 			Filter:    residual,
-			Sorter:    sorter,
+			Sorter:    q.writeSorter(opts),
 			Limit:     int(q.limit),
 			Offset:    int(q.offset),
 			Buf:       buf,
@@ -291,6 +310,14 @@ func (q *collQuery) Iter(ctx context.Context) (iter Iterator, err error) {
 		return
 	}
 
+	// Source validation precedes the unsatisfiable() short-circuit: an invalid
+	// $knn/_distance/legacy clause must error here exactly as it would with a
+	// satisfiable filter.
+	if err = q.validateSources(); err != nil {
+		qb.Close()
+		return
+	}
+
 	// Fast path: filter provably matches no documents — return an empty
 	// iterator with no transaction, no plan construction, no I/O.
 	if q.unsatisfiable() {
@@ -316,7 +343,7 @@ func (q *collQuery) Iter(ctx context.Context) (iter Iterator, err error) {
 	buf := q.c.db.syncPool.GetDocBuf()
 	btx := tx.btreeReadTx()
 
-	plan, _, err := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{needScores: true})
+	plan, _, err := q.compilePlan(ctx, btx, buf, qb.idBounds, planOpts{needSidecars: true})
 	if err != nil {
 		q.c.db.syncPool.ReleaseDocBuf(buf)
 		_ = tx.Commit()
@@ -346,6 +373,11 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 		return
 	}
 	defer qb.Close()
+
+	// Source validation precedes the unsatisfiable() short-circuit (see Iter).
+	if err = q.validateSources(); err != nil {
+		return
+	}
 
 	// Fast path: filter provably matches no documents — nothing to update,
 	// no write tx required. ModifyResult is the zero value (Matched=0,
@@ -496,6 +528,11 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	}
 	defer qb.Close()
 
+	// Source validation precedes the unsatisfiable() short-circuit (see Iter).
+	if err = q.validateSources(); err != nil {
+		return
+	}
+
 	// Fast path: filter provably matches no documents — nothing to delete,
 	// no write tx required.
 	if q.unsatisfiable() {
@@ -617,6 +654,11 @@ func (q *collQuery) Count(ctx context.Context) (count int, err error) {
 		q.cond = query.All{}
 	}
 
+	// Source validation precedes the unsatisfiable() short-circuit (see Iter).
+	if err = q.validateSources(); err != nil {
+		return 0, err
+	}
+
 	// Fast path: filter provably matches no documents (e.g. $in:[]). Skip
 	// the planner, the read tx, and the index walk entirely — the answer
 	// is unconditionally zero. See isUnsatisfiable.
@@ -732,6 +774,19 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 	}
 	defer qb.Close()
 
+	// Same ordering as the executing verbs: source validation first, then the
+	// unsatisfiable short-circuit — Explain(Q) describes the plan producing
+	// Rows(Q), and for an unsatisfiable filter that is the empty plan the other
+	// verbs short-circuit to, not a plan that will never run.
+	if err = q.validateSources(); err != nil {
+		return
+	}
+	if q.unsatisfiable() {
+		explain.Sql = "EmptyResult"
+		explain.Plan = "EmptyResult (filter is unsatisfiable)"
+		return
+	}
+
 	buf := q.c.db.syncPool.GetDocBuf()
 	defer q.c.db.syncPool.ReleaseDocBuf(buf)
 
@@ -754,11 +809,14 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 		explain.Sql = plan.String()
 		explain.Plan = plan.ExplainString()
 
-		// Report indexes with used index first
-		for _, idx := range cboIndexes {
-			used := idx.Info.Name == plan.IndexName
+		// Report indexes with used index first. Vector and full-text indexes
+		// are enumerated alongside the CBO candidates: Explain printing
+		// "FullScan(filtered)" with no index report for a working ANN query is
+		// how four verbs ignoring the vector clause went unnoticed.
+		addIndex := func(name string) {
+			used := name == plan.IndexName
 			ie := IndexExplain{
-				Name: idx.Info.Name,
+				Name: name,
 				Cost: plan.Cost,
 				Used: used,
 			}
@@ -767,6 +825,15 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 			} else {
 				explain.Indexes = append(explain.Indexes, ie)
 			}
+		}
+		for _, idx := range cboIndexes {
+			addIndex(idx.Info.Name)
+		}
+		for _, vi := range q.c.loadVectorIndexes() {
+			addIndex(vi.info.Name)
+		}
+		for _, fx := range q.c.loadFtsIndexes() {
+			addIndex(fx.info.Name)
 		}
 		return nil
 	})

--- a/query.go
+++ b/query.go
@@ -231,15 +231,10 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		if opts.forWrite && q.limit == 0 {
 			return nil, nil, ErrVectorWriteWithoutLimit
 		}
+		// No default distance SortIter: every ANN source is TotallyOrdered —
+		// it streams (distance, docId) ascending at the source — so with no
+		// explicit sort the planner streams candidates straight to LimitIter.
 		sorter := q.writeSorter(opts)
-		if sorter == nil && !opts.countOnly && !vspec.Ordered {
-			// No explicit sort and the source isn't already distance-ordered
-			// (brute-force): order by distance ascending. When the ANN source
-			// is ordered, we leave sorter nil so the planner skips a redundant
-			// SortIter and streams the already-closest-first candidates
-			// straight to LimitIter.
-			sorter, _ = query.ParseSort(qplanner.DistanceField)
-		}
 		plan = qplanner.BuildPlan(&qplanner.PlanParams{
 			Tx:        btx,
 			DataNs:    q.c.ns,

--- a/query.go
+++ b/query.go
@@ -80,6 +80,16 @@ type collQuery struct {
 
 	indexHints []IndexHint
 
+	// srcValidated memoizes validateSources: the verbs validate before their
+	// unsatisfiable() short-circuit and compilePlan validates again — without
+	// the flag a $knn query would pay the guard walks (and a throwaway
+	// detection) twice more per verb. Only the VERDICT is cached, never the
+	// detected spec: the spec's Search closure captures the resolved index
+	// handle, which is only reconciled (multi-process staleness) when the
+	// verb's read tx begins — see detectKnnQuery. A collQuery is a single-use
+	// builder (never shared across goroutines), so a plain field suffices.
+	srcValidated bool
+
 	err error
 }
 
@@ -148,6 +158,9 @@ type planOpts struct {
 // source must error identically on every verb, not return 0/nil wherever an
 // unrelated $in:[] happens to make the filter unsatisfiable.
 func (q *collQuery) validateSources() error {
+	if q.srcValidated {
+		return nil
+	}
 	vidxs := q.c.loadVectorIndexes()
 	if err := rejectLegacyVectorClause(q.cond, vidxs); err != nil {
 		return err
@@ -167,6 +180,7 @@ func (q *collQuery) validateSources() error {
 			return err
 		}
 	}
+	q.srcValidated = true
 	return nil
 }
 
@@ -812,12 +826,15 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 		// Report indexes with used index first. Vector and full-text indexes
 		// are enumerated alongside the CBO candidates: Explain printing
 		// "FullScan(filtered)" with no index report for a working ANN query is
-		// how four verbs ignoring the vector clause went unnoticed.
-		addIndex := func(name string) {
+		// how four verbs ignoring the vector clause went unnoticed. They are
+		// NOT CBO candidates though — the optimizer never costed them — so
+		// they carry a cost only when they actually drive the plan; a phantom
+		// plan.Cost on an unconsidered index would read as a costed candidate.
+		addIndex := func(name string, cost float64) {
 			used := name == plan.IndexName
 			ie := IndexExplain{
 				Name: name,
-				Cost: plan.Cost,
+				Cost: cost,
 				Used: used,
 			}
 			if used {
@@ -827,13 +844,19 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 			}
 		}
 		for _, idx := range cboIndexes {
-			addIndex(idx.Info.Name)
+			addIndex(idx.Info.Name, plan.Cost)
+		}
+		sourceCost := func(name string) float64 {
+			if name == plan.IndexName {
+				return plan.Cost
+			}
+			return 0
 		}
 		for _, vi := range q.c.loadVectorIndexes() {
-			addIndex(vi.info.Name)
+			addIndex(vi.info.Name, sourceCost(vi.info.Name))
 		}
 		for _, fx := range q.c.loadFtsIndexes() {
-			addIndex(fx.info.Name)
+			addIndex(fx.info.Name, sourceCost(fx.info.Name))
 		}
 		return nil
 	})

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"regexp"
 	"strings"
 	"unicode"
@@ -449,7 +448,6 @@ func parseKnn(v *anyenc.Value) (Filter, error) {
 		kn       Knn
 		hasQuery bool
 		hasK     bool
-		hasEf    bool
 		perr     error
 	)
 	obj.Visit(func(key []byte, val *anyenc.Value) {
@@ -480,7 +478,6 @@ func parseKnn(v *anyenc.Value) (Filter, error) {
 				return
 			}
 			kn.Ef = n
-			hasEf = true
 		case "$index":
 			sb, e := val.StringBytes()
 			if e != nil {
@@ -503,19 +500,13 @@ func parseKnn(v *anyenc.Value) (Filter, error) {
 	if !hasQuery {
 		return nil, errors.New("$knn requires $query")
 	}
-	if len(kn.Query) == 0 {
-		return nil, errors.New("$knn: $query must be non-empty")
-	}
-	for _, f := range kn.Query {
-		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
-			return nil, errors.New("$knn: $query must contain finite numbers")
-		}
-	}
 	if !hasK {
 		return nil, errors.New("$knn requires $k (the number of neighbours to select)")
 	}
-	if hasEf && kn.Ef < kn.K {
-		return nil, fmt.Errorf("$knn: $ef must be an integer in [$k, %d], got %v", KnnMaxEf, kn.Ef)
+	// Range/finiteness rules live in ONE place, shared with the executor's
+	// detection walk (which validates programmatic NewKnn filters).
+	if err := kn.Validate(); err != nil {
+		return nil, err
 	}
 	return kn, nil
 }

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"unicode"
@@ -43,6 +44,10 @@ const (
 	opType
 	opRegexp
 	opSize
+
+	// opKnn is appended at the END of the block deliberately: it stays > _opVal
+	// (field-level for free via isTopLevel) and shifts no existing iota value.
+	opKnn
 )
 
 var (
@@ -68,6 +73,7 @@ var (
 	opBytesRegexp = []byte("$regex")
 	opBytesSize   = []byte("$size")
 	opBytesText   = []byte("$text")
+	opBytesKnn    = []byte("$knn")
 )
 
 func MustParseCondition(cond any) Filter {
@@ -277,6 +283,7 @@ func parseCompObjOp(val *anyenc.Value) (ok bool, f Filter, err error) {
 		isOp     bool
 		op       Operator
 		hasNonOp bool
+		hasKnn   bool
 	)
 
 	var fs And
@@ -302,6 +309,9 @@ func parseCompObjOp(val *anyenc.Value) (ok bool, f Filter, err error) {
 				return
 			}
 			ok = true
+			if op == opKnn {
+				hasKnn = true
+			}
 			if f, err = makeCompFilter(op, v); err != nil {
 				return
 			}
@@ -318,6 +328,14 @@ func parseCompObjOp(val *anyenc.Value) (ok bool, f Filter, err error) {
 	})
 	if err != nil {
 		return false, nil, err
+	}
+	// A $knn is a ranked SOURCE, not a predicate: And{Knn, Comp} on one field
+	// would leave the Comp as a residual on a field the source already owns,
+	// with fail-closed Knn.Ok lurking under any evaluator that sees the pair.
+	// One JSON object, one operator. (Programmatic And{Key{f,Knn},Key{f,Comp}}
+	// stays legal — the residual builder strips by node identity.)
+	if hasKnn && obj.Len() > 1 {
+		return false, nil, errors.New("$knn must be the only operator on its field")
 	}
 	if hasNonOp {
 		return false, nil, nil
@@ -391,6 +409,11 @@ func makeCompFilter(op Operator, v *anyenc.Value) (f Filter, err error) {
 		if !isOp {
 			return nil, fmt.Errorf("no operators found for $not")
 		}
+		// A Knn under Not would evaluate !false == match-all (fail-closed Ok
+		// reflected). Unrepresentable, at the door.
+		if ContainsKnn(not.Filter) {
+			return nil, errors.New("$knn is not allowed under $not")
+		}
 		return not, nil
 	case opExists:
 		return parseExists(v)
@@ -400,9 +423,101 @@ func makeCompFilter(op Operator, v *anyenc.Value) (f Filter, err error) {
 		return parseRegexp(v)
 	case opSize:
 		return parseSize(v)
+	case opKnn:
+		// This arm is critical: without it a $knn value would fall through to
+		// makeArrComp, whose default arm panics on an unrecognized op.
+		return parseKnn(v)
 	default:
 		return makeArrComp(op, v)
 	}
+}
+
+// parseKnn parses the {"$knn":{...}} options object. Exactly one form is
+// accepted; every rejection is a parse error with a normative message. All of
+// these rules are RE-CHECKED at detection time (query build), because the two
+// production consumers construct query.Knn programmatically and never pass
+// through this parser.
+func parseKnn(v *anyenc.Value) (Filter, error) {
+	if v.Type() != anyenc.TypeObject {
+		// NOTE: a sole-key {"$vector":[…]} object cannot even reach here as an
+		// object — anyenc decodes it into a TypeVectorF32 VALUE before the
+		// parser runs. That extjson landmine is why the payload key is $query.
+		return nil, errors.New(`$knn must be an object, e.g. {"$knn":{"$query":[...],"$k":10}}`)
+	}
+	obj, _ := v.Object()
+	var (
+		kn       Knn
+		hasQuery bool
+		hasK     bool
+		hasEf    bool
+		perr     error
+	)
+	obj.Visit(func(key []byte, val *anyenc.Value) {
+		if perr != nil {
+			return
+		}
+		switch string(key) {
+		case "$query":
+			var ok bool
+			kn.Query, ok = anyenc.AppendFloat32s(val.MarshalTo(nil), nil)
+			if !ok {
+				perr = errors.New(`$knn: $query must be an array of numbers or {"$vector":[...]}`)
+				return
+			}
+			hasQuery = true
+		case "$k":
+			n, e := val.Int()
+			if e != nil || val.Type() != anyenc.TypeNumber || float64(n) != val.GetFloat64() || n < 1 || n > KnnMaxK {
+				perr = fmt.Errorf("$knn: $k must be an integer in [1, %d], got %v", KnnMaxK, val)
+				return
+			}
+			kn.K = n
+			hasK = true
+		case "$ef":
+			n, e := val.Int()
+			if e != nil || val.Type() != anyenc.TypeNumber || float64(n) != val.GetFloat64() || n > KnnMaxEf {
+				perr = fmt.Errorf("$knn: $ef must be an integer in [$k, %d], got %v", KnnMaxEf, val)
+				return
+			}
+			kn.Ef = n
+			hasEf = true
+		case "$index":
+			sb, e := val.StringBytes()
+			if e != nil {
+				perr = errors.New("$knn: $index must be a string")
+				return
+			}
+			kn.Index = string(sb)
+		case "$vector":
+			perr = errors.New(`unknown $knn field: $vector (did you mean "$query"? $vector is the value-type wrapper: {"$query":{"$vector":[...]}})`)
+		case "$maxDistance", "$minScore", "$prefilter", "$nprobe":
+			// Reserved so adding them later is non-breaking; rejected in v1.
+			perr = fmt.Errorf("$knn: %s is reserved and not supported", string(key))
+		default:
+			perr = fmt.Errorf("unknown $knn field: %s", string(key))
+		}
+	})
+	if perr != nil {
+		return nil, perr
+	}
+	if !hasQuery {
+		return nil, errors.New("$knn requires $query")
+	}
+	if len(kn.Query) == 0 {
+		return nil, errors.New("$knn: $query must be non-empty")
+	}
+	for _, f := range kn.Query {
+		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+			return nil, errors.New("$knn: $query must contain finite numbers")
+		}
+	}
+	if !hasK {
+		return nil, errors.New("$knn requires $k (the number of neighbours to select)")
+	}
+	if hasEf && kn.Ef < kn.K {
+		return nil, fmt.Errorf("$knn: $ef must be an integer in [$k, %d], got %v", KnnMaxEf, kn.Ef)
+	}
+	return kn, nil
 }
 
 // parseText parses the $text predicate object into a Text filter:
@@ -718,6 +833,8 @@ func isOperator(key []byte) (ok bool, op Operator, err error) {
 			return true, opSize, nil
 		case bytes.Equal(key, opBytesText):
 			return true, opText, nil
+		case bytes.Equal(key, opBytesKnn):
+			return true, opKnn, nil
 		default:
 			return true, 0, fmt.Errorf("unknow operator: %s", string(key))
 		}

--- a/query/filter.go
+++ b/query/filter.go
@@ -3,6 +3,7 @@ package query
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -841,6 +842,28 @@ func (k Knn) String() string {
 	return b.String()
 }
 
+// Validate checks the $knn argument rules — the ONE copy shared by the parser
+// (parseKnn, after its shape/presence checks) and the executor's detection
+// walk (which re-validates because programmatic NewKnn filters never see the
+// parser). Message texts are the normative parse-error strings.
+func (k Knn) Validate() error {
+	if len(k.Query) == 0 {
+		return errors.New("$knn: $query must be non-empty")
+	}
+	for _, f := range k.Query {
+		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+			return errors.New("$knn: $query must contain finite numbers")
+		}
+	}
+	if k.K < 1 || k.K > KnnMaxK {
+		return fmt.Errorf("$knn: $k must be an integer in [1, %d], got %d", KnnMaxK, k.K)
+	}
+	if k.Ef != 0 && (k.Ef < k.K || k.Ef > KnnMaxEf) {
+		return fmt.Errorf("$knn: $ef must be an integer in [$k, %d], got %d", KnnMaxEf, k.Ef)
+	}
+	return nil
+}
+
 // KnnOpt is an option for NewKnn.
 type KnnOpt func(*Knn)
 
@@ -864,37 +887,76 @@ func NewKnn(vec []float32, k int, opts ...KnnOpt) Knn {
 	return kn
 }
 
-// ContainsKnn reports whether the tree contains a Knn ANYWHERE. It MUST walk
-// And/*And/Or/Nor/Not/Key: a Knn under Not would evaluate !false == match-all
-// (see the Knn type comment), so every consumer that rejects bad placements
-// needs the full walk.
-func ContainsKnn(f Filter) bool {
-	switch ft := f.(type) {
-	case Knn:
+// FilterTreeAny walks the standard filter tree and reports whether pred is
+// true for any node. It descends And/Or/Nor/Not/Key — in BOTH their value and
+// pointer forms: every composite here has value-receiver methods, so a
+// pointer-built &Not{…}/&Key{…}/&Or{…} satisfies Filter too, and a walker that
+// switches only on value types silently skips such nodes. That is not a
+// stylistic gap — ContainsKnn is a mass-delete guard (see Knn), and a missed
+// node is a guard bypass.
+func FilterTreeAny(f Filter, pred func(Filter) bool) bool {
+	if f == nil {
+		return false
+	}
+	if pred(f) {
 		return true
+	}
+	switch ft := f.(type) {
 	case And:
-		return anyContainsKnn(ft)
+		return anyFilterTree(ft, pred)
 	case *And:
-		return anyContainsKnn(*ft)
+		return anyFilterTree(*ft, pred)
 	case Or:
-		return anyContainsKnn(ft)
+		return anyFilterTree(ft, pred)
+	case *Or:
+		return anyFilterTree(*ft, pred)
 	case Nor:
-		return anyContainsKnn(ft)
+		return anyFilterTree(ft, pred)
+	case *Nor:
+		return anyFilterTree(*ft, pred)
 	case Not:
-		return ContainsKnn(ft.Filter)
+		return FilterTreeAny(ft.Filter, pred)
+	case *Not:
+		return FilterTreeAny(ft.Filter, pred)
 	case Key:
-		return ContainsKnn(ft.Filter)
+		return FilterTreeAny(ft.Filter, pred)
+	case *Key:
+		return FilterTreeAny(ft.Filter, pred)
 	}
 	return false
 }
 
-func anyContainsKnn(fs []Filter) bool {
+func anyFilterTree(fs []Filter, pred func(Filter) bool) bool {
 	for _, f := range fs {
-		if ContainsKnn(f) {
+		if FilterTreeAny(f, pred) {
 			return true
 		}
 	}
 	return false
+}
+
+func isKnnLeaf(f Filter) bool {
+	switch f.(type) {
+	case Knn, *Knn:
+		return true
+	}
+	return false
+}
+
+func isSourceLeaf(f Filter) bool {
+	switch f.(type) {
+	case Knn, *Knn, Text, *Text:
+		return true
+	}
+	return false
+}
+
+// ContainsKnn reports whether the tree contains a Knn ANYWHERE. It MUST walk
+// the whole tree, pointer nodes included: a Knn under Not would evaluate
+// !false == match-all (see the Knn type comment), so every consumer that
+// rejects bad placements needs the full walk.
+func ContainsKnn(f Filter) bool {
+	return FilterTreeAny(f, isKnnLeaf)
 }
 
 // ContainsSourceFilter reports whether the tree contains a SOURCE filter — one
@@ -905,32 +967,7 @@ func anyContainsKnn(fs []Filter) bool {
 // subscription pattern) MUST reject these: Text.Ok matches everything, Knn.Ok
 // matches nothing.
 func ContainsSourceFilter(f Filter) bool {
-	switch ft := f.(type) {
-	case Text, Knn:
-		return true
-	case And:
-		return anyContainsSourceFilter(ft)
-	case *And:
-		return anyContainsSourceFilter(*ft)
-	case Or:
-		return anyContainsSourceFilter(ft)
-	case Nor:
-		return anyContainsSourceFilter(ft)
-	case Not:
-		return ContainsSourceFilter(ft.Filter)
-	case Key:
-		return ContainsSourceFilter(ft.Filter)
-	}
-	return false
-}
-
-func anyContainsSourceFilter(fs []Filter) bool {
-	for _, f := range fs {
-		if ContainsSourceFilter(f) {
-			return true
-		}
-	}
-	return false
+	return FilterTreeAny(f, isSourceLeaf)
 }
 
 // presenceNullProbe is an explicit JSON null used by GuaranteesPresence to test
@@ -963,8 +1000,7 @@ func GuaranteesPresence(f Filter, fieldName string) bool {
 		// the AGGRESSIVE answer, feeding sparse-index selection with a claim
 		// the filter never made. (Text is "safe" only because its Ok fails
 		// open; special-case it anyway rather than lean on that accident.)
-		switch ft.Filter.(type) {
-		case Knn, Text:
+		if isSourceLeaf(ft.Filter) {
 			return false
 		}
 		if strings.Join(ft.Path, ".") == fieldName {

--- a/query/filter.go
+++ b/query/filter.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/valyala/fastjson"
@@ -771,6 +772,167 @@ func (t Text) String() string {
 	return fmt.Sprintf(`{"$text":{"$search":%q}}`, t.Search)
 }
 
+// Knn is the {"<field>":{"$knn":{"$query":[…],"$k":N}}} approximate-nearest-neighbour
+// clause. It is NOT a predicate: it selects the K documents whose vector at this
+// field the field's vector index ranks closest to Query. "Is this document one of
+// the k nearest?" is a property of the CANDIDATE SET, not of the document, so no
+// per-document truth value exists.
+//
+// Ok therefore returns FALSE, unconditionally, and is unreachable in a correct
+// plan: the executor detects the clause on EVERY verb, drives the query from the
+// ANN source, strips the clause from the residual, and hard-errors on any
+// placement where it could not be stripped. The false FAILS CLOSED — a Knn that
+// somehow reaches a document-by-document evaluator matches nothing rather than
+// everything. Contrast query.Text, whose Ok returns TRUE: fail-open on
+// Query.Delete costs the collection. Never do that here.
+//
+// FAIL-CLOSED IS LOAD-BEARING IN TWO PLACES, both of which must be kept in sync:
+//   - ContainsKnn must walk Not/Nor: Not{Knn}.Ok == !false == MATCH-ALL. A $knn
+//     that reaches a Not is a mass delete through the front door, reachable from
+//     Query.Delete.
+//   - GuaranteesPresence must special-case Knn: it calls the inner filter's Ok
+//     DIRECTLY and reads !Ok(nil) && !Ok(null) as "guarantees presence" — so a
+//     fail-closed Ok yields TRUE, the AGGRESSIVE answer.
+type Knn struct {
+	Query []float32 // non-empty, finite; len checked against the index dim at detection
+	K     int       // required, 1..KnnMaxK
+	Ef    int       // 0 = auto; candidate/beam depth (numCandidates); >= K when set
+	Index string    // optional: vector index name (disambiguates 2 indexes on one field)
+}
+
+const (
+	// KnnMaxK bounds $k. Policy, not semantics: raising it later is
+	// non-breaking, lowering it is not — start conservative.
+	KnnMaxK = 10_000
+	// KnnMaxEf bounds $ef, the ANN candidate/beam depth.
+	KnnMaxEf = 65_536
+)
+
+// Ok fails closed: a Knn is not a predicate (see the type comment).
+func (k Knn) Ok(*anyenc.Value, *syncpool.DocBuffer) bool { return false }
+
+// IndexBounds returns bs verbatim: a Knn clause contributes no range-index
+// bounds. Verbatim matters — Or.IndexBounds detects "this branch contributed
+// nothing" by comparing lengths, and a shorter return silently discards
+// accumulated sibling bounds.
+func (k Knn) IndexBounds(_ string, bs Bounds) Bounds { return bs }
+
+// String renders the clause losslessly: MustParseCondition round-trips it.
+func (k Knn) String() string {
+	var b strings.Builder
+	b.WriteString(`{"$knn":{"$query":[`)
+	for i, f := range k.Query {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.FormatFloat(float64(f), 'g', -1, 32))
+	}
+	b.WriteString(`],"$k":`)
+	b.WriteString(strconv.Itoa(k.K))
+	if k.Ef != 0 {
+		b.WriteString(`,"$ef":`)
+		b.WriteString(strconv.Itoa(k.Ef))
+	}
+	if k.Index != "" {
+		b.WriteString(`,"$index":`)
+		b.WriteString(strconv.Quote(k.Index))
+	}
+	b.WriteString(`}}`)
+	return b.String()
+}
+
+// KnnOpt is an option for NewKnn.
+type KnnOpt func(*Knn)
+
+// KnnEf sets the explicit ANN candidate/beam depth ($ef).
+func KnnEf(ef int) KnnOpt { return func(k *Knn) { k.Ef = ef } }
+
+// KnnIndex names the vector index to search ($index) — required only when the
+// field has more than one vector index.
+func KnnIndex(name string) KnnOpt { return func(k *Knn) { k.Index = name } }
+
+// NewKnn is the programmatic constructor for the $knn clause: wrap it in a
+// query.Key naming the vector field. It exists because programmatic consumers
+// build their ANN filter as a Go value and never touch JSON; every validation
+// the parser applies is re-checked at query build time (detection), which is
+// the only validation a hand-built filter ever sees.
+func NewKnn(vec []float32, k int, opts ...KnnOpt) Knn {
+	kn := Knn{Query: vec, K: k}
+	for _, o := range opts {
+		o(&kn)
+	}
+	return kn
+}
+
+// ContainsKnn reports whether the tree contains a Knn ANYWHERE. It MUST walk
+// And/*And/Or/Nor/Not/Key: a Knn under Not would evaluate !false == match-all
+// (see the Knn type comment), so every consumer that rejects bad placements
+// needs the full walk.
+func ContainsKnn(f Filter) bool {
+	switch ft := f.(type) {
+	case Knn:
+		return true
+	case And:
+		return anyContainsKnn(ft)
+	case *And:
+		return anyContainsKnn(*ft)
+	case Or:
+		return anyContainsKnn(ft)
+	case Nor:
+		return anyContainsKnn(ft)
+	case Not:
+		return ContainsKnn(ft.Filter)
+	case Key:
+		return ContainsKnn(ft.Filter)
+	}
+	return false
+}
+
+func anyContainsKnn(fs []Filter) bool {
+	for _, f := range fs {
+		if ContainsKnn(f) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsSourceFilter reports whether the tree contains a SOURCE filter — one
+// matched by an index (Text, Knn) rather than by Ok. RECURSIVE, not a shallow
+// type check: the only legal shapes are Key{path, Knn} and And{Text, …}, so a
+// shallow test would return false for every real query and protect nobody.
+// External consumers that post-filter by calling Filter.Ok directly (the
+// subscription pattern) MUST reject these: Text.Ok matches everything, Knn.Ok
+// matches nothing.
+func ContainsSourceFilter(f Filter) bool {
+	switch ft := f.(type) {
+	case Text, Knn:
+		return true
+	case And:
+		return anyContainsSourceFilter(ft)
+	case *And:
+		return anyContainsSourceFilter(*ft)
+	case Or:
+		return anyContainsSourceFilter(ft)
+	case Nor:
+		return anyContainsSourceFilter(ft)
+	case Not:
+		return ContainsSourceFilter(ft.Filter)
+	case Key:
+		return ContainsSourceFilter(ft.Filter)
+	}
+	return false
+}
+
+func anyContainsSourceFilter(fs []Filter) bool {
+	for _, f := range fs {
+		if ContainsSourceFilter(f) {
+			return true
+		}
+	}
+	return false
+}
+
 // presenceNullProbe is an explicit JSON null used by GuaranteesPresence to test
 // whether a predicate rejects a present-but-null value, as distinct from a
 // missing field (which probes as a nil *anyenc.Value).
@@ -795,6 +957,16 @@ var presenceNullProbe = anyenc.MustParseJson("null")
 func GuaranteesPresence(f Filter, fieldName string) bool {
 	switch ft := f.(type) {
 	case Key:
+		// Source filters (Knn, Text) are matched by an index, not by Ok, so
+		// their Ok says nothing about presence. Knn is the trap this guard
+		// exists for: its fail-closed Ok would probe !false && !false == true —
+		// the AGGRESSIVE answer, feeding sparse-index selection with a claim
+		// the filter never made. (Text is "safe" only because its Ok fails
+		// open; special-case it anyway rather than lean on that accident.)
+		switch ft.Filter.(type) {
+		case Knn, Text:
+			return false
+		}
 		if strings.Join(ft.Path, ".") == fieldName {
 			var buf syncpool.DocBuffer
 			return !ft.Filter.Ok(nil, &buf) && !ft.Filter.Ok(presenceNullProbe, &buf)

--- a/query/filter_contract_test.go
+++ b/query/filter_contract_test.go
@@ -34,6 +34,7 @@ const filterZoo = `{
 	"n": {"$not": {"$eq": 3}},
 	"vf": {"$eq": {"$vector": [1, 2]}},
 	"vt": {"$type": "vectorF32"},
+	"vk": {"$knn": {"$query": [1, 2], "$k": 3}},
 	"$text": {"$search": "hello"}
 }`
 

--- a/query/knn_parse_test.go
+++ b/query/knn_parse_test.go
@@ -266,8 +266,9 @@ func TestKnn_OkIsFalse(t *testing.T) {
 	a := &anyenc.Arena{}
 	assert.False(t, kn.Ok(a.NewVectorF32([]float32{1, 2}), buf), "vector probe — even the exact query vector")
 
-	// IndexBounds returns bs VERBATIM (BUG-30 shape: Or.IndexBounds detects a
-	// non-contributing branch by comparing lengths).
+	// IndexBounds returns bs VERBATIM: Or.IndexBounds detects a
+	// non-contributing branch by comparing lengths, so a shorter return would
+	// silently discard accumulated sibling bounds.
 	bs := Bounds{{}}
 	assert.Equal(t, bs, kn.IndexBounds("v", bs))
 }
@@ -297,6 +298,22 @@ func TestContainsKnn_WalksEveryNode(t *testing.T) {
 	assert.True(t, ContainsKnn(Key{Path: []string{"w"}, Filter: Not{Filter: NewKnn([]float32{1}, 1)}}))
 	assert.True(t, ContainsKnn(NewKnn([]float32{1}, 1)), "a bare unwrapped Knn")
 	assert.False(t, ContainsKnn(MustParseCondition(`{"x":{"$gt":1},"$text":{"$search":"q"}}`)))
+
+	// Pointer-built composites satisfy Filter via value-receiver method sets
+	// and MUST be walked too — a skipped &Not{Knn} is a match-all reflection.
+	knnP := NewKnn([]float32{1}, 3)
+	assert.True(t, ContainsKnn(&kn), "*Key")
+	assert.True(t, ContainsKnn(&knnP), "*Knn")
+	assert.True(t, ContainsKnn(Key{Path: []string{"v"}, Filter: &knnP}), "Key{*Knn}")
+	notP := Not{Filter: kn}
+	assert.True(t, ContainsKnn(&notP), "*Not")
+	orP := Or{kn}
+	assert.True(t, ContainsKnn(&orP), "*Or")
+	norP := Nor{kn}
+	assert.True(t, ContainsKnn(&norP), "*Nor")
+	textP := Text{Search: "x"}
+	assert.True(t, ContainsSourceFilter(&textP), "*Text")
+	assert.False(t, GuaranteesPresence(Key{Path: []string{"v"}, Filter: &knnP}, "v"), "*Knn presence carve-out")
 
 	assert.True(t, ContainsSourceFilter(and))
 	assert.True(t, ContainsSourceFilter(MustParseCondition(`{"$text":{"$search":"q"},"x":1}`)))

--- a/query/knn_parse_test.go
+++ b/query/knn_parse_test.go
@@ -1,0 +1,304 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// TestKnnParse pins the $knn grammar: exactly one accepted form, and a
+// normative error string for every rejected shape. The error strings are part
+// of the contract — programmatic consumers see the same rules re-checked at
+// detection, and both layers must speak identically.
+func TestKnnParse(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			json string
+			want Knn
+		}{
+			{
+				name: "plain array query",
+				json: `{"v":{"$knn":{"$query":[0.5,1,2],"$k":10}}}`,
+				want: Knn{Query: []float32{0.5, 1, 2}, K: 10},
+			},
+			{
+				name: "packed $vector query",
+				json: `{"v":{"$knn":{"$query":{"$vector":[0.5,1,2]},"$k":10}}}`,
+				want: Knn{Query: []float32{0.5, 1, 2}, K: 10},
+			},
+			{
+				name: "all options",
+				json: `{"v":{"$knn":{"$query":[1],"$k":5,"$ef":400,"$index":"emb"}}}`,
+				want: Knn{Query: []float32{1}, K: 5, Ef: 400, Index: "emb"},
+			},
+			{
+				name: "ef == k",
+				json: `{"v":{"$knn":{"$query":[1],"$k":7,"$ef":7}}}`,
+				want: Knn{Query: []float32{1}, K: 7, Ef: 7},
+			},
+			{
+				name: "dotted path",
+				json: `{"a.b":{"$knn":{"$query":[1],"$k":1}}}`,
+				want: Knn{Query: []float32{1}, K: 1},
+			},
+			{
+				name: "under $and",
+				json: `{"$and":[{"v":{"$knn":{"$query":[1],"$k":3}}},{"x":1}]}`,
+				want: Knn{Query: []float32{1}, K: 3},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				f, err := ParseCondition(tc.json)
+				require.NoError(t, err)
+				require.True(t, ContainsKnn(f), "parsed filter must contain the Knn")
+				var got *Knn
+				var walk func(Filter)
+				walk = func(f Filter) {
+					switch ft := f.(type) {
+					case Knn:
+						got = &ft
+					case Key:
+						walk(ft.Filter)
+					case And:
+						for _, s := range ft {
+							walk(s)
+						}
+					case *And:
+						for _, s := range *ft {
+							walk(s)
+						}
+					}
+				}
+				walk(f)
+				require.NotNil(t, got)
+				assert.Equal(t, tc.want, *got)
+			})
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			json    string
+			wantErr string
+		}{
+			{
+				name:    "not an object: bare array",
+				json:    `{"v":{"$knn":[1,2,3]}}`,
+				wantErr: `$knn must be an object, e.g. {"$knn":{"$query":[...],"$k":10}}`,
+			},
+			{
+				name: "not an object: sole-key $vector (eaten by extjson into a vector VALUE)",
+				json: `{"v":{"$knn":{"$vector":[1,2]}}}`,
+				// anyenc decodes the single-key {"$vector":[…]} object into a
+				// TypeVectorF32 value before the parser sees it, so this fails
+				// the object check — not the unknown-field check.
+				wantErr: `$knn must be an object`,
+			},
+			{
+				name:    "missing $query",
+				json:    `{"v":{"$knn":{"$k":10}}}`,
+				wantErr: `$knn requires $query`,
+			},
+			{
+				name:    "$query not numeric",
+				json:    `{"v":{"$knn":{"$query":"abc","$k":10}}}`,
+				wantErr: `$knn: $query must be an array of numbers or {"$vector":[...]}`,
+			},
+			{
+				name:    "$query mixed array",
+				json:    `{"v":{"$knn":{"$query":[1,"x"],"$k":10}}}`,
+				wantErr: `$knn: $query must be an array of numbers or {"$vector":[...]}`,
+			},
+			{
+				name:    "$query empty",
+				json:    `{"v":{"$knn":{"$query":[],"$k":10}}}`,
+				wantErr: `$knn: $query must be non-empty`,
+			},
+			{
+				name:    "missing $k",
+				json:    `{"v":{"$knn":{"$query":[1,2]}}}`,
+				wantErr: `$knn requires $k (the number of neighbours to select)`,
+			},
+			{
+				name:    "$k zero",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":0}}}`,
+				wantErr: `$knn: $k must be an integer in [1, 10000]`,
+			},
+			{
+				name:    "$k negative",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":-3}}}`,
+				wantErr: `$knn: $k must be an integer in [1, 10000]`,
+			},
+			{
+				name:    "$k too big",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10001}}}`,
+				wantErr: `$knn: $k must be an integer in [1, 10000]`,
+			},
+			{
+				name:    "$k fractional",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":2.5}}}`,
+				wantErr: `$knn: $k must be an integer in [1, 10000]`,
+			},
+			{
+				name:    "$k not a number",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":"ten"}}}`,
+				wantErr: `$knn: $k must be an integer in [1, 10000]`,
+			},
+			{
+				name:    "$ef below $k",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$ef":5}}}`,
+				wantErr: `$knn: $ef must be an integer in [$k, 65536]`,
+			},
+			{
+				name:    "$ef too big",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$ef":65537}}}`,
+				wantErr: `$knn: $ef must be an integer in [$k, 65536]`,
+			},
+			{
+				name:    "$ef fractional",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$ef":10.5}}}`,
+				wantErr: `$knn: $ef must be an integer in [$k, 65536]`,
+			},
+			{
+				name:    "$index not a string",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$index":7}}}`,
+				wantErr: `$knn: $index must be a string`,
+			},
+			{
+				name:    "unknown field",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$bogus":1}}}`,
+				wantErr: `unknown $knn field: $bogus`,
+			},
+			{
+				name:    "$vector as an option key (with other keys, so not eaten)",
+				json:    `{"v":{"$knn":{"$vector":[1,2],"$k":10}}}`,
+				wantErr: `unknown $knn field: $vector (did you mean "$query"?`,
+			},
+			{
+				name:    "reserved $maxDistance",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$maxDistance":0.5}}}`,
+				wantErr: `$knn: $maxDistance is reserved and not supported`,
+			},
+			{
+				name:    "reserved $minScore",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$minScore":0.5}}}`,
+				wantErr: `$knn: $minScore is reserved and not supported`,
+			},
+			{
+				name:    "reserved $prefilter",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$prefilter":true}}}`,
+				wantErr: `$knn: $prefilter is reserved and not supported`,
+			},
+			{
+				name:    "reserved $nprobe",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10,"$nprobe":8}}}`,
+				wantErr: `$knn: $nprobe is reserved and not supported`,
+			},
+			{
+				name:    "mixed with another operator on the field",
+				json:    `{"v":{"$knn":{"$query":[1],"$k":10},"$exists":true}}`,
+				wantErr: `$knn must be the only operator on its field`,
+			},
+			{
+				name:    "under $not",
+				json:    `{"v":{"$not":{"$knn":{"$query":[1],"$k":10}}}}`,
+				wantErr: `$knn is not allowed under $not`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := ParseCondition(tc.json)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			})
+		}
+	})
+
+	t.Run("NaN and Inf rejected", func(t *testing.T) {
+		// JSON cannot spell NaN/Inf, so exercise the guard through the packed
+		// $vector encoding, which carries raw float32 bits.
+		a := &anyenc.Arena{}
+		obj := a.NewObject()
+		obj.Set("$query", a.NewVectorF32([]float32{1, float32(nan())}))
+		obj.Set("$k", a.NewNumberInt(3))
+		_, err := parseKnn(obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "$knn: $query must contain finite numbers")
+	})
+}
+
+func nan() float64 {
+	var zero float64
+	return zero / zero
+}
+
+// TestKnnString_RoundTrip pins the lossless String() contract:
+// MustParseCondition(f.String()) reproduces the filter exactly. Contrast
+// Text.String(), which is lossy — do not repeat that here.
+func TestKnnString_RoundTrip(t *testing.T) {
+	for _, kn := range []Knn{
+		{Query: []float32{0.1, 0.25, -3e-7}, K: 10},
+		{Query: []float32{1}, K: 1, Ef: 64},
+		{Query: []float32{1.5, 2.5}, K: 3, Ef: 4096, Index: "emb"},
+		NewKnn([]float32{9.75}, 2, KnnEf(8), KnnIndex("x")),
+	} {
+		f := MustParseCondition(`{"v":` + kn.String() + `}`)
+		key, ok := f.(Key)
+		require.True(t, ok, "round-trip of %s", kn.String())
+		require.Equal(t, kn, key.Filter, "String() must round-trip losslessly: %s", kn.String())
+	}
+}
+
+// TestKnn_OkIsFalse pins fail-closed Ok — the opposite of Text.Ok's fail-open
+// (which is a bug when reached: a fail-open source filter on Query.Delete
+// costs the collection; a fail-closed one costs zero rows and is loud).
+func TestKnn_OkIsFalse(t *testing.T) {
+	kn := NewKnn([]float32{1, 2}, 3)
+	buf := &syncpool.DocBuffer{}
+	assert.False(t, kn.Ok(nil, buf), "nil probe")
+	assert.False(t, kn.Ok(anyenc.MustParseJson(`5`), buf), "scalar probe")
+	assert.False(t, kn.Ok(anyenc.MustParseJson(`[1,2]`), buf), "array probe")
+	a := &anyenc.Arena{}
+	assert.False(t, kn.Ok(a.NewVectorF32([]float32{1, 2}), buf), "vector probe — even the exact query vector")
+
+	// IndexBounds returns bs VERBATIM (BUG-30 shape: Or.IndexBounds detects a
+	// non-contributing branch by comparing lengths).
+	bs := Bounds{{}}
+	assert.Equal(t, bs, kn.IndexBounds("v", bs))
+}
+
+// TestGuaranteesPresence_SourceFilters pins the source-filter carve-out:
+// GuaranteesPresence probes the inner filter's Ok directly, so fail-closed
+// Knn.Ok would read as "guarantees presence" — the aggressive answer, feeding
+// sparse-index selection. Both source filters must answer false.
+func TestGuaranteesPresence_SourceFilters(t *testing.T) {
+	assert.False(t, GuaranteesPresence(Key{Path: []string{"v"}, Filter: NewKnn([]float32{1}, 3)}, "v"))
+	assert.False(t, GuaranteesPresence(Key{Path: []string{"v"}, Filter: Text{Search: "x"}}, "v"))
+	// Sanity: a real predicate that rejects nil and null still answers true.
+	assert.True(t, GuaranteesPresence(MustParseCondition(`{"v":{"$gt":1}}`), "v"))
+}
+
+// TestContainsKnn_WalksEveryNode pins the full-tree walk: a Knn under Not/Nor
+// is exactly the match-all reflection the walk exists to catch.
+func TestContainsKnn_WalksEveryNode(t *testing.T) {
+	kn := Key{Path: []string{"v"}, Filter: NewKnn([]float32{1}, 3)}
+	and := And{kn, MustParseCondition(`{"x":1}`)}
+	assert.True(t, ContainsKnn(kn))
+	assert.True(t, ContainsKnn(and))
+	assert.True(t, ContainsKnn(&and))
+	assert.True(t, ContainsKnn(Or{kn}))
+	assert.True(t, ContainsKnn(Nor{kn}))
+	assert.True(t, ContainsKnn(Not{Filter: kn}))
+	assert.True(t, ContainsKnn(Key{Path: []string{"w"}, Filter: Not{Filter: NewKnn([]float32{1}, 1)}}))
+	assert.True(t, ContainsKnn(NewKnn([]float32{1}, 1)), "a bare unwrapped Knn")
+	assert.False(t, ContainsKnn(MustParseCondition(`{"x":{"$gt":1},"$text":{"$search":"q"}}`)))
+
+	assert.True(t, ContainsSourceFilter(and))
+	assert.True(t, ContainsSourceFilter(MustParseCondition(`{"$text":{"$search":"q"},"x":1}`)))
+	assert.False(t, ContainsSourceFilter(MustParseCondition(`{"x":{"$gt":1}}`)))
+}

--- a/query_vector_verbs_test.go
+++ b/query_vector_verbs_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/anyproto/any-store/v2/anyenc"
 )
 
-// A vector clause must denote the same document set on every verb. Before the
-// shared compiler, only Iter ran detectVectorQuery: a valid clause was a
+// A $knn clause must denote the same document set on every verb. Before the
+// shared compiler, only Iter ran vector detection: a valid clause was a
 // silent no-op on Update/Delete (matched nothing as a literal filter), and an
 // invalid one degraded to a scalar comparison. Now the write verbs compile
-// through the same seam as Iter.
+// through the same seam as Iter, and $k bounds the blast radius of a write to
+// a number the caller typed.
 
 func vectorVerbColl(t *testing.T) Collection {
 	fx := newFixture(t)
@@ -31,17 +32,19 @@ func vectorVerbColl(t *testing.T) Collection {
 	return coll
 }
 
-const vectorVerbClause = `{"v":[3,1,2]}`
+func vectorVerbClause(k int) string {
+	return fmt.Sprintf(`{"v":{"$knn":{"$query":[3,1,2],"$k":%d}}}`, k)
+}
 
 func TestVectorClauseDelete_RemovesExactlyIterSelection(t *testing.T) {
 	coll := vectorVerbColl(t)
 
-	want := writeOrderIterIds(t, coll.Find(vectorVerbClause).Limit(5))
-	require.Len(t, want, 5, "test premise: the ANN query returns a bounded candidate set")
+	want := writeOrderIterIds(t, coll.Find(vectorVerbClause(5)))
+	require.Len(t, want, 5, "test premise: $k bounds the denoted set")
 
-	res, err := coll.Find(vectorVerbClause).Limit(5).Delete(ctx)
+	res, err := coll.Find(vectorVerbClause(5)).Delete(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 5, res.Modified, "a valid vector clause must not be a silent no-op on Delete")
+	assert.Equal(t, 5, res.Modified, "a valid $knn clause must not be a silent no-op on Delete")
 
 	survivors := writeOrderSurvivors(t, coll)
 	for _, id := range want {
@@ -53,25 +56,32 @@ func TestVectorClauseDelete_RemovesExactlyIterSelection(t *testing.T) {
 func TestVectorClauseUpdate_ModifiesExactlyIterSelection(t *testing.T) {
 	coll := vectorVerbColl(t)
 
-	want := writeOrderIterIds(t, coll.Find(vectorVerbClause).Limit(4))
+	want := writeOrderIterIds(t, coll.Find(vectorVerbClause(4)))
 	require.Len(t, want, 4)
 
-	res, err := coll.Find(vectorVerbClause).Limit(4).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	res, err := coll.Find(vectorVerbClause(4)).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
 	require.NoError(t, err)
-	assert.Equal(t, 4, res.Modified, "a valid vector clause must not be a silent no-op on Update")
+	assert.Equal(t, 4, res.Modified, "a valid $knn clause must not be a silent no-op on Update")
 
 	touched := writeOrderIterIds(t, coll.Find(`{"n":1}`))
 	assert.ElementsMatch(t, want, touched)
 }
 
 func TestVectorClauseInvalid_WriteVerbsAgreeWithIter(t *testing.T) {
-	// Whatever Iter decides about a malformed vector query — reject or treat
-	// as an ordinary (never-matching) filter — the write verbs must decide
-	// identically, and the collection must stay intact either way.
+	// Whatever Iter decides about a clause on the vector field — reject it or
+	// treat it as an ordinary (never-matching) filter — the write verbs must
+	// decide identically, and the collection must stay intact either way.
+	// Note on `{"v":{"$gt":…}}`: these docs store v as a PLAIN array, so an
+	// ordering op compares element-wise (array semantics) — a deliberately
+	// ordinary filter now, not an ANN shape. $gt:5000 exceeds every element,
+	// so it legally matches nothing; Rule V (vector-vs-scalar) applies only to
+	// packed TypeVectorF32 values and is pinned in query/filter_vector_test.go.
 	coll := vectorVerbColl(t)
 	for _, cond := range []string{
-		`{"v":{"$gt":1}}`,
-		`{"v":[1,2]}`, // wrong dimension
+		`{"v":{"$gt":5000}}`,                     // ordering op on the vector field: ordinary filter, matches nothing
+		`{"v":[1,2]}`,                            // wrong dim: not the ANN shape — ordinary filter
+		`{"v":[3,1,2]}`,                          // dim-sized bare array: the legacy ANN spelling — hard error
+		`{"v":{"$knn":{"$query":[1,2],"$k":5}}}`, // wrong-dim $query — hard error
 	} {
 		iterOK := true
 		if it, ierr := coll.Find(cond).Iter(ctx); ierr != nil {
@@ -87,6 +97,10 @@ func TestVectorClauseInvalid_WriteVerbsAgreeWithIter(t *testing.T) {
 			assert.Zero(t, res.Modified, "cond=%s matches no documents", cond)
 		}
 
+		_, cerr := coll.Find(cond).Count(ctx)
+		assert.Equal(t, iterOK, cerr == nil,
+			"cond=%s: Count's accept/reject decision must match Iter's", cond)
+
 		remaining, err := coll.Count(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, 20, remaining, "cond=%s: collection must be intact", cond)
@@ -96,8 +110,9 @@ func TestVectorClauseInvalid_WriteVerbsAgreeWithIter(t *testing.T) {
 func TestVectorClauseCount_MatchesIter(t *testing.T) {
 	coll := vectorVerbColl(t)
 	for name, q := range map[string]func() Query{
-		"plain": func() Query { return coll.Find(vectorVerbClause) },
-		"limit": func() Query { return coll.Find(vectorVerbClause).Limit(5) },
+		"plain":  func() Query { return coll.Find(vectorVerbClause(7)) },
+		"limit":  func() Query { return coll.Find(vectorVerbClause(7)).Limit(5) },
+		"offset": func() Query { return coll.Find(vectorVerbClause(7)).Offset(3).Limit(3) },
 	} {
 		t.Run(name, func(t *testing.T) {
 			ids := writeOrderIterIds(t, q())
@@ -108,24 +123,22 @@ func TestVectorClauseCount_MatchesIter(t *testing.T) {
 	}
 }
 
-func TestVectorClauseUnboundedWrite_Rejected(t *testing.T) {
-	// A vector clause denotes an ANN candidate window, not a predicate: an
-	// unbounded write must state its blast radius. Before the seam this call
-	// was a silent no-op (the clause degraded to a literal filter); executing
-	// the ANN plan unbounded would instead mutate the whole candidate set —
-	// both silently wrong, so it errors until $knn makes k part of the clause.
+func TestVectorClauseUnboundedWrite_BoundedByK(t *testing.T) {
+	// $k is the blast radius: an Update/Delete with no .Limit() mutates exactly
+	// the k nearest — never "however many candidates the search yields". The
+	// old ErrVectorWriteWithoutLimit guard is retired by construction: the
+	// unbounded-delete query it rejected is unrepresentable under $knn.
 	coll := vectorVerbColl(t)
 
-	_, err := coll.Find(vectorVerbClause).Delete(ctx)
-	require.ErrorIs(t, err, ErrVectorWriteWithoutLimit)
-	_, err = coll.Find(vectorVerbClause).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
-	require.ErrorIs(t, err, ErrVectorWriteWithoutLimit)
+	res, err := coll.Find(vectorVerbClause(5)).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 5, res.Modified, "Delete removes exactly $k documents")
 
 	remaining, err := coll.Count(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 20, remaining, "collection intact")
+	assert.Equal(t, 15, remaining)
 
-	// Reads stay unbounded-legal.
-	ids := writeOrderIterIds(t, coll.Find(vectorVerbClause))
-	assert.NotEmpty(t, ids)
+	res, err = coll.Find(vectorVerbClause(4)).Update(ctx, anyenc.MustParseJson(`{"$inc":{"n":1}}`))
+	require.NoError(t, err)
+	assert.Equal(t, 4, res.Modified, "Update visits exactly $k documents")
 }

--- a/query_verbcoherence_test.go
+++ b/query_verbcoherence_test.go
@@ -1,0 +1,174 @@
+package anystore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// TestVerbCoherence_Knn pins the central $knn invariant: for a fixed query Q on
+// a fixed snapshot, every verb denotes the same document sequence Rows(Q) —
+// Count(Q) == len(Rows(Q)), Delete(Q) removes exactly set(Rows(Q)), Update(Q)
+// visits exactly that set, Explain(Q) describes the ANN plan, and two identical
+// runs return identical output (source-level determinism).
+//
+// Matrix: all five index modes × {no residual, selective residual, _distance
+// residual} × {no sort, real-field sort, _distance sort} × {no paging,
+// Limit(3), Offset(2).Limit(3)}. The _distance residual on the non-Iter verbs
+// is the axis that catches the injectDistance gating trap: if injection were
+// gated on the sidecar, Comp.Ok(nil) would be TRUE for $lt against a missing
+// _distance and a bounded Delete would remove all k instead of the thresholded
+// subset.
+func TestVerbCoherence_Knn(t *testing.T) {
+	const (
+		dim = 8
+		n   = 400
+		k   = 6
+	)
+
+	// v = [i/10, fixed…] → L2 distance to query [q0, fixed…] is |i-q|/10:
+	// distinct per doc, exact under PQ re-rank, and the _distance threshold
+	// below has a predictable membership. "r" is a sort field uncorrelated
+	// with id; "a" is a ~50% selective residual field.
+	docJSON := func(i int) string {
+		return fmt.Sprintf(`{"id":%d,"v":[%g,1,2,3,4,5,6,7],"a":%d,"r":%d}`,
+			i, float32(i)/10, i%2, (i*7919)%n)
+	}
+	queryVec := `[20.05,1,2,3,4,5,6,7]` // between docs 200 and 201: no exact ties, no self-doc
+
+	modes := []struct {
+		name string
+		mode VectorMode
+	}{
+		{"btree", VectorModeBTree},
+		{"hybrid", VectorModeHybrid},
+		{"bruteforce", VectorModeBruteForce},
+		{"ivfpq", VectorModeIVFPQ},
+		{"ivfsq", VectorModeIVFSQ},
+	}
+	residuals := []struct {
+		name string
+		cond string // appended after the $knn clause
+	}{
+		{"none", ""},
+		{"selective", `,"a":1`},
+		// |i-200.5|/10 < 0.35 → docs 198..203 (6 docs) are within the
+		// threshold BEFORE the k-cut; survivors depend on the ANN ranking.
+		{"distance", `,"_distance":{"$lt":0.35}`},
+	}
+	sorts := []struct {
+		name string
+		sort []any
+	}{
+		{"none", nil},
+		{"real-field", []any{"-r"}},
+		{"distance", []any{"_distance"}},
+	}
+	pagings := []struct {
+		name          string
+		limit, offset uint
+	}{
+		{"all", 0, 0},
+		{"limit3", 3, 0},
+		{"offset2limit3", 3, 2},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			fx := newFixture(t)
+			coll, err := fx.CreateCollection(ctx, "vc_"+m.name)
+			require.NoError(t, err)
+			// Docs first: IVF trains its codebooks from existing documents.
+			docs := make(map[int]string, n)
+			for i := 0; i < n; i++ {
+				docs[i] = docJSON(i)
+				require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(docs[i])))
+			}
+			require.NoError(t, coll.CreateIndex(ctx, IndexInfo{
+				Name: "emb", Kind: IndexKindVector,
+				Vector: &VectorParams{Field: "v", Dim: dim, Metric: VectorL2, EfSearch: 64, Mode: m.mode},
+			}))
+
+			if m.mode == VectorModeHybrid {
+				// Warm the RAM l0 mirror and dirty its overlay: read verbs
+				// (Iter/Count) traverse the mirror while write verbs
+				// (Delete/Update) traverse raw btree adjacency inside the
+				// write tx — the coherence below asserts the two are
+				// candidate-identical, an equivalence nothing exercised while
+				// the write verbs never reached the vector path at all.
+				for w := 0; w < 3; w++ {
+					_, werr := coll.Find(fmt.Sprintf(`{"v":{"$knn":{"$query":%s,"$k":%d}}}`, queryVec, k)).Count(ctx)
+					require.NoError(t, werr)
+				}
+				require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(docJSON(n))))
+				require.NoError(t, coll.DeleteId(ctx, n))
+			}
+
+			for _, res := range residuals {
+				for _, srt := range sorts {
+					for _, pg := range pagings {
+						name := fmt.Sprintf("res=%s/sort=%s/page=%s", res.name, srt.name, pg.name)
+						t.Run(name, func(t *testing.T) {
+							cond := fmt.Sprintf(`{"v":{"$knn":{"$query":%s,"$k":%d}}%s}`, queryVec, k, res.cond)
+							mkQ := func() Query {
+								q := coll.Find(cond)
+								if srt.sort != nil {
+									q = q.Sort(srt.sort...)
+								}
+								if pg.limit > 0 {
+									q = q.Limit(pg.limit)
+								}
+								if pg.offset > 0 {
+									q = q.Offset(pg.offset)
+								}
+								return q
+							}
+
+							ids := writeOrderIterIds(t, mkQ())
+							assert.LessOrEqual(t, len(ids), k, "the k-cut bounds every page")
+							assert.Equal(t, ids, writeOrderIterIds(t, mkQ()),
+								"two identical runs must return identical sequences")
+
+							count, err := mkQ().Count(ctx)
+							require.NoError(t, err)
+							assert.Equal(t, len(ids), count, "Count(Q) == len(Rows(Q))")
+
+							exp, err := mkQ().Explain(ctx)
+							require.NoError(t, err)
+							assert.Contains(t, exp.Sql, "KnnSearch(", "Explain describes the ANN plan: %s", exp.Sql)
+
+							upd, err := mkQ().Update(ctx, anyenc.MustParseJson(`{"$inc":{"touched":1}}`))
+							require.NoError(t, err)
+							assert.Equal(t, len(ids), upd.Matched, "Update(Q) visits exactly Rows(Q)")
+
+							before, err := coll.Count(ctx)
+							require.NoError(t, err)
+							del, err := mkQ().Delete(ctx)
+							require.NoError(t, err)
+							assert.Equal(t, len(ids), del.Modified, "Delete(Q) removes exactly len(Rows(Q))")
+							after, err := coll.Count(ctx)
+							require.NoError(t, err)
+							assert.Equal(t, before-len(ids), after)
+							for _, id := range ids {
+								doc, gerr := coll.FindId(ctx, id)
+								assert.Error(t, gerr, "doc %d was in Rows(Q) and must be deleted (got %v)", id, doc)
+							}
+
+							// Restore the deleted docs so the next cell sees
+							// the same document set (the index graph churns,
+							// which only adds realism — each cell is
+							// self-consistent on its own snapshot).
+							for _, id := range ids {
+								require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(docs[id])))
+							}
+						})
+					}
+				}
+			}
+		})
+	}
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -529,147 +529,128 @@ func (c *collection) reconcileVectorIndexesLocked(tx *btree.ReadTx, infos []Inde
 	}
 }
 
-// ErrMultipleVectorClauses is returned when a query constrains more than one
-// vector-indexed field (unsupported).
+// ErrMultipleVectorClauses is returned when a query carries more than one $knn
+// clause (unsupported).
 var ErrMultipleVectorClauses = errors.New("any-store: query has multiple vector clauses")
 
-// ErrInvalidVectorQuery is returned when a clause targets a vector-indexed field
-// but isn't a valid ANN clause: it must be an equality against a numeric array of
-// the index's dimension, e.g. {embedding: [..dim floats..]}.
-var ErrInvalidVectorQuery = errors.New("any-store: invalid vector query clause")
+// ErrInvalidVectorQuery is returned when a $knn clause is malformed: an empty or
+// non-finite $query, a $query whose length differs from the index dimension, or
+// an out-of-range $k/$ef. It says nothing about non-$knn clauses on a
+// vector-indexed field — those are ordinary filters on every verb.
+var ErrInvalidVectorQuery = errors.New("any-store: invalid $knn clause")
 
-// ErrVectorWriteWithoutLimit rejects an Update/Delete whose filter is a vector
-// clause but which carries no Limit. A vector clause denotes an ANN candidate
-// WINDOW (its size depends on tunable search parameters), not a predicate — an
-// unbounded write would mutate however many candidates the search happens to
-// yield. State the blast radius with .Limit(k); the planned $knn operator
-// moves k into the clause itself.
-var ErrVectorWriteWithoutLimit = errors.New("any-store: a vector-clause Update/Delete requires an explicit Limit")
+// ErrNoVectorIndex is returned when a $knn clause targets a field with no vector
+// index (or $index names one that doesn't exist). Exact search is an index MODE
+// (VectorModeBruteForce), not a fallback.
+var ErrNoVectorIndex = errors.New("any-store: no vector index on field")
+
+// ErrAmbiguousVectorIndex is returned when a $knn clause targets a field with
+// more than one vector index and no $index to disambiguate. Without it the
+// searched index — and therefore the selected documents, on Delete too — would
+// depend on index load order.
+var ErrAmbiguousVectorIndex = errors.New("any-store: field has multiple vector indexes; name one with $index")
+
+// ErrKnnBadPlacement is returned when a $knn clause sits anywhere other than the
+// top level or under $and: a ranked source cannot be a disjunct ($or/$nor), a
+// negation ($not — fail-closed Ok would reflect to match-all), or a nested
+// sub-filter.
+var ErrKnnBadPlacement = errors.New("any-store: $knn is only allowed at the top level or under $and")
+
+// ErrKnnWithText is returned when one query carries both $knn and $text: a query
+// has one source.
+var ErrKnnWithText = errors.New("any-store: $knn and $text cannot be combined in one query")
+
+// ErrLegacyVectorClause is returned, on every verb, for the pre-$knn ANN
+// spelling — a bare equality of a dim-sized numeric array against a
+// vector-indexed field. Silent demotion to a literal filter would mean 0 rows
+// (packed storage) or 1 row (plain-array storage) with err == nil; a hard error
+// turns every migration point into a test failure instead.
+var ErrLegacyVectorClause = errors.New(`any-store: field has a vector index; a bare-array equality clause is no longer an ANN query — use {"$knn":{"$query":[...],"$k":N}} (or query.NewKnn) to search it`)
 
 // ErrDistanceWithoutVector is returned when the synthetic _distance field is used
-// in a filter or sort but the query has no vector clause to produce it.
+// in a filter or sort but the query has no $knn clause to produce it.
 var ErrDistanceWithoutVector = errors.New("any-store: _distance is only available in a vector query")
 
-// detectVectorQuery inspects the parsed filter for an equality on a
-// vector-indexed field (`{vectorField: [..]}`). If found it returns a planner
-// spec and the residual filter (the original filter minus the vector clause —
-// keeping _distance predicates and any other field filters). Returns
-// (nil, original, nil) when this is not a vector query.
-func (q *collQuery) detectVectorQuery() (*qplanner.VectorQuerySpec, query.Filter, error) {
-	vidxs := q.c.loadVectorIndexes()
-	if len(vidxs) == 0 || q.cond == nil {
-		// No vector clause is possible, so _distance (in filter or sort) is invalid.
-		if filterRefsField(q.cond, qplanner.DistanceField) || sortRefsField(q.sort, qplanner.DistanceField) {
-			return nil, nil, ErrDistanceWithoutVector
-		}
+// detectKnnQuery is a SYNTACTIC operator check (template: detectFtsQuery): it
+// finds the $knn clause, validates it, resolves the vector index, and returns
+// the planner spec plus the residual filter (the original tree minus the Knn
+// node). Returns (nil, original, nil) when the query has no $knn.
+//
+// It runs on EVERY verb, via compilePlan, and it is AUTHORITATIVE: every rule
+// parseKnn enforces is re-checked here, because ParseCondition short-circuits
+// on an already-built Filter and the production consumers build their ANN
+// filter programmatically — this walk is the only validation they ever see.
+func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, error) {
+	if q.cond == nil || !query.ContainsKnn(q.cond) {
 		return nil, q.cond, nil
 	}
-
-	var clauses []query.Filter
-	switch f := q.cond.(type) {
-	case query.And:
-		clauses = f
-	default:
-		clauses = []query.Filter{q.cond}
+	node, err := findKnnClause(q.cond)
+	if err != nil {
+		return nil, nil, err
+	}
+	knn, _ := node.Filter.(query.Knn)
+	if err = validateKnnClause(knn); err != nil {
+		return nil, nil, err
+	}
+	field := strings.Join(node.Path, ".")
+	vi, err := resolveKnnIndex(q.c.loadVectorIndexes(), field, knn.Index)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(knn.Query) != vi.dim {
+		return nil, nil, fmt.Errorf("%w: $knn on %q: got %d dims, index has %d", ErrInvalidVectorQuery, field, len(knn.Query), vi.dim)
 	}
 
-	vecIdx := -1
-	var vi *vectorIndex
-	var qvec []float32
-	for i, cl := range clauses {
-		k, isKey := cl.(query.Key)
-		if !isKey {
-			continue
-		}
-		field := strings.Join(k.Path, ".")
-		v := findVectorIndexByField(vidxs, field)
-		if v == nil {
-			continue // ordinary (non-vector) field clause
-		}
-		// The clause targets a vector-indexed field, so it must be a valid ANN
-		// clause — an equality against a dim-sized numeric array. Anything else
-		// (a range op, a scalar, a wrong-dim array) is a mistake, not a silent
-		// fall-through to a literal field match.
-		comp, isComp := k.Filter.(*query.Comp)
-		if !isComp || comp.CompOp != query.CompOpEq {
-			return nil, nil, fmt.Errorf("%w: field %q must be an equality against a %d-dim array", ErrInvalidVectorQuery, field, v.dim)
-		}
-		vec, derr := decodeVectorValue(comp.EqValue, v.dim)
-		if derr != nil {
-			return nil, nil, fmt.Errorf("%w: field %q: %v", ErrInvalidVectorQuery, field, derr)
-		}
-		if vecIdx >= 0 {
-			return nil, nil, ErrMultipleVectorClauses
-		}
-		vecIdx, vi, qvec = i, v, vec
+	residual := knnResidualFilter(q.cond)
+	// HARD post-condition, not an optimization: a Knn leaking into the residual
+	// FilterIter fail-closes every candidate — Iter = 0 rows, Delete = no-op,
+	// err == nil, on all verbs. findKnnClause has already rejected every shape
+	// the strip cannot handle, so this is unreachable; keep it that way.
+	if query.ContainsKnn(residual) {
+		return nil, nil, fmt.Errorf("%w: internal: $knn survived residual extraction", ErrKnnBadPlacement)
 	}
-	if vecIdx < 0 {
-		// Not a vector query: _distance is synthetic and only produced by a vector
-		// search, so referencing it in a filter or sort here is an error rather
-		// than a silent match-everything / sort-on-nothing.
-		if filterRefsField(q.cond, qplanner.DistanceField) || sortRefsField(q.sort, qplanner.DistanceField) {
-			return nil, nil, ErrDistanceWithoutVector
-		}
-		return nil, q.cond, nil
-	}
+	hasResidual := residual != nil && !isAllQueryFilter(residual)
 
-	residual := residualFilter(clauses, vecIdx)
 	captured := vi
-	if vi.isIVF() {
-		// IVF-PQ: probe a few cells (contiguous range scans), re-rank by exact
-		// distance. ef is the re-rank depth / candidate count, sized to the page
-		// window; nprobe is fixed in the index. SearchCandidates returns them
-		// (distance, docId) ascending (TotallyOrdered) — measurably faster than letting SortIter sort, as
-		// the planner then skips the SortIter for the default distance order and
-		// streams straight to LimitIter; an explicit multi-key Sort still uses SortIter.
-		ef := chooseEf(int(q.vectorEf), captured.ivf.NProbe()*8, int(q.limit)+int(q.offset), residual != nil)
-		spec := &qplanner.VectorQuerySpec{
-			Query:   qvec,
-			Ef:      ef,
-			TotallyOrdered: true,
-			Search: func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
-				cands, err := captured.ivf.SearchCandidates(tx, qv, ef)
-				if err != nil {
-					return nil, err
-				}
-				out := make([]qplanner.VectorCandidate, len(cands))
-				for i, c := range cands {
-					out[i] = qplanner.VectorCandidate{DocId: c.DocID, Distance: c.Distance}
-				}
-				return out, nil
-			},
-		}
-		return spec, residual, nil
-	}
-	if vi.ix == nil {
-		// Brute-force: the scan computes an exact distance for every document,
-		// so it can rank and (when nothing downstream needs the full set) cut
-		// to the query window itself. With a residual filter or an explicit
-		// sort the full ranked set is returned — FilterIter/SortIter/LimitIter
-		// keep their exact semantics over it.
-		topK := 0
-		if residual == nil && q.sort == nil && q.limit > 0 {
-			topK = int(q.limit) + int(q.offset)
-		}
-		spec := &qplanner.VectorQuerySpec{
-			Query:   qvec,
-			TotallyOrdered: true, // bruteVectorCandidates returns (distance, docId) ascending
-			Search: func(tx *btree.ReadTx, qv []float32, _ int) ([]qplanner.VectorCandidate, error) {
-				return q.c.bruteVectorCandidates(tx, captured, qv, topK)
-			},
-		}
-		return spec, residual, nil
-	}
-	// Size the candidate list for the whole window the caller will page through
-	// (offset+limit), over-fetching when a residual filter will discard some. The
-	// limit/offset themselves are still applied downstream by Sort/LimitIter over
-	// the post-filter stream — ef only governs how many candidates the ANN yields.
-	ef := chooseEf(int(q.vectorEf), vi.ix.EfSearch(), int(q.limit)+int(q.offset), residual != nil)
 	spec := &qplanner.VectorQuerySpec{
-		Query:   qvec,
-		Ef:      ef,
-		TotallyOrdered: true, // SearchCandidates yields (distance, docId) ascending
-		Search: func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
+		Query:          knn.Query,
+		K:              knn.K,
+		IndexName:      vi.info.Name,
+		TotallyOrdered: true, // all three backends return (distance, docId) ascending
+	}
+	switch {
+	case vi.isIVF():
+		// IVF: probe a few cells (contiguous range scans), re-rank by exact
+		// distance. ef is the re-rank depth / candidate count; nprobe is fixed
+		// in the index.
+		spec.Ef = knnEf(knn.Ef, captured.ivf.NProbe()*8, knn.K, hasResidual)
+		spec.Search = func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
+			cands, err := captured.ivf.SearchCandidates(tx, qv, ef)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]qplanner.VectorCandidate, len(cands))
+			for i, c := range cands {
+				out[i] = qplanner.VectorCandidate{DocId: c.DocID, Distance: c.Distance}
+			}
+			return out, nil
+		}
+	case vi.ix == nil:
+		// Brute-force: the scan computes an exact distance for every document,
+		// so it can rank and cut to k itself — but ONLY when no residual will
+		// discard candidates downstream (it is the one backend that can
+		// guarantee k post-residual survivors, by returning everything).
+		topK := 0
+		if !hasResidual {
+			topK = knn.K
+		}
+		spec.Search = func(tx *btree.ReadTx, qv []float32, _ int) ([]qplanner.VectorCandidate, error) {
+			return q.c.bruteVectorCandidates(tx, captured, qv, topK)
+		}
+	default:
+		// HNSW: ef is the beam width.
+		spec.Ef = knnEf(knn.Ef, vi.ix.EfSearch(), knn.K, hasResidual)
+		spec.Search = func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
 			cands, err := captured.ix.SearchCandidates(tx, qv, ef)
 			if err != nil {
 				return nil, err
@@ -679,24 +660,261 @@ func (q *collQuery) detectVectorQuery() (*qplanner.VectorQuerySpec, query.Filter
 				out[i] = qplanner.VectorCandidate{DocId: c.DocID, Distance: c.Distance}
 			}
 			return out, nil
-		},
+		}
 	}
 	return spec, residual, nil
 }
 
-// findVectorIndexByField returns the vector index whose embedding field path
-// matches field, or nil.
-func findVectorIndexByField(vidxs []*vectorIndex, field string) *vectorIndex {
+// validateKnnClause re-checks every parse-time rule on a (possibly hand-built)
+// Knn. parseKnn's messages are the normative strings; these wrap
+// ErrInvalidVectorQuery so programmatic consumers get a matchable sentinel.
+func validateKnnClause(knn query.Knn) error {
+	if len(knn.Query) == 0 {
+		return fmt.Errorf("%w: $query must be non-empty", ErrInvalidVectorQuery)
+	}
+	for _, f := range knn.Query {
+		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+			return fmt.Errorf("%w: $query must contain finite numbers", ErrInvalidVectorQuery)
+		}
+	}
+	if knn.K < 1 || knn.K > query.KnnMaxK {
+		return fmt.Errorf("%w: $k must be an integer in [1, %d], got %d", ErrInvalidVectorQuery, query.KnnMaxK, knn.K)
+	}
+	if knn.Ef != 0 && (knn.Ef < knn.K || knn.Ef > query.KnnMaxEf) {
+		return fmt.Errorf("%w: $ef must be an integer in [$k, %d], got %d", ErrInvalidVectorQuery, query.KnnMaxEf, knn.Ef)
+	}
+	return nil
+}
+
+// findKnnClause walks the WHOLE tree for the single legal $knn placement:
+// Key{path, Knn} at the top level or under $and (any nesting, both And and
+// *And). A second hit is ErrMultipleVectorClauses; a Knn under Or/Nor/Not,
+// nested inside a Key's inner filter, or bare (no Key naming the field) is
+// ErrKnnBadPlacement. Callers guarantee ContainsKnn(f).
+func findKnnClause(f query.Filter) (node query.Key, err error) {
+	var found bool
+	var walk func(f query.Filter, andDepthOnly bool) // andDepthOnly: only And/*And above us
+	walk = func(f query.Filter, andDepthOnly bool) {
+		if err != nil {
+			return
+		}
+		switch ft := f.(type) {
+		case query.Knn:
+			// A bare Knn names no field: nothing to resolve an index against.
+			err = fmt.Errorf("%w (a $knn must name its field: query.Key{Path, Knn})", ErrKnnBadPlacement)
+		case query.Key:
+			if _, isKnn := ft.Filter.(query.Knn); isKnn {
+				if !andDepthOnly {
+					err = ErrKnnBadPlacement
+					return
+				}
+				if found {
+					err = ErrMultipleVectorClauses
+					return
+				}
+				node, found = ft, true
+				return
+			}
+			// A Knn deeper inside this Key's inner filter (Key{p, And{Knn,…}},
+			// Key{p, Not{Knn}}, …) cannot be stripped as a unit.
+			if query.ContainsKnn(ft.Filter) {
+				err = ErrKnnBadPlacement
+			}
+		case query.And:
+			for _, sub := range ft {
+				walk(sub, andDepthOnly)
+			}
+		case *query.And:
+			for _, sub := range *ft {
+				walk(sub, andDepthOnly)
+			}
+		case query.Or, query.Nor, query.Not:
+			if query.ContainsKnn(f) {
+				err = ErrKnnBadPlacement
+			}
+		}
+	}
+	walk(f, true)
+	if err != nil {
+		return query.Key{}, err
+	}
+	if !found {
+		return query.Key{}, fmt.Errorf("%w: internal: ContainsKnn true but no clause found", ErrKnnBadPlacement)
+	}
+	return node, nil
+}
+
+// knnResidualFilter returns f minus the (unique — findKnnClause enforced it)
+// Key{…, Knn} node, recursively rebuilding And/*And and collapsing an empty
+// result to nil, NOT All{}: the ef sizing and the brute-force topK both key off
+// "no residual", and an All{} would silently flip them to the ×10
+// over-fetch / full-ranking path on every bare $knn.
+//
+// The strip tests the NODE (is this Key's inner filter the Knn?), never the
+// path: And{Key{v, Knn}, Key{v, Comp{Ne,…}}} is legal programmatically, and a
+// path-keyed strip would drop the $ne too — widening the residual, so Delete
+// would remove documents the filter excluded.
+func knnResidualFilter(f query.Filter) query.Filter {
+	switch ft := f.(type) {
+	case query.Key:
+		if _, isKnn := ft.Filter.(query.Knn); isKnn {
+			return nil
+		}
+		return ft
+	case query.And:
+		rest := make(query.And, 0, len(ft))
+		for _, sub := range ft {
+			if r := knnResidualFilter(sub); r != nil {
+				rest = append(rest, r)
+			}
+		}
+		switch len(rest) {
+		case 0:
+			return nil
+		case 1:
+			return rest[0]
+		default:
+			return rest
+		}
+	case *query.And:
+		return knnResidualFilter(query.And(*ft))
+	default:
+		return f
+	}
+}
+
+// isAllQueryFilter reports whether f is the match-all filter. Distinct from
+// nil: knnResidualFilter never produces All{}, but a programmatic caller can
+// hand us And{Key{v,Knn}, All{}}, and All must not count as "has residual".
+func isAllQueryFilter(f query.Filter) bool {
+	_, isAll := f.(query.All)
+	return isAll
+}
+
+// resolveKnnIndex picks the vector index a $knn clause searches. With $index
+// set, the name must exist and be a vector index on the field; without it, the
+// field must carry exactly one vector index — with two, the searched index (and
+// therefore the selected documents, on Delete too) would depend on load order.
+func resolveKnnIndex(vidxs []*vectorIndex, field, indexName string) (*vectorIndex, error) {
+	var match *vectorIndex
 	for _, v := range vidxs {
-		if v.info.Vector.Field == field {
-			return v
+		if v.info.Vector.Field != field {
+			continue
+		}
+		if indexName != "" {
+			if v.info.Name == indexName {
+				return v, nil
+			}
+			continue
+		}
+		if match != nil {
+			return nil, fmt.Errorf("%w: field %q", ErrAmbiguousVectorIndex, field)
+		}
+		match = v
+	}
+	if match == nil {
+		if indexName != "" {
+			return nil, fmt.Errorf("%w: %q ($index %q matches no vector index on that field)", ErrNoVectorIndex, field, indexName)
+		}
+		return nil, fmt.Errorf("%w: %q", ErrNoVectorIndex, field)
+	}
+	return match, nil
+}
+
+// rejectLegacyVectorClause errors on the pre-$knn ANN spelling: an equality of
+// a plain dim-sized numeric ARRAY against a vector-indexed field, anywhere in
+// the tree (full walk — Or/Nor/Not/Key included, so no placement smuggles one
+// past). Scoped to TypeArray only, NEVER TypeVectorF32: $eq against a packed
+// {"$vector":[…]} literal is ordinary byte equality (Rule V defines it), and
+// catching it would make exact-vector equality unexpressible. The == dim
+// requirement means {"v":{"$eq":[]}} is never caught (validateVectorParams
+// forbids dim == 0).
+func rejectLegacyVectorClause(f query.Filter, vidxs []*vectorIndex) error {
+	if f == nil || len(vidxs) == 0 {
+		return nil
+	}
+	return rejectLegacyWalk(f, "", vidxs)
+}
+
+func rejectLegacyWalk(f query.Filter, path string, vidxs []*vectorIndex) error {
+	switch ft := f.(type) {
+	case query.And:
+		for _, sub := range ft {
+			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
+				return err
+			}
+		}
+	case *query.And:
+		return rejectLegacyWalk(query.And(*ft), path, vidxs)
+	case query.Or:
+		for _, sub := range ft {
+			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
+				return err
+			}
+		}
+	case query.Nor:
+		for _, sub := range ft {
+			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
+				return err
+			}
+		}
+	case query.Not:
+		return rejectLegacyWalk(ft.Filter, path, vidxs)
+	case query.Key:
+		p := strings.Join(ft.Path, ".")
+		if path != "" {
+			p = path + "." + p
+		}
+		return rejectLegacyWalk(ft.Filter, p, vidxs)
+	case *query.Comp:
+		if path == "" || ft.CompOp != query.CompOpEq {
+			return nil
+		}
+		raw := ft.EqValue
+		if len(raw) == 0 || raw[0] != byte(anyenc.TypeArray) {
+			return nil
+		}
+		for _, vi := range vidxs {
+			if vi.info.Vector.Field != path {
+				continue
+			}
+			if vec, ok := anyenc.AppendFloat32s(raw, nil); ok && len(vec) == vi.dim {
+				return fmt.Errorf("%w (field %q, index %q)", ErrLegacyVectorClause, path, vi.info.Name)
+			}
 		}
 	}
 	return nil
 }
 
-// filterRefsField reports whether the filter tree references the given field path
-// (used to detect _distance outside a vector query). Walks And/Or/Key.
+// knnEf resolves the ANN candidate depth. PURE function of the clause (+
+// whether a residual filter exists). q.limit / q.offset / q.sort are
+// deliberately NOT inputs, so every verb computes the same ef and walks the
+// same beam — that is what makes Count == len(Iter) a theorem instead of a
+// hope.
+func knnEf(explicit, indexDefault, k int, hasResidual bool) int {
+	ef := explicit
+	if ef == 0 {
+		ef = indexDefault
+		want := k
+		if hasResidual {
+			want = k * vectorOverFetch
+		}
+		if ef < want {
+			ef = want
+		}
+		if c := max(vectorEfCap, k); ef > c {
+			ef = c // the cap may NEVER starve k
+		}
+	}
+	if ef < k {
+		ef = k
+	}
+	return ef
+}
+
+// filterRefsField reports whether the filter tree references the given field
+// path (used to detect _distance outside a vector query). FULL walk —
+// And/*And/Or/Nor/Not/Key — so no placement hides a reference.
 func filterRefsField(f query.Filter, field string) bool {
 	switch v := f.(type) {
 	case query.And:
@@ -705,14 +923,27 @@ func filterRefsField(f query.Filter, field string) bool {
 				return true
 			}
 		}
+	case *query.And:
+		return filterRefsField(query.And(*v), field)
 	case query.Or:
 		for _, c := range v {
 			if filterRefsField(c, field) {
 				return true
 			}
 		}
+	case query.Nor:
+		for _, c := range v {
+			if filterRefsField(c, field) {
+				return true
+			}
+		}
+	case query.Not:
+		return filterRefsField(v.Filter, field)
 	case query.Key:
-		return strings.Join(v.Path, ".") == field
+		if strings.Join(v.Path, ".") == field {
+			return true
+		}
+		return filterRefsField(v.Filter, field)
 	}
 	return false
 }
@@ -728,30 +959,6 @@ func sortRefsField(s query.Sort, field string) bool {
 		}
 	}
 	return false
-}
-
-// decodeVectorValue decodes a marshaled anyenc array into a dim-sized []float32.
-func decodeVectorValue(eqValue []byte, dim int) ([]float32, error) {
-	var p anyenc.Parser
-	v, err := p.Parse(eqValue)
-	if err != nil {
-		return nil, err
-	}
-	if v.Type() != anyenc.TypeArray {
-		return nil, fmt.Errorf("not an array")
-	}
-	arr, err := v.Array()
-	if err != nil || len(arr) != dim {
-		return nil, fmt.Errorf("array length %d != dim %d", len(arr), dim)
-	}
-	out := make([]float32, dim)
-	for i, e := range arr {
-		if e.Type() != anyenc.TypeNumber {
-			return nil, fmt.Errorf("non-numeric element")
-		}
-		out[i] = float32(e.GetFloat64())
-	}
-	return out, nil
 }
 
 // bruteVectorCandidates scans the whole collection and returns the documents
@@ -900,46 +1107,6 @@ const vectorOverFetch = 10
 // filter can't trigger a pathologically wide search. Callers that genuinely need
 // more set VectorEf explicitly.
 const vectorEfCap = 4096
-
-// chooseEf resolves the ANN candidate-list size (numCandidates). An explicit
-// override wins; otherwise start from the index default, ensure it covers the
-// limit, and over-fetch when a residual filter will discard candidates.
-func chooseEf(explicit, indexDefault, limit int, hasFilter bool) int {
-	if explicit > 0 {
-		return explicit
-	}
-	ef := indexDefault
-	if limit > 0 {
-		want := limit
-		if hasFilter {
-			want = limit * vectorOverFetch
-		}
-		if want > ef {
-			ef = want
-		}
-	}
-	if ef > vectorEfCap {
-		ef = vectorEfCap
-	}
-	return ef
-}
-
-func residualFilter(clauses []query.Filter, skip int) query.Filter {
-	rest := make([]query.Filter, 0, len(clauses)-1)
-	for i, c := range clauses {
-		if i != skip {
-			rest = append(rest, c)
-		}
-	}
-	switch len(rest) {
-	case 0:
-		return nil
-	case 1:
-		return rest[0]
-	default:
-		return query.And(rest)
-	}
-}
 
 // CompactVectorIndex rebuilds the named vector index from its live vectors,
 // reclaiming the storage and graph quality lost to tombstoned (deleted or

--- a/vector_index.go
+++ b/vector_index.go
@@ -619,14 +619,14 @@ func (q *collQuery) detectVectorQuery() (*qplanner.VectorQuerySpec, query.Filter
 		// IVF-PQ: probe a few cells (contiguous range scans), re-rank by exact
 		// distance. ef is the re-rank depth / candidate count, sized to the page
 		// window; nprobe is fixed in the index. SearchCandidates returns them
-		// closest-first (Ordered) — measurably faster than letting SortIter sort, as
+		// (distance, docId) ascending (TotallyOrdered) — measurably faster than letting SortIter sort, as
 		// the planner then skips the SortIter for the default distance order and
 		// streams straight to LimitIter; an explicit multi-key Sort still uses SortIter.
 		ef := chooseEf(int(q.vectorEf), captured.ivf.NProbe()*8, int(q.limit)+int(q.offset), residual != nil)
 		spec := &qplanner.VectorQuerySpec{
 			Query:   qvec,
 			Ef:      ef,
-			Ordered: true,
+			TotallyOrdered: true,
 			Search: func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
 				cands, err := captured.ivf.SearchCandidates(tx, qv, ef)
 				if err != nil {
@@ -653,7 +653,7 @@ func (q *collQuery) detectVectorQuery() (*qplanner.VectorQuerySpec, query.Filter
 		}
 		spec := &qplanner.VectorQuerySpec{
 			Query:   qvec,
-			Ordered: true, // bruteVectorCandidates returns distance-ascending
+			TotallyOrdered: true, // bruteVectorCandidates returns (distance, docId) ascending
 			Search: func(tx *btree.ReadTx, qv []float32, _ int) ([]qplanner.VectorCandidate, error) {
 				return q.c.bruteVectorCandidates(tx, captured, qv, topK)
 			},
@@ -668,7 +668,7 @@ func (q *collQuery) detectVectorQuery() (*qplanner.VectorQuerySpec, query.Filter
 	spec := &qplanner.VectorQuerySpec{
 		Query:   qvec,
 		Ef:      ef,
-		Ordered: true, // SearchCandidates yields candidates closest-first
+		TotallyOrdered: true, // SearchCandidates yields (distance, docId) ascending
 		Search: func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
 			cands, err := captured.ix.SearchCandidates(tx, qv, ef)
 			if err != nil {

--- a/vector_index.go
+++ b/vector_index.go
@@ -580,6 +580,13 @@ var ErrDistanceWithoutVector = errors.New("any-store: _distance is only availabl
 // parseKnn enforces is re-checked here, because ParseCondition short-circuits
 // on an already-built Filter and the production consumers build their ANN
 // filter programmatically — this walk is the only validation they ever see.
+// NOTE: the result is deliberately NOT memoized across calls. The spec's
+// Search closure captures the resolved *vectorIndex HANDLE, and stale handles
+// are reconciled at read-tx begin — a spec detected before the verb's tx
+// opens (validateSources runs pre-tx, ahead of the unsatisfiable()
+// short-circuit) would search a peer-rebuilt index through its dead gen-0
+// namespaces (caught by the multiprocess IVF consistency test). compilePlan
+// re-detects after the tx begins, on the handle set the plan executes on.
 func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, error) {
 	if q.cond == nil || !query.ContainsKnn(q.cond) {
 		return nil, q.cond, nil
@@ -588,9 +595,13 @@ func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, e
 	if err != nil {
 		return nil, nil, err
 	}
-	knn, _ := node.Filter.(query.Knn)
-	if err = validateKnnClause(knn); err != nil {
-		return nil, nil, err
+	knn, _ := knnOf(node.Filter)
+	// Re-check the parse-time argument rules (query.Knn.Validate is the one
+	// shared copy): programmatic NewKnn filters never see the parser, and this
+	// walk is the only validation they get. Wrapped in ErrInvalidVectorQuery
+	// so consumers have a matchable sentinel.
+	if verr := knn.Validate(); verr != nil {
+		return nil, nil, fmt.Errorf("%w: %s", ErrInvalidVectorQuery, verr)
 	}
 	field := strings.Join(node.Path, ".")
 	vi, err := resolveKnnIndex(q.c.loadVectorIndexes(), field, knn.Index)
@@ -665,76 +676,76 @@ func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, e
 	return spec, residual, nil
 }
 
-// validateKnnClause re-checks every parse-time rule on a (possibly hand-built)
-// Knn. parseKnn's messages are the normative strings; these wrap
-// ErrInvalidVectorQuery so programmatic consumers get a matchable sentinel.
-func validateKnnClause(knn query.Knn) error {
-	if len(knn.Query) == 0 {
-		return fmt.Errorf("%w: $query must be non-empty", ErrInvalidVectorQuery)
+// knnOf extracts the Knn from a leaf, accepting the pointer form too: every
+// composite filter here has value-receiver methods, so a hand-built &Knn{…}
+// satisfies query.Filter just like Knn does, and a value-only type test would
+// let it slip past detection into the residual (fail-closed → 0 rows / no-op
+// writes with err == nil).
+func knnOf(f query.Filter) (query.Knn, bool) {
+	switch k := f.(type) {
+	case query.Knn:
+		return k, true
+	case *query.Knn:
+		return *k, true
 	}
-	for _, f := range knn.Query {
-		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
-			return fmt.Errorf("%w: $query must contain finite numbers", ErrInvalidVectorQuery)
-		}
-	}
-	if knn.K < 1 || knn.K > query.KnnMaxK {
-		return fmt.Errorf("%w: $k must be an integer in [1, %d], got %d", ErrInvalidVectorQuery, query.KnnMaxK, knn.K)
-	}
-	if knn.Ef != 0 && (knn.Ef < knn.K || knn.Ef > query.KnnMaxEf) {
-		return fmt.Errorf("%w: $ef must be an integer in [$k, %d], got %d", ErrInvalidVectorQuery, query.KnnMaxEf, knn.Ef)
-	}
-	return nil
+	return query.Knn{}, false
 }
 
 // findKnnClause walks the WHOLE tree for the single legal $knn placement:
-// Key{path, Knn} at the top level or under $and (any nesting, both And and
-// *And). A second hit is ErrMultipleVectorClauses; a Knn under Or/Nor/Not,
-// nested inside a Key's inner filter, or bare (no Key naming the field) is
-// ErrKnnBadPlacement. Callers guarantee ContainsKnn(f).
+// Key{path, Knn} at the top level or under $and (any nesting; And/*And). Every
+// composite is matched in BOTH value and pointer form — a pointer-built
+// &Not{Key{v, Knn}} that a value-only switch skipped would evaluate
+// !false == match-all on Delete. A second hit is ErrMultipleVectorClauses; a
+// Knn under Or/Nor/Not, nested inside a Key's inner filter, or bare (no Key
+// naming the field) is ErrKnnBadPlacement. Callers guarantee ContainsKnn(f).
 func findKnnClause(f query.Filter) (node query.Key, err error) {
 	var found bool
-	var walk func(f query.Filter, andDepthOnly bool) // andDepthOnly: only And/*And above us
-	walk = func(f query.Filter, andDepthOnly bool) {
+	var walkKey func(ft query.Key)
+	var walk func(f query.Filter)
+	walkKey = func(ft query.Key) {
+		if _, isKnn := knnOf(ft.Filter); isKnn {
+			if found {
+				err = ErrMultipleVectorClauses
+				return
+			}
+			node, found = ft, true
+			return
+		}
+		// A Knn deeper inside this Key's inner filter (Key{p, And{Knn,…}},
+		// Key{p, Not{Knn}}, …) cannot be stripped as a unit.
+		if query.ContainsKnn(ft.Filter) {
+			err = ErrKnnBadPlacement
+		}
+	}
+	walk = func(f query.Filter) {
 		if err != nil {
 			return
 		}
 		switch ft := f.(type) {
-		case query.Knn:
+		case query.Knn, *query.Knn:
 			// A bare Knn names no field: nothing to resolve an index against.
 			err = fmt.Errorf("%w (a $knn must name its field: query.Key{Path, Knn})", ErrKnnBadPlacement)
 		case query.Key:
-			if _, isKnn := ft.Filter.(query.Knn); isKnn {
-				if !andDepthOnly {
-					err = ErrKnnBadPlacement
-					return
-				}
-				if found {
-					err = ErrMultipleVectorClauses
-					return
-				}
-				node, found = ft, true
-				return
-			}
-			// A Knn deeper inside this Key's inner filter (Key{p, And{Knn,…}},
-			// Key{p, Not{Knn}}, …) cannot be stripped as a unit.
-			if query.ContainsKnn(ft.Filter) {
-				err = ErrKnnBadPlacement
-			}
+			walkKey(ft)
+		case *query.Key:
+			walkKey(*ft)
 		case query.And:
 			for _, sub := range ft {
-				walk(sub, andDepthOnly)
+				walk(sub)
 			}
 		case *query.And:
 			for _, sub := range *ft {
-				walk(sub, andDepthOnly)
+				walk(sub)
 			}
-		case query.Or, query.Nor, query.Not:
+		default:
+			// Or/Nor/Not (any form), or an unknown filter type wrapping a Knn:
+			// not a placement the residual builder can strip.
 			if query.ContainsKnn(f) {
 				err = ErrKnnBadPlacement
 			}
 		}
 	}
-	walk(f, true)
+	walk(f)
 	if err != nil {
 		return query.Key{}, err
 	}
@@ -753,11 +764,17 @@ func findKnnClause(f query.Filter) (node query.Key, err error) {
 // The strip tests the NODE (is this Key's inner filter the Knn?), never the
 // path: And{Key{v, Knn}, Key{v, Comp{Ne,…}}} is legal programmatically, and a
 // path-keyed strip would drop the $ne too — widening the residual, so Delete
-// would remove documents the filter excluded.
+// would remove documents the filter excluded. Pointer-built *Key/*Knn strip
+// identically (findKnnClause accepted them, so the strip must too).
 func knnResidualFilter(f query.Filter) query.Filter {
 	switch ft := f.(type) {
 	case query.Key:
-		if _, isKnn := ft.Filter.(query.Knn); isKnn {
+		if _, isKnn := knnOf(ft.Filter); isKnn {
+			return nil
+		}
+		return ft
+	case *query.Key:
+		if _, isKnn := knnOf(ft.Filter); isKnn {
 			return nil
 		}
 		return ft
@@ -837,37 +854,45 @@ func rejectLegacyVectorClause(f query.Filter, vidxs []*vectorIndex) error {
 }
 
 func rejectLegacyWalk(f query.Filter, path string, vidxs []*vectorIndex) error {
+	each := func(fs []query.Filter) error {
+		for _, sub := range fs {
+			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	switch ft := f.(type) {
 	case query.And:
-		for _, sub := range ft {
-			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
-				return err
-			}
-		}
+		return each(ft)
 	case *query.And:
-		return rejectLegacyWalk(query.And(*ft), path, vidxs)
+		return each(*ft)
 	case query.Or:
-		for _, sub := range ft {
-			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
-				return err
-			}
-		}
+		return each(ft)
+	case *query.Or:
+		return each(*ft)
 	case query.Nor:
-		for _, sub := range ft {
-			if err := rejectLegacyWalk(sub, path, vidxs); err != nil {
-				return err
-			}
-		}
+		return each(ft)
+	case *query.Nor:
+		return each(*ft)
 	case query.Not:
 		return rejectLegacyWalk(ft.Filter, path, vidxs)
+	case *query.Not:
+		return rejectLegacyWalk(ft.Filter, path, vidxs)
 	case query.Key:
-		p := strings.Join(ft.Path, ".")
-		if path != "" {
-			p = path + "." + p
-		}
-		return rejectLegacyWalk(ft.Filter, p, vidxs)
+		return rejectLegacyKey(ft, path, vidxs)
+	case *query.Key:
+		return rejectLegacyKey(*ft, path, vidxs)
 	case *query.Comp:
-		if path == "" || ft.CompOp != query.CompOpEq {
+		// The legacy trigger is $eq — the old ANN spelling — AND $ne: on
+		// packed storage a plain-array operand never byte-equals the stored
+		// TypeVectorF32 value, so a dim-sized-array $ne is true for EVERY
+		// document (a "delete all but this vector" that removes that vector
+		// too, silently). Both are the same ANN-shaped-literal mistake.
+		// (Deliberate widening of the design's Eq-only scoping — the design's
+		// own rationale, "loud error over two silent wrong answers", applies
+		// with more force to the match-all direction.)
+		if path == "" || (ft.CompOp != query.CompOpEq && ft.CompOp != query.CompOpNe) {
 			return nil
 		}
 		raw := ft.EqValue
@@ -884,6 +909,14 @@ func rejectLegacyWalk(f query.Filter, path string, vidxs []*vectorIndex) error {
 		}
 	}
 	return nil
+}
+
+func rejectLegacyKey(ft query.Key, path string, vidxs []*vectorIndex) error {
+	p := strings.Join(ft.Path, ".")
+	if path != "" {
+		p = path + "." + p
+	}
+	return rejectLegacyWalk(ft.Filter, p, vidxs)
 }
 
 // knnEf resolves the ANN candidate depth. PURE function of the clause (+
@@ -914,36 +947,54 @@ func knnEf(explicit, indexDefault, k int, hasResidual bool) int {
 
 // filterRefsField reports whether the filter tree references the given field
 // path (used to detect _distance outside a vector query). FULL walk —
-// And/*And/Or/Nor/Not/Key — so no placement hides a reference.
+// And/Or/Nor/Not/Key, value and pointer forms — so no placement hides a
+// reference. A nested Key's path is RELATIVE to its parent: the walk descends
+// with the remaining suffix, so Key{["a"], Key{["_distance"], …}} refers to
+// the stored field "a._distance", not the synthetic top-level "_distance".
 func filterRefsField(f query.Filter, field string) bool {
 	switch v := f.(type) {
 	case query.And:
-		for _, c := range v {
-			if filterRefsField(c, field) {
-				return true
-			}
-		}
+		return anyRefsField(v, field)
 	case *query.And:
-		return filterRefsField(query.And(*v), field)
+		return anyRefsField(*v, field)
 	case query.Or:
-		for _, c := range v {
-			if filterRefsField(c, field) {
-				return true
-			}
-		}
+		return anyRefsField(v, field)
+	case *query.Or:
+		return anyRefsField(*v, field)
 	case query.Nor:
-		for _, c := range v {
-			if filterRefsField(c, field) {
-				return true
-			}
-		}
+		return anyRefsField(v, field)
+	case *query.Nor:
+		return anyRefsField(*v, field)
 	case query.Not:
 		return filterRefsField(v.Filter, field)
+	case *query.Not:
+		return filterRefsField(v.Filter, field)
 	case query.Key:
-		if strings.Join(v.Path, ".") == field {
+		return keyRefsField(v, field)
+	case *query.Key:
+		return keyRefsField(*v, field)
+	}
+	return false
+}
+
+func anyRefsField(fs []query.Filter, field string) bool {
+	for _, c := range fs {
+		if filterRefsField(c, field) {
 			return true
 		}
-		return filterRefsField(v.Filter, field)
+	}
+	return false
+}
+
+func keyRefsField(v query.Key, field string) bool {
+	p := strings.Join(v.Path, ".")
+	if p == field {
+		return true
+	}
+	// Nested Keys address sub-paths of this Key: only the matching suffix of
+	// field can still be referenced below.
+	if suffix, ok := strings.CutPrefix(field, p+"."); ok {
+		return filterRefsField(v.Filter, suffix)
 	}
 	return false
 }

--- a/vector_index_test.go
+++ b/vector_index_test.go
@@ -48,17 +48,14 @@ type vhit struct {
 	Distance float32
 }
 
-// vsearch runs a k-NN search through the public Find() pipeline (the supported
-// path now that collection.VectorSearch is removed) and returns docId+distance
-// pairs, closest-first. ef<=0 uses the index default; k<=0 means no limit.
+// vsearch runs a k-NN search through the public Find() pipeline via the $knn
+// operator and returns docId+distance pairs, closest-first. ef<=0 uses the
+// index default. k must be > 0: $k is mandatory in the clause.
 func vsearch(coll Collection, field string, q []float32, k, ef int) ([]vhit, error) {
-	fq := coll.Find(fmt.Sprintf(`{%q:%s}`, field, vqJSON(q)))
-	if k > 0 {
-		fq = fq.Limit(uint(k))
+	if k <= 0 {
+		panic("vsearch: $knn requires k > 0")
 	}
-	if ef > 0 {
-		fq = fq.VectorEf(uint(ef))
-	}
+	fq := coll.Find(fmt.Sprintf(`{%q:%s}`, field, vknnJSON(q, k, ef)))
 	iter, err := fq.Iter(ctx)
 	if err != nil {
 		return nil, err
@@ -289,7 +286,7 @@ func TestVectorIndex_Int8Quantization(t *testing.T) {
 
 	// reopen-from-disk preserves int8 + results (covered for in-memory here via a
 	// fresh Find through the pipeline)
-	iter, err := coll.Find(fmt.Sprintf(`{"v":[%s]}`, joinFloats(vecs[7]))).Limit(1).Iter(ctx)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":{"$knn":{"$query":[%s],"$k":1}}}`, joinFloats(vecs[7]))).Iter(ctx)
 	require.NoError(t, err)
 	require.True(t, iter.Next())
 	d, _ := iter.Doc()

--- a/vector_ivfpq_bench_test.go
+++ b/vector_ivfpq_bench_test.go
@@ -28,21 +28,27 @@ func BenchmarkIVFPQQuery(b *testing.B) {
 		Vector: &VectorParams{Field: "v", Dim: dim, Metric: VectorL2, Mode: VectorModeIVFPQ, Closure: 4, NProbe: 16},
 	}))
 
-	queries := make([]string, 256)
-	for i := range queries {
-		queries[i] = fmt.Sprintf(`{"v":%s}`, vqJSON(vecs[i]))
+	// $k covers the page window (offset+limit); Limit/Offset paginate within it.
+	mkQueries := func(k int) []string {
+		queries := make([]string, 256)
+		for i := range queries {
+			queries[i] = fmt.Sprintf(`{"v":%s}`, vknnJSON(vecs[i], k, 0))
+		}
+		return queries
 	}
 
 	cases := []struct {
 		name          string
+		k             int
 		limit, offset uint
 	}{
-		{"limit10", 10, 0},
-		{"limit1", 1, 0},
-		{"limit100", 100, 0},
-		{"limit10_offset200", 10, 200},
+		{"limit10", 10, 10, 0},
+		{"limit1", 1, 1, 0},
+		{"limit100", 100, 100, 0},
+		{"limit10_offset200", 210, 10, 200},
 	}
 	for _, tc := range cases {
+		queries := mkQueries(tc.k)
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/vector_ivfpq_test.go
+++ b/vector_ivfpq_test.go
@@ -114,7 +114,7 @@ func TestVectorMode_IVFPQ_EndToEnd(t *testing.T) {
 	assert.GreaterOrEqual(t, recall, 0.85, "IVF-PQ + re-rank should reach high recall on clustered data")
 
 	// _distance decoration + ascending order through the pipeline.
-	iter, err := coll.Find(vectorEqFilter(vecs[7])).Limit(5).Iter(ctx)
+	iter, err := coll.Find(vectorKnnFilter(vecs[7], 5)).Iter(ctx)
 	require.NoError(t, err)
 	var last float32 = -1
 	got7 := false
@@ -147,7 +147,7 @@ func TestVectorMode_IVFPQ_FilterUpdateDelete(t *testing.T) {
 
 	// Residual filter: vector clause + id predicate. Every returned doc must satisfy
 	// the predicate.
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"id":{"$lt":100}}`, vqJSON(vecs[5]))).Limit(10).Iter(ctx)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"id":{"$lt":100}}`, vknnJSON(vecs[5], 10, 0))).Iter(ctx)
 	require.NoError(t, err)
 	cnt := 0
 	for iter.Next() {

--- a/vector_ivfsq_test.go
+++ b/vector_ivfsq_test.go
@@ -81,7 +81,7 @@ func TestVectorMode_IVFSQ_EndToEnd(t *testing.T) {
 	assert.GreaterOrEqual(t, recall, 0.9, "IVF-SQ should reach high recall on clustered data")
 
 	// _distance ordering through the pipeline.
-	iter, err := coll.Find(vectorEqFilter(vecs[7])).Limit(5).Iter(ctx)
+	iter, err := coll.Find(vectorKnnFilter(vecs[7], 5)).Iter(ctx)
 	require.NoError(t, err)
 	var last float32 = -1
 	for iter.Next() {

--- a/vector_knn_detect_test.go
+++ b/vector_knn_detect_test.go
@@ -1,0 +1,266 @@
+package anystore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/query"
+)
+
+// knnDetectColl builds a 3-dim vector-indexed collection ("v", index "emb")
+// with a handful of docs, for exercising detectKnnQuery through the verbs.
+func knnDetectColl(t *testing.T) Collection {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "knn_detect")
+	require.NoError(t, err)
+	require.NoError(t, coll.CreateIndex(ctx, IndexInfo{
+		Name: "emb", Kind: IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: 3, Metric: VectorL2, EfSearch: 64},
+	}))
+	for i := 0; i < 10; i++ {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(
+			fmt.Sprintf(`{"id":%d,"v":[%d,1,2],"a":%d,"b":%d}`, i, i, i%2, i%3))))
+	}
+	return coll
+}
+
+const kd = `{"$knn":{"$query":[3,1,2],"$k":4}}`
+
+// TestDetectKnn_Placement pins the detection rows of the $knn design (T2.4):
+// legal placements search; illegal ones hard-error with the named sentinel, on
+// every verb (Iter and Count exercised here; the verb-agreement property is
+// TestVectorClauseInvalid_WriteVerbsAgreeWithIter).
+func TestDetectKnn_Placement(t *testing.T) {
+	coll := knnDetectColl(t)
+
+	legal := []struct {
+		name string
+		cond string
+	}{
+		{"plain", fmt.Sprintf(`{"v":%s}`, kd)},
+		{"flat residual", fmt.Sprintf(`{"v":%s,"a":1}`, kd)},
+		{"$and single", fmt.Sprintf(`{"$and":[{"v":%s}]}`, kd)},
+		{"$and multi (*And)", fmt.Sprintf(`{"$and":[{"v":%s},{"a":1}]}`, kd)},
+		{"nested *And (the residual-leak shape)", fmt.Sprintf(`{"$and":[{"$and":[{"v":%s},{"a":1}]},{"b":2}]}`, kd)},
+	}
+	for _, tc := range legal {
+		t.Run("legal/"+tc.name, func(t *testing.T) {
+			ids := writeOrderIterIds(t, coll.Find(tc.cond))
+			assert.NotEmpty(t, ids, "a legal $knn placement must search, not silently return 0 rows")
+			n, err := coll.Find(tc.cond).Count(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, len(ids), n)
+			assert.LessOrEqual(t, n, 4, "the k-cut bounds the denoted set")
+		})
+	}
+
+	illegal := []struct {
+		name   string
+		cond   string
+		wantIs error
+	}{
+		{"$or", fmt.Sprintf(`{"$or":[{"v":%s},{"a":1}]}`, kd), ErrKnnBadPlacement},
+		{"$nor", fmt.Sprintf(`{"$nor":[{"v":%s}]}`, kd), ErrKnnBadPlacement},
+		{"$or nested under $and", fmt.Sprintf(`{"$and":[{"$or":[{"v":%s},{"a":1}]},{"b":2}]}`, kd), ErrKnnBadPlacement},
+		{"two $knn", fmt.Sprintf(`{"$and":[{"v":%s},{"v":%s}]}`, kd, kd), ErrMultipleVectorClauses},
+		{"$knn with $text", fmt.Sprintf(`{"v":%s,"$text":{"$search":"x"}}`, kd), ErrKnnWithText},
+		{"unindexed field", fmt.Sprintf(`{"w":%s}`, kd), ErrNoVectorIndex},
+		{"$index names no index", `{"v":{"$knn":{"$query":[3,1,2],"$k":4,"$index":"nope"}}}`, ErrNoVectorIndex},
+		{"wrong dim", `{"v":{"$knn":{"$query":[3,1],"$k":4}}}`, ErrInvalidVectorQuery},
+		{"legacy bare array", `{"v":[3,1,2]}`, ErrLegacyVectorClause},
+		{"legacy under $not", `{"v":{"$not":{"$eq":[3,1,2]}}}`, ErrLegacyVectorClause},
+		{"_distance without $knn", `{"_distance":{"$lt":1.0},"a":1}`, ErrDistanceWithoutVector},
+		{"_distance inside $or without $knn", `{"$or":[{"_distance":{"$lt":1.0}},{"a":1}]}`, ErrDistanceWithoutVector},
+		{"_distance inside $not without $knn", `{"a":{"$gt":0},"$nor":[{"_distance":{"$lt":1.0}}]}`, ErrDistanceWithoutVector},
+	}
+	for _, tc := range illegal {
+		t.Run("illegal/"+tc.name, func(t *testing.T) {
+			_, err := coll.Find(tc.cond).Iter(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Iter")
+			_, err = coll.Find(tc.cond).Count(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Count")
+			_, err = coll.Find(tc.cond).Delete(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Delete")
+			_, err = coll.Find(tc.cond).Explain(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Explain")
+		})
+	}
+
+	// An invalid source errors even when an unrelated clause makes the filter
+	// unsatisfiable — validation precedes the unsatisfiable() short-circuit.
+	t.Run("validation precedes unsatisfiable", func(t *testing.T) {
+		cond := `{"v":{"$knn":{"$query":[3,1],"$k":4}},"a":{"$in":[]}}`
+		_, err := coll.Find(cond).Iter(ctx)
+		require.ErrorIs(t, err, ErrInvalidVectorQuery, "Iter")
+		_, err = coll.Find(cond).Count(ctx)
+		require.ErrorIs(t, err, ErrInvalidVectorQuery, "Count")
+		_, err = coll.Find(cond).Delete(ctx)
+		require.ErrorIs(t, err, ErrInvalidVectorQuery, "Delete")
+		_, err = coll.Find(cond).Explain(ctx)
+		require.ErrorIs(t, err, ErrInvalidVectorQuery, "Explain")
+	})
+}
+
+// TestDetectKnn_HandBuilt pins the programmatic path: a pre-built query.Filter
+// bypasses the parser entirely (ParseCondition short-circuits), so detection is
+// the only validation it ever sees — every parse rule must hold there too.
+func TestDetectKnn_HandBuilt(t *testing.T) {
+	coll := knnDetectColl(t)
+	knn := func() query.Filter {
+		return query.Key{Path: []string{"v"}, Filter: query.NewKnn([]float32{3, 1, 2}, 4)}
+	}
+
+	t.Run("legal Key{v,Knn}", func(t *testing.T) {
+		ids := writeOrderIterIds(t, coll.Find(knn()))
+		assert.NotEmpty(t, ids)
+	})
+	t.Run("legal And{Key{v,Knn},Key{v,Comp}} — strip by node, not path", func(t *testing.T) {
+		// Two Keys on ONE path: the $ne residual must survive the Knn strip.
+		// A path-keyed strip would drop it and widen the deleted set.
+		f := query.And{
+			knn(),
+			query.Key{Path: []string{"v"}, Filter: query.NewComp(query.CompOpNe, "nothing-stored-matches")},
+		}
+		ids := writeOrderIterIds(t, coll.Find(f))
+		assert.NotEmpty(t, ids, "the $ne residual matches every doc; the knn still selects k")
+		f2 := query.And{
+			knn(),
+			// $eq "x" on v matches nothing → residual excludes everything.
+			query.Key{Path: []string{"v"}, Filter: query.NewComp(query.CompOpEq, "x")},
+		}
+		n, err := coll.Find(f2).Count(ctx)
+		require.NoError(t, err)
+		assert.Zero(t, n, "the co-path residual must be preserved and applied")
+	})
+
+	for _, tc := range []struct {
+		name   string
+		f      query.Filter
+		wantIs error
+	}{
+		{"bare Knn (no Key)", query.NewKnn([]float32{3, 1, 2}, 4), ErrKnnBadPlacement},
+		{"Not{Key{v,Knn}}", query.Not{Filter: knn()}, ErrKnnBadPlacement},
+		{"Key{v,Not{Knn}}", query.Key{Path: []string{"v"}, Filter: query.Not{Filter: query.NewKnn([]float32{3, 1, 2}, 4)}}, ErrKnnBadPlacement},
+		{"Or{Key{v,Knn},…}", query.Or{knn(), query.MustParseCondition(`{"a":1}`)}, ErrKnnBadPlacement},
+		{"k=0", query.Key{Path: []string{"v"}, Filter: query.Knn{Query: []float32{3, 1, 2}}}, ErrInvalidVectorQuery},
+		{"empty query", query.Key{Path: []string{"v"}, Filter: query.Knn{K: 3}}, ErrInvalidVectorQuery},
+		{"ef below k", query.Key{Path: []string{"v"}, Filter: query.NewKnn([]float32{3, 1, 2}, 4, query.KnnEf(2))}, ErrInvalidVectorQuery},
+		{"legacy programmatic (the downstream indexer shape)", legacyEqFilter([]float32{3, 1, 2}), ErrLegacyVectorClause},
+	} {
+		t.Run("illegal/"+tc.name, func(t *testing.T) {
+			_, err := coll.Find(tc.f).Iter(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Iter")
+			_, err = coll.Find(tc.f).Count(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Count")
+			_, err = coll.Find(tc.f).Delete(ctx)
+			require.ErrorIs(t, err, tc.wantIs, "Delete")
+		})
+	}
+
+	t.Run("non-ANN predicates on the vector field stay ordinary on every verb", func(t *testing.T) {
+		// The downstream EnsureVectorIndex pattern: Count with {v:{$exists}}.
+		n, err := coll.Find(query.Key{Path: []string{"v"}, Filter: query.Exists{}}).Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 10, n)
+	})
+}
+
+// legacyEqFilter reproduces the pre-$knn programmatic ANN construction
+// (query.NewCompValue(CompOpEq, <plain array>)) that must now hard-error.
+func legacyEqFilter(qv []float32) query.Filter {
+	a := &anyenc.Arena{}
+	arr := a.NewArray()
+	for i, f := range qv {
+		arr.SetArrayItem(i, a.NewNumberFloat64(float64(f)))
+	}
+	return query.Key{Path: []string{"v"}, Filter: query.NewCompValue(query.CompOpEq, arr)}
+}
+
+// TestDetectKnn_AmbiguousIndex: two vector indexes on one field require $index;
+// either name resolves; a $knn without it errors rather than searching
+// whichever index loaded first.
+func TestDetectKnn_AmbiguousIndex(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "knn_ambig")
+	require.NoError(t, err)
+	require.NoError(t, coll.CreateIndex(ctx, IndexInfo{
+		Name: "emb_l2", Kind: IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: 3, Metric: VectorL2},
+	}))
+	require.NoError(t, coll.CreateIndex(ctx, IndexInfo{
+		Name: "emb_cos", Kind: IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: 3, Metric: VectorCosine},
+	}))
+	for i := 0; i < 6; i++ {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(fmt.Sprintf(`{"id":%d,"v":[%d,1,2]}`, i, i))))
+	}
+
+	_, err = coll.Find(fmt.Sprintf(`{"v":%s}`, kd)).Iter(ctx)
+	require.ErrorIs(t, err, ErrAmbiguousVectorIndex)
+	_, err = coll.Find(fmt.Sprintf(`{"v":%s}`, kd)).Count(ctx)
+	require.ErrorIs(t, err, ErrAmbiguousVectorIndex)
+
+	for _, name := range []string{"emb_l2", "emb_cos"} {
+		cond := fmt.Sprintf(`{"v":{"$knn":{"$query":[3,1,2],"$k":2,"$index":%q}}}`, name)
+		ids := writeOrderIterIds(t, coll.Find(cond))
+		assert.NotEmpty(t, ids, "$index %s must resolve", name)
+		exp, eerr := coll.Find(cond).Explain(ctx)
+		require.NoError(t, eerr)
+		var used []string
+		for _, ix := range exp.Indexes {
+			if ix.Used {
+				used = append(used, ix.Name)
+			}
+		}
+		assert.Equal(t, []string{name}, used, "Explain must report the resolved index as used")
+	}
+}
+
+// TestDetectKnn_ExplainReportsKnn: Explain names the ANN plan and the driving
+// vector index — Explain printing FullScan for a working ANN query is why the
+// verb divergence survived as long as it did.
+func TestDetectKnn_ExplainReportsKnn(t *testing.T) {
+	coll := knnDetectColl(t)
+	exp, err := coll.Find(fmt.Sprintf(`{"v":%s,"a":1}`, kd)).Explain(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, exp.Sql, "KnnSearch(k=4,ef=", "the plan names the ANN source: %s", exp.Sql)
+	assert.Contains(t, exp.Sql, "Filter", "the residual filter appears in the plan: %s", exp.Sql)
+	var used []string
+	for _, ix := range exp.Indexes {
+		if ix.Used {
+			used = append(used, ix.Name)
+		}
+	}
+	assert.Equal(t, []string{"emb"}, used)
+}
+
+// TestKnnResidual_NoKnnSurvives is the hard post-condition behind the
+// fail-closed design: for every legal placement, the residual handed to the
+// FilterIter contains no Knn (a leaked Knn rejects every candidate — 0 rows,
+// no-op Delete, err == nil — silently, on all verbs).
+func TestKnnResidual_NoKnnSurvives(t *testing.T) {
+	for _, cond := range []string{
+		fmt.Sprintf(`{"v":%s}`, kd),
+		fmt.Sprintf(`{"v":%s,"a":1}`, kd),
+		fmt.Sprintf(`{"$and":[{"v":%s}]}`, kd),
+		fmt.Sprintf(`{"$and":[{"v":%s},{"a":1}]}`, kd),
+		fmt.Sprintf(`{"$and":[{"$and":[{"v":%s},{"a":1}]},{"b":2}]}`, kd),
+		fmt.Sprintf(`{"$and":[{"$and":[{"v":%s}]},{"$and":[{"a":1},{"b":2}]}]}`, kd),
+	} {
+		f := query.MustParseCondition(cond)
+		require.True(t, query.ContainsKnn(f), cond)
+		residual := knnResidualFilter(f)
+		assert.False(t, residual != nil && query.ContainsKnn(residual),
+			"the Knn must be stripped from the residual: %s -> %v", cond, residual)
+	}
+
+	// Empty residual collapses to nil, NOT All{}: ef sizing and the
+	// brute-force topK both key off "no residual" — All{} would flip every
+	// bare $knn onto the ×10 over-fetch / full-ranking path invisibly.
+	assert.Nil(t, knnResidualFilter(query.MustParseCondition(fmt.Sprintf(`{"v":%s}`, kd))))
+	assert.Nil(t, knnResidualFilter(query.MustParseCondition(fmt.Sprintf(`{"$and":[{"v":%s}]}`, kd))))
+}

--- a/vector_knn_detect_test.go
+++ b/vector_knn_detect_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/anyproto/any-store/v2/anyenc"
 	"github.com/anyproto/any-store/v2/query"
+	"github.com/anyproto/any-store/v2/syncpool"
 )
 
 // knnDetectColl builds a 3-dim vector-indexed collection ("v", index "emb")
@@ -423,4 +424,56 @@ func TestExplain_UnconsideredSourceIndexesCarryNoCost(t *testing.T) {
 		}
 	}
 	assert.True(t, sawVector, "the vector index must still be listed")
+}
+
+// opaqueWrapKnn and opaqueNotKnn are CUSTOM Filter implementations wrapping a
+// $knn clause — foreign types the detection walk cannot see through, by
+// construction (a walker only knows the library's own node types; arbitrary
+// user code is not introspectable).
+type opaqueWrapKnn struct{ inner query.Filter }
+
+func (w opaqueWrapKnn) Ok(v *anyenc.Value, b *syncpool.DocBuffer) bool { return w.inner.Ok(v, b) }
+func (w opaqueWrapKnn) IndexBounds(_ string, bs query.Bounds) query.Bounds {
+	return bs
+}
+func (w opaqueWrapKnn) String() string { return "opaque" }
+
+type opaqueNotKnn struct{ inner query.Filter }
+
+func (w opaqueNotKnn) Ok(v *anyenc.Value, b *syncpool.DocBuffer) bool { return !w.inner.Ok(v, b) }
+func (w opaqueNotKnn) IndexBounds(_ string, bs query.Bounds) query.Bounds {
+	return bs
+}
+func (w opaqueNotKnn) String() string { return "opaqueNot" }
+
+// TestKnn_InsideCustomFilterFailsClosed pins the failure DIRECTIONS for a Knn
+// smuggled inside a custom Filter implementation, where detection is
+// structurally blind (see docs/query-filter-contract.md rule 5: custom filters
+// must not embed source filters).
+//
+//   - A pass-through wrapper inherits fail-closed Ok: the query silently
+//     matches NOTHING — zero rows, no-op writes, err == nil. Annoying but
+//     safe; this is precisely why Knn.Ok returns false and Text.Ok's true is
+//     the bug (a fail-open source filter here would over-delete instead).
+//   - A NEGATING wrapper reflects fail-closed into match-all, exactly like
+//     query.Not would — but unlike &Not{…} (the library's own type, walked
+//     since the pointer-form fix) this is the user's own matching code, which
+//     could just as easily `return true` outright: wrapping a Knn grants no
+//     destructive power that writing a custom filter didn't already grant.
+//
+// If an unwrap protocol (e.g. a Children() []Filter interface the walkers
+// descend) ever lands, update this test deliberately — until then these are
+// the documented consequences, not defects.
+func TestKnn_InsideCustomFilterFailsClosed(t *testing.T) {
+	coll := knnDetectColl(t)
+	kn := query.Key{Path: []string{"v"}, Filter: query.NewKnn([]float32{3, 1, 2}, 4)}
+
+	res, err := coll.Find(opaqueWrapKnn{kn}).Delete(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, res.Modified, "pass-through wrapper: fail-closed Knn.Ok matches nothing")
+	ids := writeOrderIterIds(t, coll.Find(opaqueWrapKnn{kn}))
+	assert.Empty(t, ids, "pass-through wrapper: Iter agrees (0 rows, err == nil)")
+	n, err := coll.Find(nil).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 10, n, "collection intact — the safe failure direction")
 }

--- a/vector_knn_detect_test.go
+++ b/vector_knn_detect_test.go
@@ -264,3 +264,163 @@ func TestKnnResidual_NoKnnSurvives(t *testing.T) {
 	assert.Nil(t, knnResidualFilter(query.MustParseCondition(fmt.Sprintf(`{"v":%s}`, kd))))
 	assert.Nil(t, knnResidualFilter(query.MustParseCondition(fmt.Sprintf(`{"$and":[{"v":%s}]}`, kd))))
 }
+
+// TestDetectKnn_PointerBuiltFilters pins the pointer-form walk: every
+// composite filter has value-receiver methods, so &Not{…}/&Key{…}/&Or{…}
+// satisfy query.Filter too, and a value-only type switch would skip them —
+// letting &Not{Key{v,Knn}} reflect fail-closed Ok into a full-collection
+// Delete, and &Key{v,Knn} silently return 0 rows instead of searching.
+func TestDetectKnn_PointerBuiltFilters(t *testing.T) {
+	coll := knnDetectColl(t)
+	knnLeaf := func() query.Knn { return query.NewKnn([]float32{3, 1, 2}, 4) }
+
+	t.Run("legal pointer forms search like their value forms", func(t *testing.T) {
+		for name, f := range map[string]query.Filter{
+			"&Key{v,Knn}": &query.Key{Path: []string{"v"}, Filter: knnLeaf()},
+			"Key{v,&Knn}": query.Key{Path: []string{"v"}, Filter: ptrKnn(knnLeaf())},
+			"&And{Key{v,Knn},residual}": func() query.Filter {
+				a := query.And{query.Key{Path: []string{"v"}, Filter: knnLeaf()}, query.MustParseCondition(`{"a":1}`)}
+				return &a
+			}(),
+		} {
+			ids := writeOrderIterIds(t, coll.Find(f))
+			require.NotEmpty(t, ids, "%s must search, not silently return 0 rows", name)
+			n, err := coll.Find(f).Count(ctx)
+			require.NoError(t, err, name)
+			assert.Equal(t, len(ids), n, name)
+		}
+	})
+
+	t.Run("illegal pointer forms error instead of bypassing detection", func(t *testing.T) {
+		for name, f := range map[string]query.Filter{
+			"&Not{Key{v,Knn}}": &query.Not{Filter: query.Key{Path: []string{"v"}, Filter: knnLeaf()}},
+			"&Or{Key{v,Knn},…}": func() query.Filter {
+				o := query.Or{query.Key{Path: []string{"v"}, Filter: knnLeaf()}, query.MustParseCondition(`{"a":1}`)}
+				return &o
+			}(),
+			"&Nor{Key{v,Knn}}": func() query.Filter {
+				n := query.Nor{query.Key{Path: []string{"v"}, Filter: knnLeaf()}}
+				return &n
+			}(),
+			"&Knn bare": ptrKnn(knnLeaf()),
+		} {
+			_, err := coll.Find(f).Iter(ctx)
+			require.ErrorIs(t, err, ErrKnnBadPlacement, "%s: Iter", name)
+			res, err := coll.Find(f).Delete(ctx)
+			require.ErrorIs(t, err, ErrKnnBadPlacement, "%s: Delete", name)
+			require.Zero(t, res.Modified, name)
+			remaining, cerr := coll.Find(nil).Count(ctx)
+			require.NoError(t, cerr)
+			require.Equal(t, 10, remaining, "%s: collection must be intact — this exact shape deleted everything before the pointer-walk fix", name)
+		}
+	})
+}
+
+func ptrKnn(k query.Knn) *query.Knn { return &k }
+
+// neArrComp builds Comp{Ne, <plain array>} — the programmatic twin of the JSON
+// {"$ne":[...]} spelling.
+func neArrComp(qv []float32) *query.Comp {
+	a := &anyenc.Arena{}
+	arr := a.NewArray()
+	for i, f := range qv {
+		arr.SetArrayItem(i, a.NewNumberFloat64(float64(f)))
+	}
+	return query.NewCompValue(query.CompOpNe, arr)
+}
+
+// TestDetectKnn_NeDimArrayIsLegacy: $ne with a dim-sized plain array on a
+// vector-indexed field is the match-all mirror of the legacy $eq spelling —
+// on packed storage the operand never byte-equals any stored value, so the
+// $ne would silently select EVERY document ("delete all but this vector"
+// removes that vector too). Loud error, both spellings.
+func TestDetectKnn_NeDimArrayIsLegacy(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "knn_ne")
+	require.NoError(t, err)
+	require.NoError(t, coll.CreateIndex(ctx, IndexInfo{
+		Name: "emb", Kind: IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: 3, Metric: VectorL2},
+	}))
+	// Packed storage — the encoding for which the $ne is a silent match-all.
+	a := &anyenc.Arena{}
+	for i := 0; i < 8; i++ {
+		obj := a.NewObject()
+		obj.Set("id", a.NewNumberInt(i))
+		obj.Set("v", a.NewVectorF32([]float32{float32(i), 1, 2}))
+		require.NoError(t, coll.Insert(ctx, obj))
+		a.Reset()
+	}
+
+	for name, f := range map[string]any{
+		"json $ne":         `{"v":{"$ne":[3,1,2]}}`,
+		"programmatic $ne": query.Key{Path: []string{"v"}, Filter: neArrComp([]float32{3, 1, 2})},
+	} {
+		_, err = coll.Find(f).Iter(ctx)
+		require.ErrorIs(t, err, ErrLegacyVectorClause, "%s: Iter", name)
+		res, derr := coll.Find(f).Delete(ctx)
+		require.ErrorIs(t, derr, ErrLegacyVectorClause, "%s: Delete", name)
+		require.Zero(t, res.Modified, name)
+	}
+	remaining, err := coll.Find(nil).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 8, remaining, "the $ne must never have executed as a match-all literal")
+
+	// Wrong-dim $ne stays an ordinary filter (not ANN-shaped).
+	n, err := coll.Find(`{"v":{"$ne":[1,2]}}`).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 8, n, "non-dim-sized $ne is an ordinary literal filter")
+}
+
+// TestDetectKnn_NestedKeyDistancePath: a nested-Key filter on a real stored
+// sub-field literally named _distance (a._distance) is NOT the synthetic
+// top-level _distance — the reference walk descends with the path suffix.
+func TestDetectKnn_NestedKeyDistancePath(t *testing.T) {
+	coll := knnDetectColl(t)
+	f := query.Key{Path: []string{"a"}, Filter: query.Key{Path: []string{"_distance"}, Filter: query.NewComp(query.CompOpGt, 1)}}
+	n, err := coll.Find(f).Count(ctx)
+	require.NoError(t, err, "a._distance is a stored sub-field, not the synthetic _distance")
+	assert.Zero(t, n)
+	// The synthetic reference itself still errors, wherever it hides.
+	_, err = coll.Find(query.Not{Filter: query.Key{Path: []string{"_distance"}, Filter: query.NewComp(query.CompOpLt, 1)}}).Count(ctx)
+	require.ErrorIs(t, err, ErrDistanceWithoutVector)
+}
+
+// TestKnn_SortedResultsKeepDistance: SortIter clears the in-flight decorated
+// doc, so the public iterator re-fetches — the _distance field must be
+// re-injected from the sidecar, as docs/vector-search.md promises.
+func TestKnn_SortedResultsKeepDistance(t *testing.T) {
+	coll := knnDetectColl(t)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s}`, kd)).Sort("-_distance").Iter(ctx)
+	require.NoError(t, err)
+	defer iter.Close()
+	rows := 0
+	for iter.Next() {
+		doc, derr := iter.Doc()
+		require.NoError(t, derr)
+		dv := doc.Value().Get("_distance")
+		require.NotNil(t, dv, "sorted $knn result lost the documented _distance field")
+		assert.InDelta(t, float64(iter.Distance()), dv.GetFloat64(), 1e-6)
+		rows++
+	}
+	require.NoError(t, iter.Err())
+	require.NotZero(t, rows)
+}
+
+// TestExplain_UnconsideredSourceIndexesCarryNoCost: vector/fts indexes are
+// listed for visibility, but only the driving index carries the plan's cost —
+// an unconsidered index with a phantom cost would read as a CBO candidate.
+func TestExplain_UnconsideredSourceIndexesCarryNoCost(t *testing.T) {
+	coll := knnDetectColl(t)
+	exp, err := coll.Find(`{"a":1}`).Explain(ctx)
+	require.NoError(t, err)
+	var sawVector bool
+	for _, ix := range exp.Indexes {
+		if ix.Name == "emb" {
+			sawVector = true
+			assert.False(t, ix.Used)
+			assert.Zero(t, ix.Cost, "the CBO never costed the vector index for a plain range query")
+		}
+	}
+	assert.True(t, sawVector, "the vector index must still be listed")
+}

--- a/vector_modes_test.go
+++ b/vector_modes_test.go
@@ -20,15 +20,11 @@ func makeVectorIndex(t *testing.T, coll Collection, mode VectorMode, dim int) {
 	}))
 }
 
-// vectorEqFilter builds the `{v: [..]}` equality filter used to issue a vector
-// query through the normal Find pipeline.
-func vectorEqFilter(qv []float32) query.Filter {
-	a := &anyenc.Arena{}
-	arr := a.NewArray()
-	for i, f := range qv {
-		arr.SetArrayItem(i, a.NewNumberFloat64(float64(f)))
-	}
-	return query.Key{Path: []string{"v"}, Filter: query.NewCompValue(query.CompOpEq, arr)}
+// vectorKnnFilter builds the programmatic $knn filter (query.NewKnn) used to
+// issue a vector query through the normal Find pipeline — the same construction
+// the downstream indexer uses (no JSON involved).
+func vectorKnnFilter(qv []float32, k int) query.Filter {
+	return query.Key{Path: []string{"v"}, Filter: query.NewKnn(qv, k)}
 }
 
 // TestVectorMode_Persist verifies every mode round-trips through reopen and is
@@ -139,7 +135,7 @@ func TestVectorMode_BruteExact(t *testing.T) {
 	assert.Equal(t, 1.0, recall, "brute-force search must be exact")
 
 	// query pipeline returns the same nearest doc, decorated with _distance.
-	iter, err := coll.Find(vectorEqFilter(vecs[7])).Limit(1).Iter(ctx)
+	iter, err := coll.Find(vectorKnnFilter(vecs[7], 1)).Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
 	require.True(t, iter.Next())

--- a/vector_pipeline_test.go
+++ b/vector_pipeline_test.go
@@ -47,12 +47,21 @@ func vqJSON(vec []float32) string {
 	return "[" + strings.Join(parts, ",") + "]"
 }
 
-// TestPipeline_Minimum: Find({"v":[..]}).Iter() — implicit distance order + Distance().
+// vknnJSON renders the $knn clause value: {"$knn":{"$query":[...],"$k":k}}.
+// ef<=0 omits $ef (the index default applies).
+func vknnJSON(vec []float32, k, ef int) string {
+	if ef > 0 {
+		return fmt.Sprintf(`{"$knn":{"$query":%s,"$k":%d,"$ef":%d}}`, vqJSON(vec), k, ef)
+	}
+	return fmt.Sprintf(`{"$knn":{"$query":%s,"$k":%d}}`, vqJSON(vec), k)
+}
+
+// TestPipeline_Minimum: Find({"v":{"$knn":..}}).Iter() — implicit distance order + Distance().
 func TestPipeline_Minimum(t *testing.T) {
 	const dim = 16
 	coll, vecs := setupPipeline(t, 800, dim)
 
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s}`, vqJSON(vecs[42]))).Iter(ctx)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s}`, vknnJSON(vecs[42], 64, 0))).Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
 
@@ -86,7 +95,7 @@ func TestPipeline_DistanceFilterAndSort(t *testing.T) {
 	coll, vecs := setupPipeline(t, 800, dim)
 
 	const thr = 1.5
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"_distance":{"$lt":%g}}`, vqJSON(vecs[100]), thr)).
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"_distance":{"$lt":%g}}`, vknnJSON(vecs[100], 64, 0), thr)).
 		Sort("_distance", "name").Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
@@ -111,7 +120,7 @@ func TestPipeline_AdditionalFilter(t *testing.T) {
 	const dim = 16
 	coll, vecs := setupPipeline(t, 800, dim)
 
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"lang":"en"}`, vqJSON(vecs[10]))).Iter(ctx)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"lang":"en"}`, vknnJSON(vecs[10], 32, 0))).Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
 
@@ -148,18 +157,18 @@ func setupPipelineEf(t *testing.T, n, dim, efSearch int) (Collection, [][]float3
 	return coll, vecs
 }
 
-// TestPipeline_OverFetch: a filtered query with a limit fills the limit because
-// the planner over-fetches candidates (ef = limit×factor), even though the
-// index's own EfSearch is small.
+// TestPipeline_OverFetch: a filtered $knn fills $k because the auto ef
+// over-fetches candidates (ef = k×factor), even though the index's own
+// EfSearch is small.
 func TestPipeline_OverFetch(t *testing.T) {
 	const (
 		dim      = 16
-		efSearch = 16 // small: limit alone (30) would not yield 30 en survivors
-		limit    = 30
+		efSearch = 16 // small: k alone (30) would not yield 30 en survivors
+		limit    = 30 // $k
 	)
 	coll, vecs := setupPipelineEf(t, 1000, dim, efSearch)
 
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"lang":"en"}`, vqJSON(vecs[0]))).Limit(limit).Iter(ctx)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"lang":"en"}`, vknnJSON(vecs[0], limit, 0))).Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
 	var count int
@@ -170,15 +179,18 @@ func TestPipeline_OverFetch(t *testing.T) {
 		count++
 	}
 	require.NoError(t, iter.Err())
-	assert.Equal(t, limit, count, "over-fetch should fill the limit despite a selective filter")
+	assert.Equal(t, limit, count, "over-fetch should fill $k despite a selective filter")
 }
 
-// TestPipeline_VectorEf: an explicit VectorEf bounds the candidate set.
-func TestPipeline_VectorEf(t *testing.T) {
+// TestPipeline_ExplicitEf: an explicit $ef bounds the candidate set — it
+// disables the auto ×10 residual over-fetch, so a selective residual
+// under-fills $k (the documented escape valve is raising $ef).
+func TestPipeline_ExplicitEf(t *testing.T) {
 	const dim = 16
 	coll, vecs := setupPipelineEf(t, 1000, dim, 64)
 
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s}`, vqJSON(vecs[0]))).VectorEf(5).Iter(ctx)
+	const k = 30
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"lang":"en"}`, vknnJSON(vecs[0], k, k))).Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
 	var count int
@@ -186,7 +198,7 @@ func TestPipeline_VectorEf(t *testing.T) {
 		count++
 	}
 	require.NoError(t, iter.Err())
-	assert.LessOrEqual(t, count, 5, "VectorEf(5) must cap the candidate set")
+	assert.Less(t, count, k, "an explicit $ef == $k must not over-fetch: ~half the candidates are filtered out")
 	assert.Greater(t, count, 0)
 }
 
@@ -196,17 +208,25 @@ func TestPipeline_Errors(t *testing.T) {
 	const dim = 16
 	coll, vecs := setupPipeline(t, 100, dim) // field "v", dim 16
 
+	knn := func(k int) string { return vknnJSON(vecs[0], k, 0) } // dim-16 query
 	cases := []struct {
 		name   string
 		find   string
 		sort   []any
 		wantIs error
 	}{
-		{"wrong-dim vector", `{"v":[1,2,3]}`, nil, ErrInvalidVectorQuery},
-		{"non-array on vector field", `{"v":"hello"}`, nil, ErrInvalidVectorQuery},
-		{"range op on vector field", `{"v":{"$gt":[0.0]}}`, nil, ErrInvalidVectorQuery},
-		{"_distance filter w/o vector clause", `{"_distance":{"$lt":1.0}}`, nil, ErrDistanceWithoutVector},
-		{"_distance sort w/o vector clause", `{"id":{"$gt":5}}`, []any{"-_distance"}, ErrDistanceWithoutVector},
+		{"legacy bare-array ANN clause", fmt.Sprintf(`{"v":%s}`, vqJSON(vecs[0])), nil, ErrLegacyVectorClause},
+		{"legacy clause under $or", fmt.Sprintf(`{"$or":[{"v":%s},{"id":1}]}`, vqJSON(vecs[0])), nil, ErrLegacyVectorClause},
+		{"wrong-dim $query", `{"v":{"$knn":{"$query":[1,2,3],"$k":5}}}`, nil, ErrInvalidVectorQuery},
+		{"$knn on unindexed field", fmt.Sprintf(`{"nosuch":%s}`, knn(5)), nil, ErrNoVectorIndex},
+		{"$index naming no index", `{"v":{"$knn":{"$query":[1,2,3],"$k":5,"$index":"bogus"}}}`, nil, ErrNoVectorIndex},
+		{"$knn under $or", fmt.Sprintf(`{"$or":[{"v":%s},{"id":1}]}`, knn(5)), nil, ErrKnnBadPlacement},
+		{"$knn under $nor", fmt.Sprintf(`{"$nor":[{"v":%s}]}`, knn(5)), nil, ErrKnnBadPlacement},
+		{"two $knn clauses", fmt.Sprintf(`{"$and":[{"v":%s},{"v":%s}]}`, knn(5), knn(5)), nil, ErrMultipleVectorClauses},
+		{"$knn with $text", fmt.Sprintf(`{"v":%s,"$text":{"$search":"x"}}`, knn(5)), nil, ErrKnnWithText},
+		{"_distance filter w/o $knn", `{"_distance":{"$lt":1.0}}`, nil, ErrDistanceWithoutVector},
+		{"_distance filter w/o $knn, inside $or", `{"$or":[{"_distance":{"$lt":1.0}},{"id":1}]}`, nil, ErrDistanceWithoutVector},
+		{"_distance sort w/o $knn", `{"id":{"$gt":5}}`, []any{"-_distance"}, ErrDistanceWithoutVector},
 		{"_distance sort, no filter", ``, []any{"_distance"}, ErrDistanceWithoutVector},
 	}
 	for _, tc := range cases {
@@ -225,11 +245,29 @@ func TestPipeline_Errors(t *testing.T) {
 		})
 	}
 
-	// sanity: a valid vector query (optionally with _distance) does NOT error
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"_distance":{"$lt":2.0}}`, vqJSON(vecs[0]))).
+	// sanity: a valid $knn query (optionally with _distance) does NOT error
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s,"_distance":{"$lt":2.0}}`, knn(10))).
 		Sort("-_distance").Iter(ctx)
 	require.NoError(t, err)
 	require.NoError(t, iter.Close())
+
+	// Non-$knn predicates on a vector-indexed field are ORDINARY filters on
+	// every verb — the rule, not the exception (programmatic consumers depend
+	// on it: {"v":{"$exists":true}}.Count decides index builds downstream).
+	for _, legal := range []string{
+		`{"v":"hello"}`,          // non-array literal
+		`{"v":[1,2,3]}`,          // wrong-dim array: not the ANN shape
+		`{"v":{"$exists":true}}`, // predicate op
+		`{"v":{"$size":16}}`,
+	} {
+		t.Run("legal literal "+legal, func(t *testing.T) {
+			it, lerr := coll.Find(legal).Iter(ctx)
+			require.NoError(t, lerr)
+			require.NoError(t, it.Close())
+			_, cerr := coll.Find(legal).Count(ctx)
+			require.NoError(t, cerr)
+		})
+	}
 }
 
 // TestPipeline_Limit: limit applies over the distance-ordered results.
@@ -237,7 +275,7 @@ func TestPipeline_Limit(t *testing.T) {
 	const dim = 16
 	coll, vecs := setupPipeline(t, 800, dim)
 
-	iter, err := coll.Find(fmt.Sprintf(`{"v":%s}`, vqJSON(vecs[5]))).Limit(10).Iter(ctx)
+	iter, err := coll.Find(fmt.Sprintf(`{"v":%s}`, vknnJSON(vecs[5], 10, 0))).Limit(10).Iter(ctx)
 	require.NoError(t, err)
 	defer iter.Close()
 	var count int
@@ -255,7 +293,7 @@ func TestPipeline_Limit(t *testing.T) {
 func TestPipeline_Offset(t *testing.T) {
 	const dim = 16
 	coll, vecs := setupPipeline(t, 800, dim)
-	qv := vqJSON(vecs[5])
+	qv := vknnJSON(vecs[5], 20, 0)
 
 	collect := func(query Query) []string {
 		iter, err := query.Iter(ctx)


### PR DESCRIPTION
Implements the decided design in `docs/plans/2026-07-13-bug32-knn-operator.md` (Increments 1c and 2). Closes the last structural hole of BUG-32: ANN intent is now an explicit operator, detected on **every** verb through the compilePlan seam, with `k` in the clause.

## Increment 1c — source-level determinism (non-breaking, own commit)

The vivf ef-cut membership depended on the pooled searcher's table size (dedup.collect walks slot order → distance-only quickselect picks an arbitrary tie subset). Cut is now tie-broken by `(dist, label)` in both backends (vivf quickselect, vindex beam admission), and all sources emit `(distance, docId)` ascending — a total order. `VectorQuerySpec.Ordered` → `TotallyOrdered`. A/B-verified reproducer: cold vs pre-grown searcher over a 290-member exact-tie group diverges at rank 10 on the old cut.

## Increment 2 — `$knn` (breaking)

**Grammar** (options object only): `{"field":{"$knn":{"$query":<vec>,"$k":N,"$ef":E?,"$index":S?}}}` — `$query` accepts a plain array or a packed `{"$vector":[…]}`; `$k` mandatory (the payload key is `$query` because anyenc eats a sole-key `$vector` object into a vector *value*). Programmatic: `query.NewKnn(vec, k, KnnEf(...), KnnIndex(...))` — required, the production consumers never touch JSON.

**Semantics**: filter → cut-to-k → sort → page, one definition for Iter/Count/Update/Delete/Explain/Aggregate-prefix. Plan shape: `KnnSearch(ef) -> [Filter] -> Limit(k) -> [Sort] -> [Limit(offset,limit)]`. `ef` is a pure function of the clause (never limit/offset/sort/verb), so `Count == len(Iter)` is structural. No verb rejects `$knn`: a write's blast radius is `$k`, a number the caller typed — `ErrVectorWriteWithoutLimit` retires by construction, `Query.VectorEf` is deleted.

**Fail-closed everywhere**: `Knn.Ok` is `false`; the parser rejects `$knn` under `$not`/mixed operators; detection (authoritative — re-checks every parse rule for hand-built filters, runs before `unsatisfiable()` on all five verbs) rejects `$or`/`$nor`/nesting/multiples/`$text`-mix/no-index/ambiguous-index/wrong-dim; the residual builder strips by node identity, recurses through `*And`, and asserts `!ContainsKnn(residual)`. `GuaranteesPresence` gets explicit source-filter arms (fail-closed Ok would read as the aggressive presence answer).

**Breaking**: the pre-`$knn` bare-array spelling is `ErrLegacyVectorClause` on every verb (scoped to `TypeArray` of exactly `dim` numbers — `$eq` against a packed vector stays ordinary byte equality per Rule V). Silent demotion would have returned 0 rows on packed storage with `err=nil`.

**Also**: `injectDistance` is unconditional (`NeedDistances` gates only the sidecar) so a `_distance` residual thresholds writes instead of matching all; Explain reports vector/fts indexes with `Used` flags and names `KnnSearch(k=,ef=)`; aggregate's third hand-rolled clause-walker (`hasVectorClause`) is deleted, in-pipeline `$knn` *and* legacy clauses rejected; `Count`/`Iter`/`Update`/`Delete` validate sources before the unsatisfiable short-circuit (Explain gains the same ordering); CLI gets `Knn(vec, k, {ef,index})`.

## Tests

- `TestVerbCoherence_Knn`: 5 index modes × {none, selective, `_distance`} residual × 3 sorts × 3 pagings — `ids(Iter)` == Delete's removals, `Count == len`, `Update.Matched == len`, Explain names KnnSearch, `len ≤ k`, identical reruns; hybrid warms the l0 mirror (read path) vs raw-btree write path.
- Detection tables (JSON + hand-built), ambiguous-index resolution via `$index`, residual post-condition, k-cut plan shape, `injectDistance` gating trap, grammar accept/reject with exact error strings, lossless `String()` round-trip.
- **Acceptance gate** (`any-store-tests`, migrated in lockstep, commit 6f37b04): differential fuzz green, e2e green; only the known-open Phase 2 bugs (BUG-24/25/27/28) fail, verified identical on btree HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)