### PR TITLE
Peer-visibility criticals: master-cell overflow readers + name caps, fulltext peer-DDL reconcile

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -1584,12 +1584,18 @@ func (c *collection) reconcileIndexes(tx *btree.ReadTx) {
 		byName[idx.info.Name] = idx
 	}
 
-	// Reconcile vector indexes separately (different namespaces / type).
+	// Reconcile vector and full-text indexes separately (different
+	// namespaces / types). Full-text infos must not fall through to the
+	// range loop below: they have no ix: namespace, so they would silently
+	// fail resolution there and the ftsIndexes snapshot would never track a
+	// peer's full-text DDL — leaving a stale handle that flushes postings
+	// into freed-and-reused ftx: pages, or never adopting a peer's index.
 	c.reconcileVectorIndexesLocked(tx, infos)
+	c.reconcileFtsIndexesLocked(tx, infos)
 
 	rangeInfos := infos[:0:0]
 	for _, info := range infos {
-		if info.Kind != IndexKindVector {
+		if info.Kind != IndexKindVector && !isFulltext(info) {
 			rangeInfos = append(rangeInfos, info)
 		}
 	}

--- a/collection.go
+++ b/collection.go
@@ -177,6 +177,15 @@ type collection struct {
 	// allocating a fresh read buffer per index.
 	sketchReadBuf []byte
 
+	// indexSetDDLTxs counts local write transactions with UNCOMMITTED index-set
+	// publications on this collection (guarded by c.mu; incremented in
+	// registerIndexSetRestore, decremented exactly once at the tx's commit
+	// publish or rollback undo). reconcileIndexes consults it: a concurrent
+	// read tx's staleness pass must not rebuild the sets from ITS (older)
+	// snapshot while the writer's mid-tx publications are in them — it would
+	// evict the writer's uncommitted indexes. See the guard in reconcileIndexes.
+	indexSetDDLTxs int
+
 	closed atomic.Bool
 	mu     sync.Mutex
 }
@@ -963,12 +972,23 @@ func (c *collection) createIndexes(ctx context.Context, ensure bool, info ...Ind
 // swapping; restoring an unchanged set is a harmless pointer store.
 func (c *collection) registerIndexSetRestore(wtx WriteTx) {
 	prevIndexes, prevFts, prevVec := c.loadIndexes(), c.loadFtsIndexes(), c.loadVectorIndexes()
+	// Mark the DDL in flight so a concurrent read tx's reconcile leaves the
+	// sets alone until this tx resolves. Exactly one of the two callbacks runs
+	// per outcome (commit → pubs, rollback/failed commit → undo), so the
+	// counter balances.
+	c.indexSetDDLTxs++
 	wtx.onRollbackUndo(func() {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		c.storeIndexes(prevIndexes)
 		c.storeFtsIndexes(prevFts)
 		c.storeVectorIndexes(prevVec)
+		c.indexSetDDLTxs--
+	})
+	wtx.onCommitPublish(func() {
+		c.mu.Lock()
+		c.indexSetDDLTxs--
+		c.mu.Unlock()
 	})
 }
 
@@ -1577,6 +1597,18 @@ func (c *collection) reconcileIndexes(tx *btree.ReadTx) {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.indexSetDDLTxs > 0 {
+		// A local write tx has uncommitted index DDL published in these sets.
+		// The cookie bump this pass reacts to predates that writer's begin (it
+		// holds the cross-process write lock), so the writer's own begin-time
+		// checkStale already reconciled it; rebuilding here from this tx's
+		// OLDER snapshot would evict the writer's uncommitted indexes (its
+		// same-tx inserts would silently stop being indexed, and buffered fts
+		// postings would never flush). Skip — the same argument as the
+		// renameInFlight guard in reconcileIndexSet.
+		return
+	}
 
 	cur := c.loadIndexes()
 	byName := make(map[string]*index, len(cur))

--- a/collection.go
+++ b/collection.go
@@ -977,6 +977,9 @@ func (c *collection) createIndex(ctx context.Context, tx *btree.WriteTx, info In
 	if info.Name == "" {
 		info.Name = info.createName()
 	}
+	if err = validateIndexName(info.Name); err != nil {
+		return nil, err
+	}
 	for _, field := range info.Fields {
 		if err = validateIndexField(field); err != nil {
 			return nil, err
@@ -1036,6 +1039,9 @@ func (c *collection) createFtsIndex(ctx context.Context, tx *btree.WriteTx, info
 	tx.MarkSchemaChanged()
 	if info.Name == "" {
 		info.Name = info.createName()
+	}
+	if err := validateIndexName(info.Name); err != nil {
+		return nil, err
 	}
 	for _, field := range info.Fields {
 		if err := validateIndexField(field); err != nil {

--- a/db.go
+++ b/db.go
@@ -353,9 +353,19 @@ func indexKeyPrefix(collName string) string {
 // with ErrNamespaceExists at index-create or rename time — it can never
 // corrupt silently. Rejecting ":" would also strand pre-validation files whose
 // collection names legally contain it.
+// maxNameLen caps collection and index names. Derived namespace names embed
+// both plus a family prefix/suffix (widest: fts "ftx:"+coll+":"+index+":vocab",
+// +11 bytes), and a master-table cell must keep its 4-byte root value within
+// maxLocalPayload(4096) = 1002, i.e. len(coll)+len(index) <= 987. 255 each
+// leaves ample margin and matches common identifier limits.
+const maxNameLen = 255
+
 func validateCollectionName(name string) error {
 	if name == "" {
 		return fmt.Errorf("%w: name must not be empty", ErrInvalidCollectionName)
+	}
+	if len(name) > maxNameLen {
+		return fmt.Errorf("%w: name exceeds %d bytes", ErrInvalidCollectionName, maxNameLen)
 	}
 	if name == systemNamespace {
 		return fmt.Errorf("%w: %q is reserved", ErrInvalidCollectionName, name)
@@ -364,6 +374,16 @@ func validateCollectionName(name string) error {
 		if strings.HasPrefix(name, prefix) {
 			return fmt.Errorf("%w: prefix %q is reserved for index namespaces", ErrInvalidCollectionName, prefix)
 		}
+	}
+	return nil
+}
+
+// validateIndexName caps the index name AFTER createName() defaulting — a long
+// field list can synthesize a name past the cap just as easily as a caller can
+// pass one.
+func validateIndexName(name string) error {
+	if len(name) > maxNameLen {
+		return fmt.Errorf("%w: name exceeds %d bytes", ErrInvalidIndexName, maxNameLen)
 	}
 	return nil
 }

--- a/docs/plans/2026-07-17-peer-visibility-criticals.md
+++ b/docs/plans/2026-07-17-peer-visibility-criticals.md
@@ -1,0 +1,144 @@
+# Peer-visibility criticals grooming: FTS peer DDL, checkpoint read-mark clobber, master-cell overflow
+
+**Repo:** `github.com/anyproto/any-store/v2`, branch `btree` @ `9a97c12`
+**Worktree (read/edit code HERE):** `/home/che/projects/any-store/.claude/worktrees/peer-visibility-groom`
+**Companion test repo:** `/home/che/projects/any-store-tests` (module `any-store-tests`, go.work → `../any-store`)
+**Bug docs:** `BUG-40-fts-peer-ddl-not-reconciled.md`, `BUG-41-checkpoint-clobbers-peer-readmarks.md`, `BUG-42-master-cell-overflow-namespace-unresolvable.md` — all in the test repo
+**Reference sources:** sqlitec pinned `version-3.52.0` at `~/projects/sqlitec` (HEAD `257fdf849`, verified this groom); all wal.c / btree.c line cites below are against that tag
+
+**Goal (acceptance):** the three bug docs flip to FIXED with descriptive regression tests green: btree-layer long-name master-cell round-trip at ps=512 + IntegrityCheck; multiprocess FTS peer-drop (IntegrityCheck clean after churn) and peer-create ($text sees backfilled + new docs); two-process checkpoint test where a live peer's SHM read-mark survives PASSIVE checkpoints and a pinned reader never observes future bytes.
+
+**Scope decisions this groom (2026-07-17, supersedes the 2026-07-12 per-doc decisions where noted):**
+- BUG-42 gets the **full fix now** (overflow-following readers + rename read-back guard + name caps), superseding "cap now, reader fix later" — exploration showed the value-reconstruction machinery already exists and one funnel point (`resolveNamespace`) repairs all four read entry points.
+- BUG-41's deferred "dedicated decision" is **this document**: align with wal.c's per-slot-lock invariant; no new drift is introduced, one filed follow-up is closed.
+- Implementation order: **BUG-42 → BUG-40 → BUG-41** (self-contained btree read fix first, app-layer reconcile second, the delicate WAL/SHM protocol change last, in its own PR).
+
+**Semantics oracle:** SQLite C sources for BUG-41/42 (btree/WAL layer — the alignment directive applies hard); BUG-40 is any-store app-layer design with no C counterpart (SQLite has no per-connection index handle snapshots), so its oracle is the repo's own vector-reconcile precedent.
+
+Every empirical claim below was verified on this worktree at 9a97c12.
+
+---
+
+## Decision summary
+
+| # | question | decision |
+|---|---|---|
+| 1 | BUG-42 scope | Full fix: overflow-following value read in `resolveNamespace` + the `masterLeaf` integrity hook, `RenameNamespace` read-back guard, and app-layer name caps. The caps prevent the public API from ever writing an overflowing master cell; the reader fix repairs the btree layer (any page size) and any already-written long-name data. |
+| 2 | BUG-42 reader mechanism | Mirror `ReadTx.AppendValue`'s overflow branch (db.go:1575-1620): copy the local `cell.value` portion, then `pager.readOverflowAt(cell.overflowPg, keyOverflow, valOverflow, dst, walMaxFrame, cache)` (pager.go:3050). Works with nil cache, so the writer path `getNamespaceLocked` is covered too. Alignment source: SQLite reads sqlite_master exclusively through `accessPayload` (btree.c:5121), which reassembles local + overflow transparently — the local-only master reader was the drift, and this change removes it (no DRIFT entry; commit message cites accessPayload). |
+| 3 | BUG-42 name caps | 255 bytes each for collection and index names, enforced in `validateCollectionName` (db.go:356) and after `createName()` defaulting (collection.go:977-978, 1037-1038). Budget: widest derived namespace is fts `len(C)+len(I)+11`; overflow needs `derived+4 > maxLocalPayload(4096)=1002`, so the binding constraint is `len(C)+len(I) ≤ 987`; 255+255 leaves 477 bytes of margin. New error var in errors.go beside `ErrInvalidCollectionName`. |
+| 4 | BUG-42 rename guard | After `bt.Put(newName, …)` (db.go:1200-1202), re-resolve `newName` and require the root page to match the moved namespace; on mismatch return an error so the caller rolls back (contract at db.go:1166-1168). Cheap backstop; only meaningful with decision 2 in place. |
+| 5 | BUG-40 mechanism | New `reconcileFtsIndexesLocked(tx, infos)` mirroring `reconcileVectorIndexesLocked` (vector_index.go:486-530), called beside it in `reconcileIndexes`; `Kind==IndexKindFulltext` infos are excluded from `rangeInfos` (fixing the misclassification at collection.go:1584-1590 that silently dropped them at `ix:` resolution). |
+| 6 | BUG-40 adopt/reuse/evict | Adopt peer-created: construct `ftsIndex` + `bindNamespaces(tx.GetNamespace)` (resolve-only, fulltext_index.go:159-178). Reuse existing iff the `nsMeta` namespace root is unchanged (analog of vector `rootUnchanged`, vector_index.go:295-307 — detects peer drop+recreate). Keep-existing on transient resolution failure (never drop a working index on an error, matching vector_index.go:515-522). Evict peer-dropped by omission **+ `fx.pending.reset()`** (precedent: `invalidateCollection`, db.go:551-553). CoW `storeFtsIndexes` iff changed. Adoption trusts the peer's on-disk backfill (matches range/vector adoption; confirmed from 2026-07-12). |
+| 7 | BUG-40 disk writes | None. Reconcile never calls `DeleteNamespace`/`removeIndex`/`MarkSchemaChanged` — the peer already performed the DDL, and reconcile may run inside a read tx. Eviction is purely local handle release. |
+| 8 | BUG-41 mechanism | Restore wal.c's invariant (wal.c:367-370: aReadMark[K] is only written under exclusive WAL_READ_LOCK(K)). Add single-word publishers `shmWriteNBackfill` / `shmWriteNBackfillAttempted` (mirroring `shmWriteReadMark`, wal.go:1302); the two `checkpointWithMode` publishes (wal.go:3580, 3801) write **counters only** — read-marks leave the checkpoint publish path entirely (the reader loop at wal.go:3500-3542 already writes them per-slot-locked). C analogs: nBackfillAttempted at wal.c:2268, `AtomicStore(&nBackfill)` at wal.c:2331 — C never bulk-copies marks when publishing counters. |
+| 9 | BUG-41 recovery/open paths | The `doResetWAL`→`reset()` path is **already lock-safe** (`tryResetWALWithBusy` wal.go:3864-3884 holds slots 1-4 exclusive — matches the range lock at wal.c:2361 before `walRestartHdr`). The unprotected sites are `recoverLocked` (wal.go:2049) and `reset()`'s open-path callers `initHeaderStateLocked` (wal.go:1785) / `writeHeader` (wal.go:1840): their SHM mark writes move to a per-slot try-lock loop that skips BUSY (live-reader) slots, mirroring walIndexRecover (wal.c:1573-1588). This closes the follow-up filed in NOTES `drift-2026-07-10-3` (NOTES.md:3325). Restructure so every SHM `aReadMark[i]` store is statically auditable as lock-bracketed. |
+| 10 | BUG-41 non-scope | Mark-*value* drifts stay untouched: drift-88 (recovery sets all marks NOT_USED vs C pre-seeding slot 1), drift-99 (restart clobbers marks 0/1 to NOT_USED vs walRestartHdr values), drift-97/98 (salts / nCkpt). This increment changes locking and publication shape only. Process-local `aReadMark` mirrors stay (in-process heapShm mode has no region; wal.go:505-520). |
+| 11 | NOTES/DRIFT output | No new DRIFT entries — all three fixes remove or avoid divergence. One NOTES edit: annotate the "Adjacent follow-up (separate issue)" sentence of `drift-2026-07-10-3` as resolved, citing the new per-slot-locked recovery mark writes. |
+| 12 | increments | 1 = BUG-42 full fix (S+S+S, btree + app validation). 2 = BUG-40 reconcile (M, app layer + multiprocess tests in the test repo). 3 = BUG-41 (L, WAL/SHM protocol, own PR, two-process tests). Separable commits per scope discipline; no BUG-NN identifiers in code or test names. |
+
+---
+
+## BUG-42 — master-cell overflow (btree layer + app caps)
+
+### Facts (verified)
+
+- Cell contract (btree.go:162-164): for overflow cells `cell.key`/`cell.value` hold the **local portions only**; when the 4-byte rootPgno value spills wholly, `len(cell.value)==0` and `cell.overflowPg != 0` (assignment guarded at btree.go:217-219).
+- All four namespace read entry points — `DB.GetNamespace` (db.go:1332), `getNamespaceLocked` (db.go:1351, writer path, nil cache), `getNamespaceAt` (db.go:1360), `ReadTx/WriteTx.GetNamespace` — funnel into `resolveNamespace` (db.go:1368-1420). The buggy read is db.go:1395-1399 (`len(cell.value) < 4 → ErrCorrupt`). Key lookup is already overflow-correct (`searchLeafWithOverflow`, db.go:1380) — only the value read is broken.
+- The `masterLeaf` IntegrityCheck hook (integrity.go:646-669) has the identical local-only read at :650-654. Overflow-page **accounting** is already correct: `checkTreePage` computes `nOverflow` and `checkList`s the chain (integrity.go:404-419), so "page never used" does not false-positive; the reported `corrupt namespace root value` is purely the value read.
+- Reconstruction machinery exists: `ReadTx.AppendValue`'s overflow branch (db.go:1575-1620) decodes keyLen/valLen, computes `nLocal`/`localValBytes`/`keyOverflow`/`valOverflow`, copies the local part, then `pager.readOverflowAt(firstPgno, skip, amt, dst, walMaxFrame, cache)` (pager.go:3050; branches internally on nil cache).
+- `maxLocalPayload = ((usableSize-12)*64/255) - 23` (page.go:105): **102** @ ps=512, **1002** @ ps=4096. Master cell overflows when `len(name)+4 > maxLocalPayload`.
+- Write side is already correct (`bt.Put` spills properly, db.go:1126-1127); `CreateNamespace` fails loudly only because the wrapper re-resolves; `RenameNamespace` (db.go:1171-1203) never re-resolves → silent durable brick.
+- Namespace-name derivations and worst-case overhead over user names (C = collection, I = index): data ns = `C` (+0); range `ix:C:I` (+4, index.go:298-300); fulltext `ftx:C:I:part`, longest part `vocab` → **+11** (fulltext_index.go:24-34); vector `vix:C:I` + suffix, longest `:cell` → +10 (vector_index.go:43-50, vivf/store.go:220-222).
+- Current validation has **no length rule anywhere**: `validateCollectionName` (db.go:356-369) rejects only empty/system/reserved prefixes; index names are unvalidated and `createName()` (index.go:285-287) can synthesize long ones from field lists.
+
+### Design
+
+1. **`resolveNamespace`**: on `cell.overflowPg != 0`, reconstruct the value exactly as db.go:1602-1618 does — local part first (the value may be split, not only wholly spilled), then `readOverflowAt` with `skip` = key-overflow bytes into a 4-byte buffer. `bt` already carries `pager`/`walMaxFrame`/`cache`.
+2. **`masterLeaf` hook**: same reconstruction with `ic.pager/ic.cache/ic.walMaxFrame/ic.usableSize` (integrity.go:608-616); widen the `onLeafCell` callback or reconstruct inside `checkTreePage` (which already calls `leafFullKey` for overflow cells at integrity.go:383-389) — implementer's choice by readability. Refresh the stale `db.go:1253` cross-ref comment at integrity.go:647.
+3. **`RenameNamespace` read-back guard** after the Put (db.go:1202): re-resolve, require `rootPage` match, error on mismatch (caller rolls back per db.go:1166-1168).
+4. **Name caps (255 bytes each)** per decision 3, with a new sentinel error in errors.go.
+5. **Tests**: btree layer — `tempDBWithPageSize(t, 512)` (helpers_test.go:13), ~120-byte name: Create→Get→Rename→Get round-trip + `IntegrityCheck` green + reopen persistence; place near `namespace_rename_test.go` / the `TestAppendValue_*Overflow` cluster (db_test.go:398/775/800). App layer — cap acceptance/rejection at the boundary (255 ok, 256 rejected) for collection and index names including a synthesized-long `createName()` case.
+
+---
+
+## BUG-40 — FTS peer DDL reconcile (app layer)
+
+### Facts (verified)
+
+- Trigger chain: tx begin → `db.checkStale` (db.go:426/402) → `tx.IsSchemaStale()` → `db.reconcileIndexSet` (db.go:478-510) → per open collection `c.reconcileIndexes(tx)` (db.go:508). `collectionVanished` (db.go:524-537) is false for peer FTS DDL (collection still exists) — whole-handle invalidation never fires, so the FTS-ignorant `reconcileIndexes` is the only chance to fix the handles.
+- `reconcileIndexes` (collection.go:1566-1636): vector infos split off to `reconcileVectorIndexesLocked` (:1582); everything else lands in `rangeInfos` (:1584-1590) — **FTS infos included**, since the predicate is `Kind != IndexKindVector`. Each range info resolves `ix:C:I`; an FTS index has no `ix:` namespace (it has five `ftx:C:I:{map,meta,vocab,info,post}`), so resolution fails into the nsErr branch (:1597-1607) and the info is silently dropped. `c.ftsIndexes` is never touched.
+- `ftsIndexes` = `atomic.Pointer[[]*ftsIndex]` (collection.go:152); mutation sites are all local-DDL/init/rollback (collection.go:284-319, 939-944, 1182-1189, 965-971).
+- Eviction subtlety: each `ftsIndex` carries a per-tx `pending` write-back buffer (fulltext_pending.go:47-55); the flush/reset drivers enumerate the **snapshot** (`flushAllFtsPending` db.go:1262-1283 at commit, `resetAllFtsPending` db.go:1288-1301 at write-tx begin), so an evicted handle's buffered postings would be stranded. Precedent: `invalidateCollection` (db.go:539-560) resets pending before dropping; `db.orphanFtsPending` (db.go:263-269) exists for mid-tx closes. Reconcile runs at tx begin (after `resetAllFtsPending` on write-tx) so the buffer is normally empty — the evict-side `pending.reset()` is the safety belt. No background goroutines exist to join (FTS merging is synchronous at commit).
+- Local `DropIndex` FTS teardown (collection.go:1172-1190) deletes the five namespaces + catalog rows — peer-drop eviction must replicate **only** the snapshot republish, never the disk writes.
+
+### Design
+
+Per decisions 5-7. Shape of `reconcileFtsIndexesLocked` (caller holds `c.mu`, mirroring vector_index.go:486-530):
+
+- Build `byName` from `loadFtsIndexes()`; `want` = infos with `Kind==IndexKindFulltext`; `changed = want != len(cur)`.
+- Per info: existing + `nsMeta` root unchanged → reuse the live object; else construct + `bindNamespaces(tx.GetNamespace)`; on resolution error with an existing object, keep the existing (transient-failure rule); on resolution error with no existing object, skip (peer's create not yet visible / mid-rollback) and set changed.
+- Republish via `storeFtsIndexes` iff changed; for every prior object not carried forward, `fx.pending.reset()`.
+- Root-identity note: `nsMeta` is stable across normal writes (namespace root moves only on drop+recreate), making it the drop+recreate detector, same as vector `MetaRoot()`.
+
+### Tests (any-store-tests, storetest/multiprocess_fts_test.go)
+
+Extend the existing harness (`runMultiProcessHelper` multiprocess_test.go:90-111, deterministic-corpus helpers at :47-82):
+
+- **Peer drop (face 1, corruption)**: parent opens collection with FTS index warm (insert + search once); child helper drops the index and inserts ~500 docs into a second "churn" collection (recycling the freed `ftx:` pages); parent inserts more docs (must return nil), then: `IntegrityCheck` green, churn count exact, parent's `$text` returns `ErrNoFulltextIndex` (the index is gone — correct post-drop behavior).
+- **Peer create (face 2, correctness)**: parent opens collection and inserts d1 (no index); child helper `EnsureIndex(fulltext)` (backfills d1); parent inserts d2; parent's `$text` (and a fresh reopen's `$text`) must return both d1 and d2.
+
+---
+
+## BUG-41 — checkpoint read-mark clobber (WAL/SHM protocol; own PR)
+
+### Facts (verified against wal.go @ this worktree and wal.c @ version-3.52.0)
+
+- **Structural root cause**: the Go port has no single-word SHM publisher for `nBackfill`/`nBackfillAttempted`; every publish funnels through `shmWriteCkptInfo()` (wal.go:1244-1257) which also stores `aReadMark[0..4]` from process-local mirrors — while holding at most slot-0's lock. C publishes the counters individually (wal.c:2268, wal.c:2331) and documents the invariant at wal.c:367-370: *"The value of aReadMark[K] may only be changed by a thread that is holding an exclusive lock on WAL_READ_LOCK(K)."*
+- **Call-site lock audit** (sharper than the bug doc):
+
+| site | wal.go | locks held on slots 1-4 | verdict |
+|---|---|---|---|
+| `checkpointWithMode` pre-backfill | 3580 | none (only `lockRead0` excl. @3566) | **the clobber** (C analog wal.c:2268 writes nBackfillAttempted only) |
+| `checkpointWithMode` post-backfill | 3801 | none (only `lockRead0` excl.) | **the clobber** (C analog wal.c:2331 writes nBackfill only) |
+| `doResetWAL` → `reset()` | 3902→832 | slots 1-4 exclusive (`tryResetWALWithBusy` 3864-3884) | lock-safe (matches wal.c:2361 range lock before walRestartHdr) |
+| `recoverLocked` publish | 2049 | recovery exclusive range, but **not** per-reader-slot | unprotected — the F1 follow-up (C: wal.c:1573-1588 takes WAL_READ_LOCK(i) per slot, skips BUSY) |
+| `initHeaderStateLocked` → `reset()` | 1785→832 | doResetWAL path: safe; open path: recovery context | unprotected on the open path |
+| `writeHeader` → `reset()` | 1840→832 | reached from recoverLocked invalid-header branch (:1894) | unprotected (same recovery context) |
+
+- The empirically-verified data-loss interleaving (bug doc) goes through the two `checkpointWithMode` sites: checkpoint #1's post-backfill publish overwrites a live peer's slot mark with local `NOT_USED`; checkpoint #2 then treats the slot as unused, never lowers `mxSafeFrame`, and backfills past the reader's pinned frame.
+- Correct templates already in-repo: `shmWriteReadMark` (single slot, wal.go:1302-1310), the checkpoint reader loop (wal.go:3500-3542: per-slot `walBusyLock` exclusive, write, unlock; BUSY → lower mxSafeFrame), the read-tx slot claim (wal.go:2848-2979: exclusive claim, write, downgrade to shared, revalidate).
+- Process-local mirrors must stay: in-process (heapShm) mode has no mmap region and the atomics are the source of truth (wal.go:505-520); `shmWriteCkptInfo`/`shmWriteReadMark` no-op harmlessly when `region()` errors.
+- Fresh-SHM seeding: mark initialization into a zeroed region happens via the recovery/reset paths, which this design keeps (now correctly locked) — the checkpoint publishes never seeded anything a recovery hadn't already written.
+- Existing NOTES entries touching this area (all stay): `drift-88` (recovery mark values), `drift-99` (restart mark values), `drift-97`/`drift-98` (salts/nCkpt), and the follow-up sentence in `drift-2026-07-10-3` (NOTES.md:3325) that this fix resolves.
+
+### Design
+
+Per decisions 8-10:
+
+1. `shmWriteNBackfill()` / `shmWriteNBackfillAttempted()` single-word publishers; `checkpointWithMode` @3580 → attempted-only, @3801 → nBackfill-only.
+2. Split the bulk writer: `reset()` keeps clearing local mirrors + hash + publishing counters; SHM mark writes become an explicit helper whose two legal call shapes are (a) under the slots-1-4 range lock (doResetWAL path — bulk write OK), (b) per-slot try-lock skip-BUSY loop (recovery/open paths — wal.c:1573-1588 analog). `shmWriteCkptInfo` in its mark-writing form disappears from unlocked contexts; `recoverLocked`'s publish (:2049) and the open-path `reset()` callers route through (b).
+3. Audit `shmReadCkptInfo`'s remaining callers (test/single-goroutine contexts per its warning, wal.go:1259-1279) — read side unchanged.
+4. NOTES.md: annotate the follow-up in `drift-2026-07-10-3` as resolved with the new function name; no new DRIFT entry.
+
+### Tests (internal/btree, re-exec harness per multiprocess_reader_test.go)
+
+- **Protocol test**: parent opens multi-process DB, pins a read tx on a slot ≥1, records `shmReadMark(slot)`; child process commits and runs ≥2 PASSIVE checkpoints; parent asserts its SHM mark is unchanged (today it flips to `readMarkNotUsed`) and `shmNBackfill()` never exceeds the pinned mark.
+- **End-to-end snapshot test**: the bug doc's interleaving — reader pins a snapshot at frame N; writer commits past N and PASSIVE-checkpoints twice; reader re-reads pages whose only ≤N version was backfilled but rewritten later, and must see the pinned-generation bytes. Torn-read oracle: uniform-fill values + growing keyspace (stable overwrites hide mixed-generation reads).
+- Both build-gated like the existing multiprocess tests and skipped on tmpfs (`requireRealFilesystem` convention in storetest; the btree-layer tests use their own TMPDIR guard).
+
+---
+
+## Increments & commit shape
+
+1. **fix(btree): master-table cells follow the overflow chain** — resolveNamespace + masterLeaf + rename read-back guard + ps=512 tests. Commit cites `accessPayload` (sqlitec btree.c:5121).
+2. **fix: cap collection and index name length** — validateCollectionName + post-`createName` index-name check + errors.go + tests. (Separable from 1; either order works, but 1 first so the cap is a hardening layer, not the fix.)
+3. **fix: reconcile fulltext indexes on peer schema changes** — reconcileFtsIndexesLocked + routing fix; multiprocess tests land in any-store-tests in the same effort.
+4. **fix(btree): publish checkpoint counters without rewriting read-marks** — single-word publishers + checkpointWithMode changes + protocol test. Own PR with 5.
+5. **fix(btree): recovery resets read-marks under per-slot locks** — recovery/open-path mark writes + NOTES annotation + end-to-end test.
+
+## Verification
+
+- Per increment: `go test ./internal/btree/` + full `go test ./...` in the worktree (TMPDIR on a real filesystem for multiprocess tests); `-race` on changed packages.
+- Test repo: storetest (new FTS peer-DDL tests + existing `TestMultiProcessFts_*`, `TestIVFPQMultiprocessConsistency`, `TestMultiProcessReaderScanCorruption`) against this worktree via a scratch GOWORK `use` block.
+- BUG-41: `-tags debugtrace` + `BTREE_TRACE` two-process trace before/after — the SHM mark must no longer flip across a checkpoint and `nBackfill` must never pass a live reader's mark.
+- Not hot paths (tx-begin reconcile, namespace resolution, checkpoint publish) → no benchstat gate; watch reconcile cost anecdotally since it runs on every stale tx begin.

--- a/docs/plans/2026-07-17-peer-visibility-criticals.md
+++ b/docs/plans/2026-07-17-peer-visibility-criticals.md
@@ -136,6 +136,46 @@ Per decisions 8-10:
 4. **fix(btree): publish checkpoint counters without rewriting read-marks** — single-word publishers + checkpointWithMode changes + protocol test. Own PR with 5.
 5. **fix(btree): recovery resets read-marks under per-slot locks** — recovery/open-path mark writes + NOTES annotation + end-to-end test.
 
+## Post-review revisions (2026-07-17, high-effort multi-agent review of the branch)
+
+Four correctness findings, all fixed on this branch:
+
+1. **Checkpoint regression (CONFIRMED):** the counters-only publish had dropped the
+   `nBackfillAttempted.Store(mxSafeFrame)` that the bulk write previously carried —
+   the publish wrote a stale value, breaking the crash-safety hint (C:
+   `pInfo->nBackfillAttempted = mxSafeFrame`, wal.c:2268). Store restored; the
+   two-process test now asserts nBackfillAttempted tracks the checkpoints.
+2. **Rename guard neutralized (CONFIRMED):** the read-back guard double-`%w`-wrapped
+   the inner error, so a not-found-class failure satisfied
+   `errors.Is(err, ErrNamespaceNotFound)` and the app-layer rename's tolerance for
+   already-missing index namespaces swallowed the guard. Inner error flattened to `%v`.
+3. **Reconcile vs. uncommitted local DDL (CONFIRMED):** a schema-stale read tx's
+   reconcile, rebuilding from its older snapshot, could evict a concurrent write
+   tx's just-published (uncommitted) index — and the evict-side `pending.reset()`
+   raced the writer's buffering. Fixed structurally: `collection.indexSetDDLTxs`
+   (set in `registerIndexSetRestore`, released exactly once at commit-publish or
+   rollback-undo) makes `reconcileIndexes` skip while local index DDL is in flight
+   (same argument as the renameInFlight guard — the cookie bump predates the
+   writer's begin, which already reconciled it), and eviction no longer touches
+   `pending` at all (publication-by-omission; the commit flush enumerates the
+   snapshot, so a dropped index's buffered postings are dropped with the object).
+   The sibling window — reconcile racing a *committed* local DDL from an older
+   snapshot — is pre-existing, shared with the range/vector paths, and
+   self-healing via the cookie; filed with the BUG-35/36/37 publish-at-commit family.
+4. **Known-stale keep on rebind failure (PLAUSIBLE):** when a peer drop+recreate was
+   already detected (definition or meta root changed) but fresh binding failed, the
+   old handle — known to point at freed roots — was republished with no retry (the
+   cookie is consumed). Now evicted: $text fails cleanly until a rebind succeeds.
+   (The vector path has the same keep-on-error shape; follow-up for that family.)
+
+Cleanups applied: the unlocked bulk `shmWriteCkptInfo` is deleted outright (tests
+compose the safe single-word publishers); the integrity master hook reports the
+value-reconstruction error class beside its generic corrupt-value report.
+Deferred (filed here as follow-ups): `leafFullKey`/`leafFullValue`/`AppendValue`
+share three hand-copies of the payload-split geometry (and the `AppendValue` copy
+lacks the `maxPayloadAlloc` bounds checks); `checkTreePage` walks an overflow
+cell's chain up to three times; the three reconcile functions share a skeleton.
+
 ## Verification
 
 - Per increment: `go test ./internal/btree/` + full `go test ./...` in the worktree (TMPDIR on a real filesystem for multiprocess tests); `-race` on changed packages.

--- a/errors.go
+++ b/errors.go
@@ -71,6 +71,10 @@ var (
 	// under the stale name returns.
 	ErrCollectionClosed = fmt.Errorf("any-store: collection handle is closed (dropped, renamed, or closed): %w", ErrCollectionNotFound)
 
+	// ErrInvalidIndexName is returned when an index name (given or derived from
+	// the field list) exceeds the maximum length (see validateIndexName).
+	ErrInvalidIndexName = errors.New("any-store: invalid index name")
+
 	// ErrIndexExists is returned when attempting to create an index that already exists.
 	ErrIndexExists = errors.New("any-store: index already exists")
 

--- a/fulltext_index.go
+++ b/fulltext_index.go
@@ -179,6 +179,96 @@ func (fx *ftsIndex) bindNamespaces(resolve func(name string) (*btree.Namespace, 
 
 func (fx *ftsIndex) Info() IndexInfo { return fx.info }
 
+// metaRootUnchanged reports whether the ftx: meta namespace still resolves to
+// the btree root this handle was bound against — false after a peer
+// drop+recreate moved the roots, which means the handles are stale and the
+// index must be rebound. A transient resolution failure returns true so a
+// working index is not dropped over a momentary view.
+func (fx *ftsIndex) metaRootUnchanged(tx *btree.ReadTx) bool {
+	if fx.nsMeta == nil {
+		return true
+	}
+	ns, err := tx.GetNamespace(ftsNsName(fx.c.name, fx.info.Name, ftsPartMeta))
+	if err != nil {
+		return true
+	}
+	return ns.RootPage() == fx.nsMeta.RootPage()
+}
+
+// reconcileFtsIndexesLocked rebuilds the full-text-index set from on-disk infos
+// after a peer committed full-text DDL. Caller holds c.mu. Mirrors
+// reconcileVectorIndexesLocked: adopt peer-created indexes (trusting the peer's
+// backfill, as the range/vector adoptions do), reuse live objects while their
+// definition and meta root are unchanged, and evict peer-dropped ones so a
+// stale handle can never flush postings into freed-and-reused ftx: pages.
+// Never touches disk — reconcile may run inside a read tx, and the peer
+// already performed the DDL; eviction is purely local handle release.
+func (c *collection) reconcileFtsIndexesLocked(tx *btree.ReadTx, infos []IndexInfo) {
+	cur := c.loadFtsIndexes()
+	byName := make(map[string]*ftsIndex, len(cur))
+	for _, fx := range cur {
+		byName[fx.info.Name] = fx
+	}
+
+	var want int
+	for _, info := range infos {
+		if isFulltext(info) {
+			want++
+		}
+	}
+	rebuilt := make([]*ftsIndex, 0, want)
+	changed := want != len(cur)
+	for _, info := range infos {
+		if !isFulltext(info) {
+			continue
+		}
+		if existing, ok := byName[info.Name]; ok &&
+			indexInfoEqual(existing.info, info) && existing.metaRootUnchanged(tx) {
+			rebuilt = append(rebuilt, existing)
+			continue
+		}
+		// New index, or a drop+recreate moved the roots under the same name so
+		// the existing object's handles are stale — bind fresh handles.
+		fx, err := newFtsIndex(c, info)
+		if err == nil {
+			err = fx.bindNamespaces(tx.GetNamespace)
+		}
+		if err != nil {
+			// Not resolvable in this snapshot — keep any existing object rather
+			// than dropping a working index over a transient view; retry on the
+			// next schema-stale tx.
+			if existing, ok := byName[info.Name]; ok {
+				rebuilt = append(rebuilt, existing)
+			} else {
+				changed = true
+			}
+			continue
+		}
+		rebuilt = append(rebuilt, fx)
+		changed = true
+	}
+	if !changed {
+		// Same set, same definitions, same roots — every live object was
+		// carried forward, so there is nothing to evict or publish.
+		return
+	}
+
+	// Reset the pending buffer of every evicted handle: the flush/reset
+	// drivers enumerate the published snapshot, so buffered postings on a
+	// handle that is no longer in it would be stranded (or worse, flushed by
+	// a caller still holding the old slice). Matches invalidateCollection.
+	kept := make(map[*ftsIndex]struct{}, len(rebuilt))
+	for _, fx := range rebuilt {
+		kept[fx] = struct{}{}
+	}
+	for _, fx := range cur {
+		if _, ok := kept[fx]; !ok {
+			fx.pending.reset()
+		}
+	}
+	c.storeFtsIndexes(rebuilt)
+}
+
 // ---- analysis -------------------------------------------------------------
 
 // analyzeInto runs the analyzer over all indexed fields of the document,

--- a/fulltext_index.go
+++ b/fulltext_index.go
@@ -234,14 +234,17 @@ func (c *collection) reconcileFtsIndexesLocked(tx *btree.ReadTx, infos []IndexIn
 			err = fx.bindNamespaces(tx.GetNamespace)
 		}
 		if err != nil {
-			// Not resolvable in this snapshot — keep any existing object rather
-			// than dropping a working index over a transient view; retry on the
-			// next schema-stale tx.
-			if existing, ok := byName[info.Name]; ok {
-				rebuilt = append(rebuilt, existing)
-			} else {
-				changed = true
-			}
+			// Not resolvable in this snapshot. With no existing object this is
+			// a peer create racing our view — skip until a later reconcile.
+			// With an existing object we only got here because its definition
+			// or meta root no longer matches the on-disk index (peer
+			// drop+recreate): the handle is KNOWN-stale and must not be
+			// republished — a later flush through it would write into freed,
+			// reused pages. Evict it; $text fails cleanly until a rebind
+			// succeeds. (Keeping a working index over a merely-transient
+			// resolution failure is handled in metaRootUnchanged, which
+			// returns true when it cannot resolve.)
+			changed = true
 			continue
 		}
 		rebuilt = append(rebuilt, fx)
@@ -253,19 +256,15 @@ func (c *collection) reconcileFtsIndexesLocked(tx *btree.ReadTx, infos []IndexIn
 		return
 	}
 
-	// Reset the pending buffer of every evicted handle: the flush/reset
-	// drivers enumerate the published snapshot, so buffered postings on a
-	// handle that is no longer in it would be stranded (or worse, flushed by
-	// a caller still holding the old slice). Matches invalidateCollection.
-	kept := make(map[*ftsIndex]struct{}, len(rebuilt))
-	for _, fx := range rebuilt {
-		kept[fx] = struct{}{}
-	}
-	for _, fx := range cur {
-		if _, ok := kept[fx]; !ok {
-			fx.pending.reset()
-		}
-	}
+	// Eviction is publication-by-omission only — an evicted handle's pending
+	// buffer is deliberately NOT touched. Resetting it here would race a
+	// concurrent writer goroutine still buffering into it (inserts read the
+	// snapshot lock-free), and there is nothing to save anyway: the commit
+	// flush enumerates the published snapshot, so an evicted (peer-dropped)
+	// index's buffered postings are dropped with the object — exactly right
+	// for an index that no longer exists. (A writer's own uncommitted index
+	// can never be evicted here: the indexSetDDLTxs guard in reconcileIndexes
+	// skips the whole pass while local DDL is in flight.)
 	c.storeFtsIndexes(rebuilt)
 }
 

--- a/fulltext_reconcile_test.go
+++ b/fulltext_reconcile_test.go
@@ -1,0 +1,89 @@
+package anystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/internal/btree"
+)
+
+// A concurrent read tx's staleness pass must not rebuild a collection's index
+// sets while a local write tx has uncommitted index DDL published in them —
+// its older snapshot would evict the writer's uncommitted indexes. The
+// indexSetDDLTxs counter carries that in-flight state.
+
+func TestIndexSetDDLTxs_BalancedAcrossCommitAndRollback(t *testing.T) {
+	fx := newFixture(t)
+	collIface, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+	coll := collIface.(*collection)
+
+	ddlTxs := func() int {
+		coll.mu.Lock()
+		defer coll.mu.Unlock()
+		return coll.indexSetDDLTxs
+	}
+	require.Zero(t, ddlTxs())
+
+	// Committed DDL: counter is 1 while the tx is open, 0 after commit.
+	tx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(tx.Context(), IndexInfo{Fields: []string{"a"}, Kind: IndexKindFulltext}))
+	assert.Equal(t, 1, ddlTxs(), "uncommitted DDL must be marked in flight")
+	require.NoError(t, tx.Commit())
+	assert.Zero(t, ddlTxs(), "commit must release the in-flight marker")
+
+	// Rolled-back DDL: same lifecycle through the undo path.
+	tx2, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(tx2.Context(), IndexInfo{Fields: []string{"b"}}))
+	assert.Equal(t, 1, ddlTxs())
+	require.NoError(t, tx2.Rollback())
+	assert.Zero(t, ddlTxs(), "rollback must release the in-flight marker")
+}
+
+func TestReconcileSkipsWhileLocalIndexDDLInFlight(t *testing.T) {
+	fx := newFixture(t)
+	collIface, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+	coll := collIface.(*collection)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{"text"}, Kind: IndexKindFulltext}))
+
+	// Plant a ghost fts handle that no on-disk catalog entry backs — the
+	// stand-in for a writer's just-published, not-yet-committed index as seen
+	// by a reconcile running on an older snapshot.
+	ghost := &ftsIndex{c: coll, info: IndexInfo{Name: "ghost", Kind: IndexKindFulltext, Fields: []string{"g"}}}
+	coll.mu.Lock()
+	coll.storeFtsIndexes(append(coll.loadFtsIndexes(), ghost))
+	coll.indexSetDDLTxs++
+	coll.mu.Unlock()
+
+	inSnapshot := func() bool {
+		for _, fxi := range coll.loadFtsIndexes() {
+			if fxi == ghost {
+				return true
+			}
+		}
+		return false
+	}
+
+	// With DDL in flight, reconcile must leave the sets untouched.
+	require.NoError(t, fx.DB.(*db).doReadTx(ctx, func(tx *btree.ReadTx) error {
+		coll.reconcileIndexes(tx)
+		return nil
+	}))
+	assert.True(t, inSnapshot(), "reconcile evicted an index while local DDL was in flight")
+
+	// Once the writer resolved, the same reconcile evicts the ghost by
+	// omission (it has no catalog entry in the snapshot).
+	coll.mu.Lock()
+	coll.indexSetDDLTxs--
+	coll.mu.Unlock()
+	require.NoError(t, fx.DB.(*db).doReadTx(ctx, func(tx *btree.ReadTx) error {
+		coll.reconcileIndexes(tx)
+		return nil
+	}))
+	assert.False(t, inSnapshot(), "reconcile must evict a catalog-less handle once no DDL is in flight")
+}

--- a/internal/btree/btree.go
+++ b/internal/btree/btree.go
@@ -935,6 +935,79 @@ func leafFullKey(data []byte, offset int, usableSize int, p *pager, walMaxFrame 
 	return fullKey, nil
 }
 
+// leafFullValue reads the full value from a leaf cell, reading overflow pages
+// if the value spills. Returns a slice into the page buffer when the value is
+// fully local, or an allocated copy when it extends into the overflow chain.
+// Matches SQLite's accessPayload() (btree.c:5121), which reassembles local +
+// overflow transparently for every payload read.
+func leafFullValue(data []byte, offset int, usableSize int, p *pager, walMaxFrame uint32, cache *pcache) ([]byte, error) {
+	dataLen := len(data)
+	if offset >= dataLen {
+		return nil, ErrCorrupt
+	}
+	keyLen, n, err := getVarintSafe(data[offset:])
+	if err != nil {
+		return nil, ErrCorrupt
+	}
+	pos := offset + n
+	if pos >= dataLen {
+		return nil, ErrCorrupt
+	}
+	valLen, n, err := getVarintSafe(data[pos:])
+	if err != nil {
+		return nil, ErrCorrupt
+	}
+	pos += n
+
+	if int(keyLen) < 0 || int(keyLen) > maxPayloadAlloc {
+		return nil, ErrCorrupt
+	}
+	if int(valLen) < 0 || int(valLen) > maxPayloadAlloc {
+		return nil, ErrCorrupt
+	}
+
+	totalPayload := int(keyLen) + int(valLen)
+	if totalPayload < 0 || totalPayload > maxPayloadAlloc {
+		return nil, ErrCorrupt
+	}
+	maxLocal := maxLocalPayload(usableSize)
+
+	if totalPayload <= maxLocal {
+		// No overflow: value is fully on-page, right after the key
+		if pos+totalPayload > dataLen {
+			return nil, ErrCorrupt
+		}
+		return data[pos+int(keyLen) : pos+totalPayload], nil
+	}
+
+	// Overflow cell
+	nLocal := localPayloadSize(totalPayload, usableSize)
+	localKeyBytes := min(nLocal, int(keyLen))
+	localValBytes := nLocal - localKeyBytes
+	keyOverflow := int(keyLen) - localKeyBytes
+	valOverflow := int(valLen) - localValBytes
+
+	if pos+nLocal+4 > dataLen {
+		return nil, ErrCorrupt
+	}
+	if valOverflow == 0 {
+		// Value fits fully in the local portion (only the key overflows)
+		return data[pos+localKeyBytes : pos+localKeyBytes+int(valLen)], nil
+	}
+
+	fullVal := make([]byte, int(valLen))
+	copy(fullVal, data[pos+localKeyBytes:pos+nLocal])
+	overflowPg := binary.BigEndian.Uint32(data[pos+nLocal : pos+nLocal+4])
+
+	// Read the value remainder from the overflow chain, skipping the key
+	// remainder that precedes it.
+	if err := p.readOverflowAt(overflowPg, keyOverflow, valOverflow,
+		fullVal[localValBytes:], walMaxFrame, cache); err != nil {
+		return nil, err
+	}
+	return fullVal, nil
+}
+
 // interiorFullKey reads the full key from an interior cell, handling overflow.
 // cache controls overflow page reads: non-nil uses the reader's private cache,
 // nil uses readOverflowChainAt (for writers who need to see their own dirty pages).

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -1207,9 +1207,14 @@ func (db *DB) RenameNamespace(tx *WriteTx, oldName, newName string) error {
 	// commit. A Put that succeeds but cannot be read back (e.g. a master-cell
 	// read defect) would otherwise durably brick the namespace — the caller
 	// rolls back on error per the contract above.
+	// The inner error is flattened (%v, not %w) deliberately: a read-back
+	// failure of the ErrNamespaceNotFound class must NOT satisfy
+	// errors.Is(err, ErrNamespaceNotFound) — callers tolerate not-found on
+	// rename (already-missing index namespaces) and would swallow the guard,
+	// committing the very brick it exists to prevent.
 	readBack, err := db.getNamespaceLocked(newName)
 	if err != nil {
-		return fmt.Errorf("%w: rename read-back failed for %q: %w", ErrCorrupt, newName, err)
+		return fmt.Errorf("%w: rename read-back failed for %q: %v", ErrCorrupt, newName, err)
 	}
 	if readBack.rootPage != ns.rootPage {
 		return fmt.Errorf("%w: rename read-back for %q resolved root %d, want %d",

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -1199,7 +1199,23 @@ func (db *DB) RenameNamespace(tx *WriteTx, oldName, newName string) error {
 	}
 	var rootPgBuf [4]byte
 	binary.BigEndian.PutUint32(rootPgBuf[:], ns.rootPage)
-	return bt.Put([]byte(newName), rootPgBuf[:])
+	if err = bt.Put([]byte(newName), rootPgBuf[:]); err != nil {
+		return err
+	}
+
+	// Read-back guard: the rename must be resolvable before it is allowed to
+	// commit. A Put that succeeds but cannot be read back (e.g. a master-cell
+	// read defect) would otherwise durably brick the namespace — the caller
+	// rolls back on error per the contract above.
+	readBack, err := db.getNamespaceLocked(newName)
+	if err != nil {
+		return fmt.Errorf("%w: rename read-back failed for %q: %w", ErrCorrupt, newName, err)
+	}
+	if readBack.rootPage != ns.rootPage {
+		return fmt.Errorf("%w: rename read-back for %q resolved root %d, want %d",
+			ErrCorrupt, newName, readBack.rootPage, ns.rootPage)
+	}
+	return nil
 }
 
 // maxTreeDepth bounds freeTreePages recursion. It is a conservative cap far
@@ -1392,11 +1408,22 @@ func (db *DB) resolveNamespace(name string, bt *btree) (*Namespace, error) {
 				bt.pager.releasePage(pg)
 				return nil, cerr
 			}
-			if len(cell.value) < 4 {
+			// cell.value holds only the local portion; a long name can push
+			// the 4-byte root value (wholly or partially) into the overflow
+			// chain, so reassemble it the way accessPayload does.
+			value := cell.value
+			if cell.overflowPg != 0 {
+				value, cerr = leafFullValue(pg.data, int(off), usableSize, bt.pager, bt.walMaxFrame, bt.cache)
+				if cerr != nil {
+					bt.pager.releasePage(pg)
+					return nil, cerr
+				}
+			}
+			if len(value) < 4 {
 				bt.pager.releasePage(pg)
 				return nil, ErrCorrupt
 			}
-			rootPage := binary.BigEndian.Uint32(cell.value)
+			rootPage := binary.BigEndian.Uint32(value)
 			bt.pager.releasePage(pg)
 			return &Namespace{
 				name:     name,

--- a/internal/btree/integrity.go
+++ b/internal/btree/integrity.go
@@ -439,7 +439,11 @@ func (ic *integrityChecker) checkTreePage(pgno uint32, lower, upper []byte, onLe
 				if cell.overflowPg != 0 {
 					fv, fverr := leafFullValue(pg.data, cellOff, ic.usableSize, ic.pager, ic.walMaxFrame, ic.cache)
 					if fverr != nil {
-						hookVal = nil // hook reports the corrupt value
+						// Surface the error class (I/O vs geometry) beside the
+						// hook's generic corrupt-value report, mirroring the
+						// key path's report above.
+						ic.report("%s cell %d: corrupt leaf value: %v", context, i, fverr)
+						hookVal = nil
 					} else {
 						hookVal = fv
 					}

--- a/internal/btree/integrity.go
+++ b/internal/btree/integrity.go
@@ -289,7 +289,7 @@ func (ic *integrityChecker) keyInBounds(key, lower, upper []byte, context string
 // strict cell ordering check this enforces
 //
 //	max(subtree[child i]) < D_i <= min(subtree[child i+1]).
-func (ic *integrityChecker) checkTreePage(pgno uint32, lower, upper []byte, onLeafCell func(cell cellData)) int {
+func (ic *integrityChecker) checkTreePage(pgno uint32, lower, upper []byte, onLeafCell func(key, value []byte)) int {
 	if ic.tooManyErrors() {
 		return 0
 	}
@@ -425,10 +425,26 @@ func (ic *integrityChecker) checkTreePage(pgno uint32, lower, upper []byte, onLe
 			// pre-builds aRoot[] from the in-memory schema (pragma.c:1761-1774);
 			// any-store has no such list, so the master root discovers each
 			// namespace subtree from its own leaf cells via this callback. The
-			// hook only READS cell.value; it does not touch the coverage heap or
-			// fragmentation accounting, so coverage is unchanged.
+			// hook receives the reassembled key and value — cell.key/cell.value
+			// hold only the local portions, and a long master key pushes the
+			// 4-byte root value into the overflow chain. The hook only reads
+			// them; it does not touch the coverage heap or fragmentation
+			// accounting, so coverage is unchanged.
 			if onLeafCell != nil {
-				onLeafCell(cell)
+				hookKey := fullKey
+				if hookKey == nil {
+					hookKey = cell.key
+				}
+				hookVal := cell.value
+				if cell.overflowPg != 0 {
+					fv, fverr := leafFullValue(pg.data, cellOff, ic.usableSize, ic.pager, ic.walMaxFrame, ic.cache)
+					if fverr != nil {
+						hookVal = nil // hook reports the corrupt value
+					} else {
+						hookVal = fv
+					}
+				}
+				onLeafCell(hookKey, hookVal)
 			}
 		} else {
 			// Interior cell (with overflow support)
@@ -643,28 +659,29 @@ func (db *DB) IntegrityCheckN(maxErrors int) error {
 	// ANY master depth. The hook only reads cell.value (the namespace root page),
 	// never the coverage heap.
 	ic.treeName = "master"
-	masterLeaf := func(cell cellData) {
-		// A master leaf value < 4 bytes is corrupt (matches resolveNamespace,
-		// db.go:1253). The interior/leaf parse + bounds checks in checkTreePage
-		// already validated cell structure; here we only validate the value.
-		if len(cell.value) < 4 {
-			ic.report("tree master cell key %q: corrupt namespace root value", string(cell.key))
+	masterLeaf := func(key, value []byte) {
+		// A master leaf value < 4 bytes is corrupt (matches resolveNamespace).
+		// The interior/leaf parse + bounds checks in checkTreePage already
+		// validated cell structure; the value arrives reassembled (local +
+		// overflow), so here we only validate its content.
+		if len(value) < 4 {
+			ic.report("tree master cell key %q: corrupt namespace root value", string(key))
 			return
 		}
-		rootPage := binary.BigEndian.Uint32(cell.value[:4])
+		rootPage := binary.BigEndian.Uint32(value[:4])
 		switch {
 		case rootPage >= 2 && rootPage <= nPages:
 			// Each namespace tree is an independent B-tree; its root has no
 			// divider bounds (unbounded both ways) and carries user data in
 			// its own leaf values, so it needs no leaf-cell hook (nil).
 			savedName := ic.treeName
-			ic.treeName = string(cell.key)
+			ic.treeName = string(key)
 			ic.checkTreePage(rootPage, nil, nil, nil)
 			ic.treeName = savedName
 		case rootPage != 0:
 			// rootPage == 0 is a valid empty namespace (intentionally skipped;
 			// exercised by TestDeleteNamespace_RootPageZero).
-			ic.report("tree master cell key %q: namespace root page %d out of range", string(cell.key), rootPage)
+			ic.report("tree master cell key %q: namespace root page %d out of range", string(key), rootPage)
 		}
 	}
 	ic.checkTreePage(1, nil, nil, masterLeaf)

--- a/internal/btree/namespace_overflow_test.go
+++ b/internal/btree/namespace_overflow_test.go
@@ -1,0 +1,108 @@
+package btree
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A master-table cell overflows once len(name)+4 > maxLocalPayload(pageSize)
+// (102 at ps=512), pushing the 4-byte root value into the overflow chain.
+// These tests pin that such namespaces stay resolvable: the readers follow the
+// chain the way SQLite's accessPayload does for sqlite_master rows.
+
+func longNsName(n int) string {
+	return "long-" + strings.Repeat("x", n-5)
+}
+
+func TestCreateNamespaceLongNameOverflowCell(t *testing.T) {
+	resetPageBufferPool()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	db, err := testOpen(t, path, Options{PageSize: 512})
+	require.NoError(t, err)
+
+	// Lengths straddle the ps=512 threshold (102) and include a value split
+	// across the local/overflow boundary as well as wholly-spilled values.
+	names := []string{longNsName(99), longNsName(103), longNsName(151), longNsName(511)}
+	for _, name := range names {
+		tx, err := db.BeginWrite()
+		require.NoError(t, err)
+		ns, err := tx.CreateNamespace(name)
+		require.NoError(t, err, "len=%d", len(name))
+		require.NoError(t, tx.Put(ns, []byte("k"), []byte(name)))
+		require.NoError(t, tx.Commit())
+	}
+
+	for _, name := range names {
+		ns, err := db.GetNamespace(name)
+		require.NoError(t, err, "len=%d", len(name))
+		rtx, err := db.BeginRead()
+		require.NoError(t, err)
+		v, err := rtx.Get(ns, []byte("k"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(name), v)
+		require.NoError(t, rtx.Rollback())
+	}
+	require.NoError(t, db.IntegrityCheck())
+
+	// Reopen: the overflowing master cells must survive a cold start.
+	require.NoError(t, db.Close())
+	db2, err := testOpen(t, path, Options{PageSize: 512})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db2.Close()) }()
+	for _, name := range names {
+		_, err := db2.GetNamespace(name)
+		require.NoError(t, err, "after reopen, len=%d", len(name))
+	}
+	require.NoError(t, db2.IntegrityCheck())
+}
+
+func TestRenameNamespaceLongNameOverflowCell(t *testing.T) {
+	resetPageBufferPool()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	db, err := testOpen(t, path, Options{PageSize: 512})
+	require.NoError(t, err)
+
+	tx, err := db.BeginWrite()
+	require.NoError(t, err)
+	ns, err := tx.CreateNamespace("short")
+	require.NoError(t, err)
+	require.NoError(t, tx.Put(ns, []byte("k"), []byte("v")))
+	require.NoError(t, tx.Commit())
+	oldRoot := ns.RootPage()
+
+	longName := longNsName(151)
+	tx2, err := db.BeginWrite()
+	require.NoError(t, err)
+	require.NoError(t, tx2.RenameNamespace("short", longName))
+	require.NoError(t, tx2.Commit())
+
+	renamed, err := db.GetNamespace(longName)
+	require.NoError(t, err)
+	assert.Equal(t, oldRoot, renamed.RootPage(), "root page must be reused")
+	_, err = db.GetNamespace("short")
+	assert.ErrorIs(t, err, ErrNamespaceNotFound)
+
+	rtx, err := db.BeginRead()
+	require.NoError(t, err)
+	v, err := rtx.Get(renamed, []byte("k"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), v)
+	require.NoError(t, rtx.Rollback())
+
+	require.NoError(t, db.IntegrityCheck())
+
+	require.NoError(t, db.Close())
+	db2, err := testOpen(t, path, Options{PageSize: 512})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db2.Close()) }()
+	ns2, err := db2.GetNamespace(longName)
+	require.NoError(t, err)
+	assert.Equal(t, oldRoot, ns2.RootPage())
+	require.NoError(t, db2.IntegrityCheck())
+}

--- a/name_length_test.go
+++ b/name_length_test.go
@@ -1,0 +1,55 @@
+package anystore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Collection and index names are capped so the derived namespace names
+// (widest: "ftx:"+coll+":"+index+":vocab") can never overflow a master-table
+// cell at the default page size.
+
+func TestNameLengthCap_Collection(t *testing.T) {
+	fx := newFixture(t)
+
+	okName := strings.Repeat("c", 255)
+	coll, err := fx.CreateCollection(ctx, okName)
+	require.NoError(t, err)
+	require.NoError(t, coll.Close())
+
+	tooLong := strings.Repeat("c", 256)
+	_, err = fx.CreateCollection(ctx, tooLong)
+	assert.ErrorIs(t, err, ErrInvalidCollectionName)
+
+	short, err := fx.CreateCollection(ctx, "short")
+	require.NoError(t, err)
+	assert.ErrorIs(t, short.Rename(ctx, tooLong), ErrInvalidCollectionName)
+	assert.Equal(t, "short", short.Name())
+}
+
+func TestNameLengthCap_Index(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+
+	okName := strings.Repeat("i", 255)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: okName, Fields: []string{"a"}}))
+
+	tooLong := strings.Repeat("i", 256)
+	err = coll.EnsureIndex(ctx, IndexInfo{Name: tooLong, Fields: []string{"b"}})
+	assert.ErrorIs(t, err, ErrInvalidIndexName)
+
+	// A name synthesized from the field list is capped the same way.
+	longField := strings.Repeat("f", 300)
+	err = coll.EnsureIndex(ctx, IndexInfo{Fields: []string{longField}})
+	assert.ErrorIs(t, err, ErrInvalidIndexName)
+
+	// Full-text index creation goes through the same validation.
+	err = coll.EnsureIndex(ctx, IndexInfo{Name: tooLong, Fields: []string{"body"}, Kind: IndexKindFulltext})
+	assert.ErrorIs(t, err, ErrInvalidIndexName)
+
+	require.NoError(t, fx.IntegrityCheck(ctx))
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -397,6 +397,9 @@ func (c *collection) createVectorIndex(tx *btree.WriteTx, info IndexInfo) (*vect
 	if info.Name == "" {
 		info.Name = info.Vector.Field
 	}
+	if err := validateIndexName(info.Name); err != nil {
+		return nil, err
+	}
 	if err := c.db.registerIndex(tx, c.name, info); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two of the three multi-process criticals from the 2026-07-12 adversarial audit, groomed and implemented as one unit (the third — the checkpoint read-mark clobber — is its own PR, as decided in the groom). Design doc: `docs/plans/2026-07-17-peer-visibility-criticals.md` (in this PR).

## Master-table cell overflow (silent durable brick)
A namespace name long enough to spill the 4-byte root value into the overflow chain read back as `ErrCorrupt` from both `resolveNamespace` and the IntegrityCheck master-leaf hook; `RenameNamespace` onto such a name returned nil and durably bricked the namespace.
- New `leafFullValue` (sibling of `leafFullKey`) reassembles local + overflow via `pager.readOverflowAt` — the `accessPayload` analog (sqlitec btree.c:5121, 3.52.0); one funnel point fixes all four namespace-read entry points.
- `RenameNamespace` read-back guard: an unresolvable rename fails the tx instead of committing (flattens the inner error so the guard can't be swallowed as not-found by the app-layer rename's tolerance path).
- App layer: collection and index names capped at 255 bytes (index names validated after `createName()` defaulting; widest derived namespace is `ftx:<coll>:<index>:vocab`, budget `len(C)+len(I) <= 987` at ps=4096).
- Regression: ps=512 long-name Create/Get/Rename round-trip + IntegrityCheck + reopen (red pre-fix with `ErrCorrupt`), name-cap boundary tests.

## Fulltext peer-DDL reconcile (cross-collection corruption + lost postings)
`reconcileIndexes` had no fulltext branch: FTS infos leaked into the range loop, failed `ix:` resolution, and were silently dropped — a peer's `DropIndex` left this process a live handle over freed `ftx:` pages (subsequent inserts flushed postings into whatever btree reused them), and a peer's `EnsureIndex` was never adopted (docs committed with no postings).
- New `reconcileFtsIndexesLocked` mirrors the vector reconcile: adopt by binding the five `ftx:` namespaces, reuse iff definition + `nsMeta` root unchanged, evict by omission. Never touches disk (reconcile can run in a read tx).
- Review hardening: reconcile skips while a local write tx has uncommitted index DDL (`indexSetDDLTxs`, the renameInFlight argument — the cookie bump predates the writer's begin, which already reconciled it); eviction never touches pending buffers (racy with the writer's lock-free buffering, and a dropped index's postings should be dropped); a known-stale handle whose rebind fails is evicted, not republished.
- Regression: `TestMultiProcessFts_PeerDropVisibility` / `TestMultiProcessFts_PeerCreateVisibility` in any-store-tests (red pre-fix, both faces), plus in-repo guard tests.

## Verification
Full repo suite green; any-store-tests storetest green except the known-open BUG-24/25/27/28 verb-divergence family (fixed on the unmerged `verb-divergences-groom` branch, unrelated). High-effort multi-agent review ran against the branch; all four correctness findings fixed here (see the "Post-review revisions" section of the design doc). Deferred cleanups (payload-geometry dedup across `leafFullKey`/`leafFullValue`/`AppendValue`, integrity chain re-walks, reconcile-skeleton sharing) are filed in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)