### PR TITLE
Reverse-index prefix bounds, VectorDot×IVF rejection, recursive fts residual

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -126,7 +126,7 @@ func (q *aggQuery) validateInPipelineStages(rest aggregate.Pipeline) error {
 		if !ok {
 			continue
 		}
-		if containsText(m.Filter) {
+		if query.ContainsText(m.Filter) {
 			return errAggTextNotInPrefix
 		}
 		if query.ContainsKnn(m.Filter) {

--- a/docs/vector-search.md
+++ b/docs/vector-search.md
@@ -52,10 +52,10 @@ Only `Field` and `Dim` are required. Other `VectorParams`:
 
 | Field | Default | Purpose |
 |---|---|---|
-| `Metric` | `VectorCosine` | distance measure: `VectorCosine`, `VectorL2`, `VectorDot` |
+| `Metric` | `VectorCosine` | distance measure: `VectorCosine`, `VectorL2`, `VectorDot`. `VectorDot` is not supported by the IVF modes (index creation and open fail with `ErrVectorMetricUnsupported`) |
 | `M`, `EfConstruction`, `EfSearch` | sensible defaults (0) | HNSW graph/search tuning |
 | `Quantization` | `VectorQuantNone` | `VectorQuantInt8` ≈ 4× smaller, RAM-resident vectors |
-| `Mode` | `VectorModeBTree` | `VectorModeHybrid` (RAM layer-0 cache) or `VectorModeBruteForce` (exact O(N) scan, no graph) |
+| `Mode` | `VectorModeBTree` | `VectorModeHybrid` (RAM layer-0 cache), `VectorModeBruteForce` (exact O(N) scan, no graph), `VectorModeIVFPQ`/`VectorModeIVFSQ` (inverted-file cells; Cosine/L2 only) |
 | `HybridCacheVectors` | `false` | hybrid only: also cache vectors in RAM for faster search |
 | `CompactRatio` | `0` (off) | auto-compact the graph when tombstones reach this ratio of live nodes |
 

--- a/fulltext_residual_test.go
+++ b/fulltext_residual_test.go
@@ -1,0 +1,88 @@
+package anystore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/query"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// TestFtsResidual_NoTextSurvives mirrors TestKnnResidual_NoKnnSurvives: the
+// residual handed to the FilterIter must never contain the Text node, in any
+// $and nesting — detection (findTextInAnd) recurses, so the strip must too.
+// A leaked Text fails open (Text.Ok returns true), so the leak is invisible
+// in results; this test pins the structural post-condition instead.
+func TestFtsResidual_NoTextSurvives(t *testing.T) {
+	td := `{"$text":{"$search":"x"}}`
+	cases := []string{
+		td,
+		fmt.Sprintf(`{"$and":[%s,{"a":1}]}`, td),
+		fmt.Sprintf(`{"$and":[{"$and":[%s,{"a":1}]},{"b":2}]}`, td),
+		fmt.Sprintf(`{"$and":[{"$and":[%s]},{"$and":[{"a":1},{"b":2}]}]}`, td),
+		fmt.Sprintf(`{"$and":[{"$and":[{"$and":[%s]}]},{"a":1}]}`, td),
+	}
+	for _, c := range cases {
+		f := query.MustParseCondition(c)
+		res := ftsResidualFilter(f)
+		require.NotNil(t, res, c)
+		assert.False(t, query.ContainsText(res), "text survived: %s", c)
+	}
+
+	// The surviving conjuncts keep their semantics: for the nested shape the
+	// residual must still require a==1 AND b==2.
+	res := ftsResidualFilter(query.MustParseCondition(cases[2]))
+	buf := &syncpool.DocBuffer{}
+	assert.True(t, res.Ok(anyenc.MustParseJson(`{"a":1,"b":2}`), buf))
+	assert.False(t, res.Ok(anyenc.MustParseJson(`{"a":1,"b":3}`), buf))
+	assert.False(t, res.Ok(anyenc.MustParseJson(`{"a":0,"b":2}`), buf))
+
+	// A text-only query leaves the match-all residual.
+	assert.Equal(t, query.All{}, ftsResidualFilter(query.MustParseCondition(td)))
+
+	// Pointer forms: *And nodes and *Text leaves must be stripped too.
+	ptr := &query.And{&query.Text{}, query.MustParseCondition(`{"a":1}`)}
+	res = ftsResidualFilter(query.And{ptr, query.MustParseCondition(`{"b":2}`)})
+	require.NotNil(t, res)
+	assert.False(t, query.ContainsText(res))
+	assert.True(t, res.Ok(anyenc.MustParseJson(`{"a":1,"b":2}`), buf))
+	assert.False(t, res.Ok(anyenc.MustParseJson(`{"a":2,"b":2}`), buf))
+}
+
+// TestFtsPipeline_NestedAndResidual drives the leak shape end-to-end: the
+// nested conjuncts must actually FILTER the BM25 candidates (guards against
+// over-stripping, the opposite failure of the leak).
+func TestFtsPipeline_NestedAndResidual(t *testing.T) {
+	fx, coll := ftsPipelineColl(t)
+	defer fx.finish()
+	cond := `{"$and":[{"$and":[{"$text":{"$search":"london"}},{"status":"open"}]},{"year":{"$lt":1940}}]}`
+
+	// a: open/1920 matches; b: closed; c: 1950; d: no "london".
+	ids, _ := collectIter(t, coll.Find(cond))
+	assert.Equal(t, []string{"a"}, ids)
+
+	cnt, err := coll.Find(cond).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+}
+
+// TestFtsPlacementRejections pins the placement errors around the residual
+// path: $text under $or/$nor/$not and duplicate $text fail with the named
+// errors on every entry point, they don't silently degrade.
+func TestFtsPlacementRejections(t *testing.T) {
+	fx, coll := ftsPipelineColl(t)
+	defer fx.finish()
+	for _, c := range []string{
+		`{"$or":[{"$text":{"$search":"london"}},{"status":"open"}]}`,
+		`{"$nor":[{"$text":{"$search":"london"}}]}`,
+	} {
+		_, err := coll.Find(c).Count(ctx)
+		assert.ErrorIs(t, err, errFtsBadPlacement, c)
+	}
+	_, err := coll.Find(`{"$and":[{"$text":{"$search":"london"}},{"$and":[{"$text":{"$search":"fog"}}]}]}`).Count(ctx)
+	assert.ErrorIs(t, err, errFtsMultiple)
+}

--- a/fulltext_residual_test.go
+++ b/fulltext_residual_test.go
@@ -86,3 +86,31 @@ func TestFtsPlacementRejections(t *testing.T) {
 	_, err := coll.Find(`{"$and":[{"$text":{"$search":"london"}},{"$and":[{"$text":{"$search":"fog"}}]}]}`).Count(ctx)
 	assert.ErrorIs(t, err, errFtsMultiple)
 }
+
+// TestFtsPointerFilterForms pins detection symmetry for programmatic filters
+// (ParseCondition passes a query.Filter through verbatim): pointer-built
+// nodes must behave exactly like their value forms — a *Text is a real $text
+// (searched, not silently ignored fail-open), and a Text inside a pointer
+// composite is a placement error, not a match-all.
+func TestFtsPointerFilterForms(t *testing.T) {
+	fx, coll := ftsPipelineColl(t)
+	defer fx.finish()
+	tf := query.MustParseCondition(`{"$text":{"$search":"london"}}`).(query.Text)
+
+	// *Text inside $and: the BM25 search must run — only the three "london"
+	// docs match, not all four.
+	ids, _ := collectIter(t, coll.Find(query.And{&tf, query.MustParseCondition(`{"status":"open"}`)}))
+	assert.ElementsMatch(t, []string{"a", "c"}, ids)
+
+	// Text inside pointer composites: same placement rejection as the value
+	// forms.
+	for _, f := range []query.Filter{
+		&query.Or{tf, query.MustParseCondition(`{"status":"open"}`)},
+		&query.Nor{tf},
+		&query.Not{Filter: tf},
+		query.And{tf, &query.Key{Path: []string{"a"}, Filter: tf}},
+	} {
+		_, err := coll.Find(f).Count(ctx)
+		assert.ErrorIs(t, err, errFtsBadPlacement, "%T", f)
+	}
+}

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"slices"
 	"sync"
@@ -959,7 +960,16 @@ func (q *collQuery) detectFtsQuery() (*qplanner.FtsQuerySpec, query.Filter, erro
 			return fx.searchCandidates(tx, text)
 		},
 	}
-	return spec, ftsResidualFilter(q.cond), nil
+	residual := ftsResidualFilter(q.cond)
+	// HARD post-condition, mirroring detectKnnQuery's ContainsKnn assert: a
+	// Text leaking into the residual FilterIter fails OPEN (Text.Ok returns
+	// true unconditionally), so today a leak only wastes a predicate — but
+	// any future fail-closed Text.Ok, or a residual evaluated against
+	// non-candidates, would turn it into silent 0-row results on every verb.
+	if query.ContainsText(residual) {
+		return nil, nil, fmt.Errorf("%w: internal: $text survived residual extraction", errFtsBadPlacement)
+	}
+	return spec, residual, nil
 }
 
 
@@ -990,7 +1000,7 @@ func findTextFilter(f query.Filter) (query.Text, bool, error) {
 			return query.Text{}, false, errFtsBadPlacement
 		}
 	case query.Or, query.Nor, query.Not:
-		if containsText(f) {
+		if query.ContainsText(f) {
 			return query.Text{}, false, errFtsBadPlacement
 		}
 	}
@@ -1020,64 +1030,41 @@ var (
 	errFtsMultiple     = errors.New("any-store: only one $text expression is supported per query")
 )
 
-// containsText reports whether any node in the filter tree is a $text predicate.
-func containsText(f query.Filter) bool {
-	switch ft := f.(type) {
-	case query.Text:
-		return true
-	case query.And:
-		return anyContainsText(ft)
-	case *query.And:
-		return anyContainsText(*ft)
-	case query.Or:
-		return anyContainsText(query.And(ft))
-	case query.Nor:
-		return anyContainsText(query.And(ft))
-	case query.Not:
-		return containsText(ft.Filter)
-	case query.Key:
-		return containsText(ft.Filter)
-	}
-	return false
-}
-
-func anyContainsText(fs []query.Filter) bool {
-	for _, f := range fs {
-		if containsText(f) {
-			return true
-		}
-	}
-	return false
-}
-
 // ftsResidualFilter returns the filter with the $text clause removed — the
 // predicate the planner's FilterIter applies to the BM25-ranked candidates. A
-// query that is just $text leaves no residual (query.All).
+// query that is just $text leaves no residual (query.All). It recurses
+// through And in both forms, mirroring knnResidualFilter: detection
+// (findTextInAnd) recurses into nested $and, so the strip must too — a
+// shallow strip would hand the FilterIter a residual still containing the
+// Text node.
 func ftsResidualFilter(f query.Filter) query.Filter {
-	switch ft := f.(type) {
-	case query.Text:
-		return query.All{}
-	case query.And:
-		return ftsResidualFromAnd(ft)
-	case *query.And:
-		return ftsResidualFromAnd(*ft)
+	if r := ftsStripText(f); r != nil {
+		return r
 	}
-	return f
+	return query.All{}
 }
 
-func ftsResidualFromAnd(and query.And) query.Filter {
-	var rest query.And
-	for _, sub := range and {
-		if _, isText := sub.(query.Text); !isText {
-			rest = append(rest, sub)
+func ftsStripText(f query.Filter) query.Filter {
+	switch ft := f.(type) {
+	case query.Text, *query.Text:
+		return nil
+	case query.And:
+		rest := make(query.And, 0, len(ft))
+		for _, sub := range ft {
+			if r := ftsStripText(sub); r != nil {
+				rest = append(rest, r)
+			}
 		}
+		switch len(rest) {
+		case 0:
+			return nil
+		case 1:
+			return rest[0]
+		default:
+			return rest
+		}
+	case *query.And:
+		return ftsStripText(query.And(*ft))
 	}
-	switch len(rest) {
-	case 0:
-		return query.All{}
-	case 1:
-		return rest[0]
-	default:
-		return rest
-	}
+	return f
 }

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -986,20 +986,24 @@ func ftsSorter(s query.Sort) query.Sort {
 
 // findTextFilter locates the $text predicate in a parsed filter. v1 supports a
 // $text only at the top level or directly inside an $and (AND context); a $text
-// nested under $or/$nor/$not is rejected. Returns (text, found, error).
+// nested under $or/$nor/$not/Key is rejected. Returns (text, found, error).
+// Every composite is matched in BOTH value and pointer form — the same
+// contract as query.FilterTreeAny: programmatic filters (ParseCondition
+// passes a query.Filter through verbatim) legally build pointer nodes, and a
+// detection walk narrower than the strip/post-condition walk would either
+// silently skip the $text (fail-open: Text.Ok returns true) or trip the
+// residual assert on shapes detection accepted.
 func findTextFilter(f query.Filter) (query.Text, bool, error) {
 	switch ft := f.(type) {
 	case query.Text:
 		return ft, true, nil
+	case *query.Text:
+		return *ft, true, nil
 	case query.And:
 		return findTextInAnd(ft)
 	case *query.And:
 		return findTextInAnd(*ft)
-	case query.Key:
-		if _, ok, _ := findTextFilter(ft.Filter); ok {
-			return query.Text{}, false, errFtsBadPlacement
-		}
-	case query.Or, query.Nor, query.Not:
+	case query.Key, *query.Key, query.Or, *query.Or, query.Nor, *query.Nor, query.Not, *query.Not:
 		if query.ContainsText(f) {
 			return query.Text{}, false, errFtsBadPlacement
 		}

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -2104,25 +2104,6 @@ func invertBytes(b []byte) []byte {
 	return out
 }
 
-// prefixSuccessor returns the smallest byte string greater than every string
-// prefixed by p: trailing 0xFF bytes are stripped and the last remaining byte
-// incremented. Used as an EXCLUSIVE End, the result admits exactly the
-// p-prefixed keys. Returns nil (+inf) when p is all-0xFF (no successor
-// exists; unreachable for anyenc bounds — inverted tags top out at 0xFE).
-// p must be freshly allocated (invertBytes output): it is truncated and
-// mutated in place.
-func prefixSuccessor(p []byte) []byte {
-	i := len(p) - 1
-	for i >= 0 && p[i] == 0xff {
-		i--
-	}
-	if i < 0 {
-		return nil
-	}
-	p = p[:i+1]
-	p[i]++
-	return p
-}
 
 // transformReverseBounds maps per-field bounds from ascending value space into
 // the inverted (stored) byte space used for a reverse-flagged index field.
@@ -2177,8 +2158,15 @@ func transformReverseBounds(bs query.Bounds) query.Bounds {
 		// Starts keep the plain inverted End: their continuations obey the
 		// tuple-boundary invariant, and the 0xFF pad both admits them and
 		// deliberately excludes ascending 0xFF escape tails.
+		//
+		// The transformed endpoints stay slightly OVER-approximate after the
+		// downstream pads (padReverseBounds widens both the exclusive-Start
+		// 0xFF pad and this exclusive End with 0x01): a handful of
+		// adjacent-value keys can enter the scan and are rejected by the
+		// residual FilterIter. Any future exactness-based residual elision
+		// must therefore treat prefix-derived bounds as INEXACT.
 		if b.StartInclude && len(b.Start) > 0 && anyenc.ValidateRaw(b.Start) != nil {
-			nb.End = prefixSuccessor(nb.End)
+			nb.End = query.PrefixSuccessor(nb.End)
 			nb.EndInclude = false
 		}
 		out = append(out, nb)

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -2104,6 +2104,26 @@ func invertBytes(b []byte) []byte {
 	return out
 }
 
+// prefixSuccessor returns the smallest byte string greater than every string
+// prefixed by p: trailing 0xFF bytes are stripped and the last remaining byte
+// incremented. Used as an EXCLUSIVE End, the result admits exactly the
+// p-prefixed keys. Returns nil (+inf) when p is all-0xFF (no successor
+// exists; unreachable for anyenc bounds — inverted tags top out at 0xFE).
+// p must be freshly allocated (invertBytes output): it is truncated and
+// mutated in place.
+func prefixSuccessor(p []byte) []byte {
+	i := len(p) - 1
+	for i >= 0 && p[i] == 0xff {
+		i--
+	}
+	if i < 0 {
+		return nil
+	}
+	p = p[:i+1]
+	p[i]++
+	return p
+}
+
 // transformReverseBounds maps per-field bounds from ascending value space into
 // the inverted (stored) byte space used for a reverse-flagged index field.
 // Inversion reverses byte order, so each bound's Start/End are inverted AND
@@ -2133,12 +2153,35 @@ func transformReverseBounds(bs query.Bounds) query.Bounds {
 	}
 	out := make(query.Bounds, 0, len(bs))
 	for _, b := range bs {
-		out = append(out, query.Bound{
+		nb := query.Bound{
 			Start:        invertBytes(b.End),
 			End:          invertBytes(b.Start),
 			StartInclude: b.EndInclude,
 			EndInclude:   b.StartInclude,
-		})
+		}
+		// An inclusive ascending Start whose bytes are an INCOMPLETE value
+		// encoding — a mid-value prefix, as emitted by TypeFilter (bare type
+		// tag) and Regexp (tag + string prefix, no EOS) — does not survive
+		// inversion as an inclusive End: inversion reverses divergent-byte
+		// order but preserves the prefix-extension relation, so every key the
+		// prefix is meant to admit sorts ABOVE inv(prefix). The downstream
+		// inclusive-End pad (AdjustBoundsForNonUnique's 0xFF append) only
+		// rescues continuations that can never be 0xFF — true at tuple
+		// boundaries, where the next byte is a docId/next-field tag or a
+		// 0x00 escape tail, but false mid-value, where the continuation is
+		// inverted payload: a raw 0x00 payload byte (a 1970s ObjectID
+		// timestamp, a float ≤ -~9e307, the EOS of an empty string) inverts
+		// to 0xFF and the key escapes the padded End — silently dropping
+		// rows. Map the prefix to its exact stored-space upper bound instead:
+		// the successor of the inverted prefix, exclusive. Complete-value
+		// Starts keep the plain inverted End: their continuations obey the
+		// tuple-boundary invariant, and the 0xFF pad both admits them and
+		// deliberately excludes ascending 0xFF escape tails.
+		if b.StartInclude && len(b.Start) > 0 && anyenc.ValidateRaw(b.Start) != nil {
+			nb.End = prefixSuccessor(nb.End)
+			nb.EndInclude = false
+		}
+		out = append(out, nb)
 	}
 	slices.SortStableFunc(out, func(a, b query.Bound) int {
 		return compareInvertedStart(a.Start, b.Start)

--- a/internal/qplanner/planner_test.go
+++ b/internal/qplanner/planner_test.go
@@ -697,6 +697,42 @@ func TestAdjustBoundsForNonUnique(t *testing.T) {
 	assert.Equal(t, anyenc.Tuple{1}, adjusted[0].Start)
 }
 
+func TestTransformReverseBounds_PrefixStart(t *testing.T) {
+	// A complete-value bound keeps the plain inverted End with its
+	// inclusivity: continuations at tuple boundaries obey the docId-tag
+	// invariant, and the downstream 0xFF pad handles them.
+	v := anyenc.AppendAnyValue(nil, "a")
+	bs := transformReverseBounds(query.Bounds{{Start: v, End: v, StartInclude: true, EndInclude: true}})
+	require.Len(t, bs, 1)
+	assert.Equal(t, anyenc.Tuple(invertBytes(v)), bs[0].End)
+	assert.True(t, bs[0].EndInclude)
+
+	// A mid-value prefix Start (bare type tag, the $type shape) maps to the
+	// successor of the inverted prefix, exclusive — the only inclusive-End
+	// form that admits keys whose inverted continuation byte is 0xFF.
+	bs = transformReverseBounds(query.Bounds{{Start: []byte{0x0b}, End: []byte{0x0c}, StartInclude: true, EndInclude: false}})
+	require.Len(t, bs, 1)
+	assert.Equal(t, anyenc.Tuple{0xf5}, bs[0].End) // succ(^0x0b = 0xf4)
+	assert.False(t, bs[0].EndInclude)
+	assert.Equal(t, anyenc.Tuple{0xf3}, bs[0].Start)
+	assert.False(t, bs[0].StartInclude)
+
+	// The $regex shape: tag + prefix bytes, no EOS.
+	pfx := append([]byte{0x03}, "foo"...)
+	bs = transformReverseBounds(query.Bounds{{Start: pfx, End: append([]byte{0x03}, "fop"...), StartInclude: true, EndInclude: false}})
+	require.Len(t, bs, 1)
+	wantEnd := invertBytes(pfx)
+	wantEnd[len(wantEnd)-1]++
+	assert.Equal(t, anyenc.Tuple(wantEnd), bs[0].End)
+	assert.False(t, bs[0].EndInclude)
+}
+
+func TestPrefixSuccessor(t *testing.T) {
+	assert.Equal(t, []byte{0x02}, prefixSuccessor([]byte{0x01, 0xff, 0xff}))
+	assert.Equal(t, []byte{0xf5}, prefixSuccessor([]byte{0xf4}))
+	assert.Nil(t, prefixSuccessor([]byte{0xff, 0xff}))
+}
+
 func TestSortCost(t *testing.T) {
 	assert.Equal(t, 0.0, sortCost(0))
 	assert.Equal(t, 0.0, sortCost(1))

--- a/internal/qplanner/planner_test.go
+++ b/internal/qplanner/planner_test.go
@@ -717,9 +717,15 @@ func TestTransformReverseBounds_PrefixStart(t *testing.T) {
 	assert.Equal(t, anyenc.Tuple{0xf3}, bs[0].Start)
 	assert.False(t, bs[0].StartInclude)
 
-	// The $regex shape: tag + prefix bytes, no EOS.
+	// The $regex shape, taken from the real emitter so this test pins what
+	// Regexp.IndexBounds actually produces (prefix-successor exclusive End).
+	rf := query.MustParseCondition(`{"name":{"$regex":"^foo"}}`)
+	fwd := rf.IndexBounds("name", nil)
+	require.Len(t, fwd, 1)
 	pfx := append([]byte{0x03}, "foo"...)
-	bs = transformReverseBounds(query.Bounds{{Start: pfx, End: append([]byte{0x03}, "fop"...), StartInclude: true, EndInclude: false}})
+	require.Equal(t, anyenc.Tuple(pfx), fwd[0].Start)
+	require.False(t, fwd[0].EndInclude)
+	bs = transformReverseBounds(fwd)
 	require.Len(t, bs, 1)
 	wantEnd := invertBytes(pfx)
 	wantEnd[len(wantEnd)-1]++
@@ -728,9 +734,10 @@ func TestTransformReverseBounds_PrefixStart(t *testing.T) {
 }
 
 func TestPrefixSuccessor(t *testing.T) {
-	assert.Equal(t, []byte{0x02}, prefixSuccessor([]byte{0x01, 0xff, 0xff}))
-	assert.Equal(t, []byte{0xf5}, prefixSuccessor([]byte{0xf4}))
-	assert.Nil(t, prefixSuccessor([]byte{0xff, 0xff}))
+	assert.Equal(t, []byte{0x02}, query.PrefixSuccessor([]byte{0x01, 0xff, 0xff}))
+	assert.Equal(t, []byte{0xf5}, query.PrefixSuccessor([]byte{0xf4}))
+	assert.Nil(t, query.PrefixSuccessor([]byte{0xff, 0xff}))
+	assert.Nil(t, query.PrefixSuccessor(nil))
 }
 
 func TestSortCost(t *testing.T) {

--- a/query.go
+++ b/query.go
@@ -173,7 +173,7 @@ func (q *collQuery) validateSources() error {
 		return ErrDistanceWithoutVector
 	}
 	if hasKnn {
-		if containsText(q.cond) {
+		if query.ContainsText(q.cond) {
 			return ErrKnnWithText
 		}
 		if _, _, err := q.detectKnnQuery(); err != nil {

--- a/query/bound.go
+++ b/query/bound.go
@@ -53,6 +53,26 @@ func (b Bound) String() string {
 	return fmt.Sprintf("%s,%s", as, bs)
 }
 
+// PrefixSuccessor returns the smallest byte string greater than every string
+// prefixed by p: trailing 0xFF bytes are stripped and the last remaining byte
+// incremented, into a fresh slice. Used as an EXCLUSIVE End, the result
+// admits exactly the p-prefixed keys — unlike the append-0xFF inclusive
+// idiom, which excludes any key continuing with a 0xFF byte after the prefix
+// (longer sorts greater). Returns nil (+inf) when p is all-0xFF or empty.
+func PrefixSuccessor(p []byte) []byte {
+	i := len(p) - 1
+	for i >= 0 && p[i] == 0xff {
+		i--
+	}
+	if i < 0 {
+		return nil
+	}
+	out := make([]byte, i+1)
+	copy(out, p[:i+1])
+	out[i]++
+	return out
+}
+
 type Bounds []Bound
 
 func (bs Bounds) String() string {

--- a/query/filter.go
+++ b/query/filter.go
@@ -957,6 +957,22 @@ func isSourceLeaf(f Filter) bool {
 	return false
 }
 
+func isTextLeaf(f Filter) bool {
+	switch f.(type) {
+	case Text, *Text:
+		return true
+	}
+	return false
+}
+
+// ContainsText reports whether the tree contains a Text ANYWHERE, pointer
+// nodes included — same full-walk contract as ContainsKnn. Consumers use it
+// both to reject bad placements ($text under $or/$nor/$not) and as the
+// post-condition that the fts residual extraction stripped every Text node.
+func ContainsText(f Filter) bool {
+	return FilterTreeAny(f, isTextLeaf)
+}
+
 // ContainsKnn reports whether the tree contains a Knn ANYWHERE. It MUST walk
 // the whole tree, pointer nodes included: a Knn under Not would evaluate
 // !false == match-all (see the Knn type comment), so every consumer that

--- a/query/filter.go
+++ b/query/filter.go
@@ -1141,11 +1141,18 @@ func (r Regexp) IndexBounds(_ string, bs Bounds) (bounds Bounds) {
 	)
 	// strip the 'eof' byte
 	prefixEncoded = prefixEncoded[:len(prefixEncoded)-1]
+	// Exclusive prefix-successor End, not the inclusive prefix+0xFF idiom:
+	// the latter drops any value whose payload continues with a raw 0xFF
+	// byte right after the prefix (the key is longer, so it compares greater
+	// than the End) — the same under-approximation 192c239 removed from
+	// TypeFilter. The successor admits exactly the prefix-continuation
+	// group, and survives the reverse-index transform (see
+	// qplanner.transformReverseBounds).
 	bound := Bound{
 		Start:        prefixEncoded,
-		End:          append(prefixEncoded, 255),
+		End:          PrefixSuccessor(prefixEncoded),
 		StartInclude: true,
-		EndInclude:   true,
+		EndInclude:   false,
 	}
 	return bs.Append(bound)
 }

--- a/query_reverse_prefix_bounds_test.go
+++ b/query_reverse_prefix_bounds_test.go
@@ -116,16 +116,20 @@ func TestReversePrefixBounds(t *testing.T) {
 
 			t.Run("regex prefix "+name, func(t *testing.T) {
 				coll, hint := newColl(t)
-				words := []string{"foo", "foobar", "fop", "fo", "other"}
+				// "foo" is one boundary row: its key continues with the
+				// inverted EOS (0xFF) right after the prefix bytes on a
+				// descending index. "foo\xff\xffz" is the other: a raw 0xFF
+				// payload run right after the prefix (legal — only NUL is
+				// escaped), which the old inclusive prefix+0xFF ascending
+				// End also dropped.
+				words := []string{"foo", "foobar", "fop", "fo", "other", "foo\xff\xffz"}
 				for i, w := range words {
 					w := w
 					trpbInsert(t, coll, i+1, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewString(w)) })
 				}
 
-				// "foo" itself is the boundary row: its key continues with the
-				// inverted EOS (0xFF) right after the prefix bytes.
 				got := trpbFindIds(t, ctx, coll, hint, `{"v":{"$regex":"^foo"}}`)
-				assert.Equal(t, []int{1, 2}, got)
+				assert.Equal(t, []int{1, 2, 6}, got)
 			})
 		}
 	}

--- a/query_reverse_prefix_bounds_test.go
+++ b/query_reverse_prefix_bounds_test.go
@@ -1,0 +1,132 @@
+package anystore
+
+import (
+	"context"
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// End-to-end coverage for index bounds whose endpoints are mid-value PREFIXES
+// of the anyenc encoding — $type's bare type tag, $regex's tag + string
+// prefix — on DESCENDING indexes. Bitwise key inversion preserves the
+// prefix-extension relation instead of reversing it, so such a bound survives
+// only via the prefix-successor transform (qplanner.transformReverseBounds).
+// Without it, every row whose first inverted continuation byte is 0xFF — a
+// leading 0x00 payload byte: a 1970s ObjectID timestamp, a float <= -~9e307,
+// the immediate EOS of an empty string, or a stored string equal to a $regex
+// prefix (its EOS inverts to 0xFF) — silently fell outside the 0xFF-padded
+// End on Count, Iter, Delete and Update, with err == nil.
+//
+// The ascending runs pin the forward behavior (exclusive next-tag End, see
+// commit 192c239) that the reverse transform must not regress.
+
+func trpbInsert(t *testing.T, coll Collection, id int, set func(a *anyenc.Arena, d *anyenc.Value)) {
+	t.Helper()
+	a := &anyenc.Arena{}
+	doc := a.NewObject()
+	doc.Set("id", a.NewNumberInt(id))
+	set(a, doc)
+	require.NoError(t, coll.Insert(ctx, doc))
+}
+
+func trpbFindIds(t *testing.T, ctx context.Context, coll Collection, hint IndexHint, cond string) []int {
+	t.Helper()
+	it, err := coll.Find(cond).IndexHint(hint).Iter(ctx)
+	require.NoError(t, err)
+	var got []int
+	for it.Next() {
+		d, derr := it.Doc()
+		require.NoError(t, derr)
+		got = append(got, d.Value().GetInt("id"))
+	}
+	require.NoError(t, it.Close())
+	slices.Sort(got)
+
+	cnt, err := coll.Find(cond).IndexHint(hint).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(got), cnt, "Count vs Iter divergence for %s", cond)
+	return got
+}
+
+func TestReversePrefixBounds(t *testing.T) {
+	zeroOid, err := anyenc.ObjectIDFromHex("000000000000000000000000")
+	require.NoError(t, err)
+	liveOid := anyenc.NewObjectID()
+
+	for _, field := range []string{"v", "-v"} {
+		for _, unique := range []bool{false, true} {
+			name := field
+			if unique {
+				name += " unique"
+			}
+			newColl := func(t *testing.T) (Collection, IndexHint) {
+				fx := newFixture(t)
+				coll, err := fx.CreateCollection(ctx, "test")
+				require.NoError(t, err)
+				require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{field}, Unique: unique}))
+				return coll, IndexHint{IndexName: strings.TrimPrefix(field, "-"), Boost: 100}
+			}
+
+			t.Run("type objectId "+name, func(t *testing.T) {
+				coll, hint := newColl(t)
+				trpbInsert(t, coll, 1, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewObjectID(zeroOid)) })
+				trpbInsert(t, coll, 2, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewObjectID(liveOid)) })
+				trpbInsert(t, coll, 3, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewNumberInt(7)) })
+
+				got := trpbFindIds(t, ctx, coll, hint, `{"v":{"$type":"objectId"}}`)
+				assert.Equal(t, []int{1, 2}, got)
+
+				res, err := coll.Find(`{"v":{"$type":"objectId"}}`).IndexHint(hint).Delete(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, 2, res.Modified)
+				cnt, err := coll.Find(nil).Count(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, 1, cnt)
+			})
+
+			t.Run("type number "+name, func(t *testing.T) {
+				coll, hint := newColl(t)
+				nums := []float64{-math.MaxFloat64, -1e308, -1, 0, 1, math.MaxFloat64}
+				for i, n := range nums {
+					n := n
+					trpbInsert(t, coll, i+1, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewNumberFloat64(n)) })
+				}
+				trpbInsert(t, coll, 100, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewString("s")) })
+
+				got := trpbFindIds(t, ctx, coll, hint, `{"v":{"$type":"number"}}`)
+				assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, got)
+			})
+
+			t.Run("type string empty "+name, func(t *testing.T) {
+				coll, hint := newColl(t)
+				trpbInsert(t, coll, 1, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewString("")) })
+				trpbInsert(t, coll, 2, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewString("x")) })
+				trpbInsert(t, coll, 3, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewNumberInt(7)) })
+
+				got := trpbFindIds(t, ctx, coll, hint, `{"v":{"$type":"string"}}`)
+				assert.Equal(t, []int{1, 2}, got)
+			})
+
+			t.Run("regex prefix "+name, func(t *testing.T) {
+				coll, hint := newColl(t)
+				words := []string{"foo", "foobar", "fop", "fo", "other"}
+				for i, w := range words {
+					w := w
+					trpbInsert(t, coll, i+1, func(a *anyenc.Arena, d *anyenc.Value) { d.Set("v", a.NewString(w)) })
+				}
+
+				// "foo" itself is the boundary row: its key continues with the
+				// inverted EOS (0xFF) right after the prefix bytes.
+				got := trpbFindIds(t, ctx, coll, hint, `{"v":{"$regex":"^foo"}}`)
+				assert.Equal(t, []int{1, 2}, got)
+			})
+		}
+	}
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -75,6 +75,14 @@ func validateVectorParams(p *VectorParams) error {
 	switch p.Mode {
 	case VectorModeBTree, VectorModeHybrid, VectorModeBruteForce:
 	case VectorModeIVFPQ, VectorModeIVFSQ:
+		if p.Metric == VectorDot {
+			// vivf has no dot-product ranking path: its distance surface is
+			// L2, or cosine via unit-normalization (StoreParams.Normalize).
+			// Accepting Dot here would silently rank by L2 — no error,
+			// plausible neighbours, wrong order. Refuse until a real MIPS
+			// path exists (dot-aware coarse assignment + ADC tables).
+			return ErrVectorMetricUnsupported
+		}
 		m := ivfM(p)
 		if p.Dim%m != 0 {
 			return fmt.Errorf("vector index: IVF requires Dim (%d) divisible by M (%d)", p.Dim, m)
@@ -84,6 +92,12 @@ func validateVectorParams(p *VectorParams) error {
 	}
 	return nil
 }
+
+// ErrVectorMetricUnsupported is returned when an index declares a metric the
+// selected mode cannot rank by. Validation runs on both create and open, so a
+// persisted index with an unsupported combination fails loudly instead of
+// silently ranking by the wrong metric.
+var ErrVectorMetricUnsupported = errors.New("any-store: vector index: VectorDot is not supported by IVF modes; use VectorModeBTree, VectorModeHybrid or VectorModeBruteForce, or the Cosine/L2 metrics")
 
 // ivfM resolves the PQ subquantizer count: explicit M, else a default that divides
 // Dim (prefer 96 → 8-dim subspaces for typical embedding dims, else the largest of

--- a/vector_metric_validation_test.go
+++ b/vector_metric_validation_test.go
@@ -1,0 +1,114 @@
+package anystore
+
+import (
+	"fmt"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// TestVectorMetricModeMatrix pins the accepted metric x mode combinations.
+// vivf's distance surface is L2, or cosine via unit-normalization — it has no
+// dot-product ranking path — so VectorDot on the IVF modes must be refused at
+// validation instead of silently ranking by L2 (wrong order, no error).
+func TestVectorMetricModeMatrix(t *testing.T) {
+	const dim = 32
+	modes := []VectorMode{VectorModeBTree, VectorModeHybrid, VectorModeBruteForce, VectorModeIVFPQ, VectorModeIVFSQ}
+	metrics := []VectorMetric{VectorCosine, VectorL2, VectorDot}
+	for _, mode := range modes {
+		for _, metric := range metrics {
+			t.Run(fmt.Sprintf("mode=%d metric=%d", mode, metric), func(t *testing.T) {
+				fx := newFixture(t)
+				coll, err := fx.CreateCollection(ctx, "docs")
+				require.NoError(t, err)
+				// IVF modes train from existing documents at create time.
+				rng := rand.New(rand.NewSource(11))
+				for i := 0; i < 128; i++ {
+					v := make([]float32, dim)
+					for d := range v {
+						v[d] = float32(rng.NormFloat64())
+					}
+					require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(vecDocJSON(i, v))))
+				}
+				err = coll.CreateIndex(ctx, IndexInfo{
+					Name: "emb",
+					Kind: IndexKindVector,
+					Vector: &VectorParams{Field: "v", Dim: dim, Metric: metric, Mode: mode},
+				})
+				if metric == VectorDot && (mode == VectorModeIVFPQ || mode == VectorModeIVFSQ) {
+					assert.ErrorIs(t, err, ErrVectorMetricUnsupported)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	}
+}
+
+// TestVectorDot_RankingMatchesBruteOracle proves VectorDot actually ranks by
+// inner product where it is accepted: brute-force mode scans exactly, so the
+// result order must equal the descending-dot oracle.
+func TestVectorDot_RankingMatchesBruteOracle(t *testing.T) {
+	const (
+		n   = 300
+		dim = 8
+		k   = 5
+	)
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+
+	rng := rand.New(rand.NewSource(41))
+	vecs := make([][]float32, n)
+	for i := range vecs {
+		v := make([]float32, dim)
+		for d := range v {
+			v[d] = float32(rng.NormFloat64())
+		}
+		vecs[i] = v
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(vecDocJSON(i, v))))
+	}
+	require.NoError(t, coll.CreateIndex(ctx, IndexInfo{
+		Name: "emb",
+		Kind: IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: dim, Metric: VectorDot, Mode: VectorModeBruteForce},
+	}))
+
+	q := make([]float32, dim)
+	for d := range q {
+		q[d] = float32(rng.NormFloat64())
+	}
+	dot := func(a, b []float32) float32 {
+		var s float32
+		for i := range a {
+			s += a[i] * b[i]
+		}
+		return s
+	}
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	slices.SortStableFunc(order, func(a, b int) int {
+		da, db := dot(q, vecs[a]), dot(q, vecs[b])
+		switch {
+		case da > db:
+			return -1
+		case da < db:
+			return 1
+		}
+		return 0
+	})
+
+	hits, err := vsearch(coll, "v", q, k, 0)
+	require.NoError(t, err)
+	require.Len(t, hits, k)
+	for i, h := range hits {
+		assert.Equal(t, idBytesOf(order[i]), h.DocId, "rank %d", i)
+	}
+}


### PR DESCRIPTION
Three independent correctness fixes filed as follow-ups from the $knn design pass, plus a review-hardening commit from a high-effort multi-agent review of the branch.

## 1. Prefix bounds survive reverse-index inversion (`a302b00`, hardened by `55f2ef1`)

Bitwise key inversion preserves the prefix-extension relation, so an inclusive ascending Start whose bytes are a mid-value prefix of the anyenc encoding (TypeFilter's bare tag, Regexp's tag+prefix) did not survive `transformReverseBounds`: the downstream 0xFF pad only rescues continuations that can never be 0xFF — true at tuple boundaries (the 18a38bc invariant), false mid-value. Silently dropped from Count/Iter/Delete/Update on a descending index, with `err == nil`:

- 1970s-timestamp ObjectIDs under `$type:"objectId"`
- floats ≤ −9e307 under `$type:"number"`
- the empty string under `$type:"string"` (its EOS inverts to 0xFF)
- the exact prefix match under `$regex:"^foo"` ("foo" itself)

The transform now detects the incomplete encoding (`anyenc.ValidateRaw` fails) and emits the successor of the inverted prefix as an exclusive End. Complete-value Starts keep the old path — their 0xFF pad also deliberately excludes ascending escape-tail keys, which a successor End would wrongly admit into entry-count paths.

The review pass then found the last member at the emitter: `Regexp.IndexBounds` still used the inclusive `prefix‖0xFF` idiom `192c239` removed from TypeFilter, dropping strings with a raw 0xFF run after the prefix on **ascending** indexes too. It now emits the exclusive prefix successor (shared `query.PrefixSuccessor`).

`TestReversePrefixBounds` (e2e matrix {asc,desc} × {unique,non-unique} × {objectId, number, empty string, regex}) fails on all descending shapes — and the regex case on ascending — before the fixes.

## 2. `VectorDot` × IVF is rejected, not silently degraded (`cdd42e1`)

vivf's distance surface is L2 or cosine-via-normalization at every stage (coarse assign, k-means, PQ LUTs, SQ scan, re-rank); `ivfStoreParams` forwarded only `Normalize`, so a `Metric: VectorDot` IVF index ranked by unnormalized L2 with no error. `validateVectorParams` now returns the named `ErrVectorMetricUnsupported`; it runs on create and open, so a persisted Dot+IVF index fails loudly instead of mis-ranking (accepted trade-off: such a collection fails to open until the index is dropped out-of-band — no VectorDot usage exists anywhere, and alpha back-compat is waived by decision). `TestVectorDot_RankingMatchesBruteOracle` is the first test proving dot ranks by inner product where it is supported.

## 3. fts residual strips `$text` recursively, with a hard post-condition (`a218f0b`, hardened by `55f2ef1`)

`ftsResidualFilter` stripped only direct Text children of the top-level `$and`, while detection recurses — so `{"$and":[{"$and":[{"$text":…},…]},…]}` handed the FilterIter a residual still containing the Text node (benign only because `Text.Ok` fails open). The strip now mirrors `knnResidualFilter`, and `detectFtsQuery` asserts `query.ContainsText(residual)` is false, the same guard the knn path has. The review pass also fixed `findTextFilter`'s value-only walk: a programmatic `*query.Text` was silently ignored fail-open, and Text inside pointer composites dodged the placement rejection.

All suites green; each fix's tests verified failing before their fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)