### PR TITLE
btree: writable-aware ReadTx.GetNamespace — same-tx namespace DDL is read-your-writes

### DIFF
--- a/index_snapshot_visibility_test.go
+++ b/index_snapshot_visibility_test.go
@@ -437,11 +437,11 @@ func TestAmbientReopenPendingRangeInvisible(t *testing.T) {
 	assert.False(t, explainHasIndex(explain, "nm"))
 }
 
-// The vector flavor of the mid-tx reopen: the graph namespaces created in
-// this tx resolve only through the writer path, which the vector open (vivf/
-// vindex OpenTx) does not use — the reopen fails cleanly rather than serving
-// a phantom, and after rollback nothing of the index remains.
-func TestAmbientReopenPendingVectorFailsClean(t *testing.T) {
+// The vector flavor of the mid-tx reopen: writable-aware namespace
+// resolution lets the reopen see the tx's own uncommitted graph namespaces,
+// and init's SchemaChanged stamp keeps the reloaded handle invisible to
+// concurrent readers — the phantom never escapes, even across a rollback.
+func TestAmbientReopenPendingVectorInvisible(t *testing.T) {
 	const dim = 8
 	fx := newFixture(t)
 	coll, err := fx.CreateCollection(ctx, "docs")
@@ -459,15 +459,24 @@ func TestAmbientReopenPendingVectorFailsClean(t *testing.T) {
 		Vector: &VectorParams{Field: "v", Dim: dim, Metric: VectorL2, EfSearch: 32},
 	}))
 	require.NoError(t, coll.Close())
-	_, err = fx.OpenCollection(tx.Context(), "docs")
-	require.Error(t, err,
-		"mid-tx reopen with same-tx uncommitted vector DDL must fail, never serve a phantom")
+	coll2, err := fx.OpenCollection(tx.Context(), "docs")
+	require.NoError(t, err)
+
+	// The ambient tx sees its own index through the reloaded handle.
+	hitsTx, err := vsearchCtx(tx.Context(), coll2, "v", vecs[7], 3, 32)
+	require.NoError(t, err)
+	assert.Len(t, hitsTx, 3)
+
+	// A concurrent reader must not: the graph exists only in the writer's
+	// uncommitted view.
+	_, err = vsearchCtx(ctx, coll2, "v", vecs[0], 3, 32)
+	assert.ErrorIs(t, err, ErrIndexNotFound)
+
 	require.NoError(t, tx.Rollback())
 
-	coll3, err := fx.OpenCollection(ctx, "docs")
-	require.NoError(t, err)
-	_, err = vsearchCtx(ctx, coll3, "v", vecs[0], 3, 32)
-	assert.ErrorIs(t, err, ErrNoVectorIndex)
+	// The rolled-back index never becomes visible.
+	_, err = vsearchCtx(ctx, coll2, "v", vecs[0], 3, 32)
+	assert.ErrorIs(t, err, ErrIndexNotFound)
 }
 
 // A stale reader on a redefined index (drop+recreate same name, different

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -1917,12 +1917,24 @@ func (tx *ReadTx) DatabaseSize() uint32 {
 	return tx.pager.readerDbSizeBound(tx.cache)
 }
 
-// GetNamespace returns a Namespace handle for the given name.
-// Uses the transaction's WAL snapshot via getPageReader with the reader's
-// private cache. Safe to call concurrently with the writer goroutine.
+// GetNamespace returns a Namespace handle for the given name, respecting the
+// same page-visibility rule as txGetPage: a write transaction's embedded view
+// resolves through the writer cache and sees its own uncommitted
+// Create/Delete/RenameNamespace — read-your-writes for the master table,
+// matching data reads (SQLite reads sqlite_master through the shared pager
+// cache inside a write tx the same way; the snapshot-bounded master read on a
+// writable view was the drift, and it broke any reopen of namespaces touched
+// earlier in the same tx: resolution returned stale committed roots while
+// page reads took the writer path). A read transaction resolves at its WAL
+// snapshot via getPageReader with the reader's private cache; that branch is
+// safe to call concurrently with the writer goroutine, the writable branch is
+// writer-goroutine-only (the txGetPage contract).
 func (tx *ReadTx) GetNamespace(name string) (*Namespace, error) {
 	if tx.closed {
 		return nil, ErrTxClosed
+	}
+	if tx.writable {
+		return tx.db.getNamespaceLocked(name)
 	}
 	return tx.db.getNamespaceAt(name, tx.walHdr.mxFrame, tx.cache)
 }

--- a/vector_compaction_test.go
+++ b/vector_compaction_test.go
@@ -409,3 +409,118 @@ func TestVectorIndex_CompactAmbientCommit_ConcurrentReader(t *testing.T) {
 	assert.Equal(t, idBytesOf(1), hits[0].DocId)
 	require.NoError(t, fx.IntegrityCheck(ctx))
 }
+
+// Chained same-tx DDL: CreateIndex then CompactVectorIndex in one ambient tx.
+// Requires writable-aware namespace resolution (the compact re-opens the
+// index it created earlier in this same tx). A concurrent reader during the
+// window errors exactly as before the DDL began (nothing committed to serve);
+// after commit the index answers.
+func TestVectorIndex_CreateThenCompactSameTx(t *testing.T) {
+	const dim = 8
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+	vecs := vrand(30, dim, 3)
+	for i, vc := range vecs {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(vecDocJSON(i, vc))))
+	}
+
+	tx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.CreateIndex(tx.Context(), IndexInfo{
+		Name:   "emb",
+		Kind:   IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: dim, Metric: VectorL2, EfSearch: 64},
+	}))
+	require.NoError(t, coll.CompactVectorIndex(tx.Context(), "emb"))
+
+	// The chain's committed tail is nil (created in this tx): a concurrent
+	// reader errors exactly as before the DDL began.
+	_, rerr := vsearch(coll, "v", vecs[0], 3, 64)
+	assert.ErrorIs(t, rerr, ErrIndexNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	hits, err := vsearch(coll, "v", vecs[0], 3, 64)
+	require.NoError(t, err)
+	assert.Len(t, hits, 3)
+}
+
+// Chained same-tx DDL: CompactVectorIndex twice in one ambient tx. The second
+// compact re-opens namespaces the first one re-created (same-tx). A
+// concurrent reader during the whole window is served the ORIGINAL committed
+// handle through the prevTarget committed-tail chain and must see results
+// identical to the pre-tx state.
+func TestVectorIndex_CompactTwiceSameTx(t *testing.T) {
+	const dim = 8
+	const n = 40
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+		Name:   "emb",
+		Kind:   IndexKindVector,
+		Vector: &VectorParams{Field: "v", Dim: dim, Metric: VectorL2, EfSearch: 64},
+	}))
+	vecs := vrand(n, dim, 7)
+	for i, vc := range vecs {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(vecDocJSON(i, vc))))
+	}
+	for i := 0; i < 10; i++ {
+		require.NoError(t, coll.DeleteId(ctx, i))
+	}
+	before, err := vsearch(coll, "v", vecs[n-1], 5, 64)
+	require.NoError(t, err)
+	require.Len(t, before, 5)
+
+	tx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.CompactVectorIndex(tx.Context(), "emb"))
+	// New tombstones inside the tx so the second compact has work.
+	for i := 10; i < 15; i++ {
+		require.NoError(t, coll.DeleteId(tx.Context(), i))
+	}
+	require.NoError(t, coll.CompactVectorIndex(tx.Context(), "emb"))
+
+	// Concurrent reader mid-window: the committed-tail chain serves the
+	// original handle — identical results to the pre-tx state.
+	during, err := vsearch(coll, "v", vecs[n-1], 5, 64)
+	require.NoError(t, err)
+	assert.Equal(t, before, during,
+		"a concurrent reader across chained compacts must see the committed state")
+
+	require.NoError(t, tx.Commit())
+
+	hits, err := vsearch(coll, "v", vecs[n-1], 5, 64)
+	require.NoError(t, err)
+	assert.Len(t, hits, 5)
+}
+
+// The IVF flavor of chained same-tx DDL (vivf.Rebuild re-opens through the
+// same writable-aware resolution).
+func TestVectorIndex_CreateThenCompactSameTxIVF(t *testing.T) {
+	const dim = 8
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "docs")
+	require.NoError(t, err)
+	vecs := vrand(64, dim, 11)
+	for i, vc := range vecs {
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(vecDocJSON(i, vc))))
+	}
+
+	tx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.CreateIndex(tx.Context(), IndexInfo{
+		Name: "emb",
+		Kind: IndexKindVector,
+		Vector: &VectorParams{
+			Field: "v", Dim: dim, Metric: VectorL2, Mode: VectorModeIVFSQ, NProbe: 32,
+		},
+	}))
+	require.NoError(t, coll.CompactVectorIndex(tx.Context(), "emb"))
+	require.NoError(t, tx.Commit())
+
+	hits, err := vsearch(coll, "v", vecs[0], 3, 0)
+	require.NoError(t, err)
+	assert.Len(t, hits, 3)
+}


### PR DESCRIPTION
A write transaction's embedded view resolved the master table snapshot-bounded while its page reads took the writer path (`txGetPage` branches on `writable`; `GetNamespace` did not). Any reopen of namespaces touched earlier in the same tx therefore got stale committed roots over current pages. `vindex.Compact`/`vivf.Rebuild` open through `&wtx.ReadTx`, so chained same-tx vector DDL failed: create-then-compact → `namespace not found`, compact-twice → `key not found` on the freed old roots.

Fix: `ReadTx.GetNamespace` mirrors `txGetPage` — writable → `getNamespaceLocked` (writer cache, writer-goroutine-only, the existing contract), reader → snapshot-bounded as before. SQLite parity: a write tx reads sqlite_master through the shared pager cache and sees its own uncommitted schema; the snapshot-bounded master read on a writable view was the drift.

Also unlocked, with visibility verified:
- **Mid-tx collection reopen after same-tx vector DDL** now works (previously failed clean): init's SchemaChanged stamp (#142) keeps the reloaded handle invisible to concurrent readers, verified across rollback.
- **The committed-tail prev chain from #142 is exercised end-to-end**: a concurrent reader across chained compacts sees results identical to the committed state.

Tests: create→compact and compact→compact in one ambient tx (HNSW + IVF-SQ flavor), the rewritten ambient-reopen vector test, concurrent-reader visibility asserts throughout. Full any-store suite + race green; any-store-tests multiprocess vector/fts + crash-fuzz storetest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)