### PR TITLE
qplanner: unindexed-sort raw key path + covering filter elision

### DIFF
--- a/index_cover_elision_test.go
+++ b/index_cover_elision_test.go
@@ -1,0 +1,90 @@
+package anystore
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+func TestIndexScanCoveringFilterElision(t *testing.T) {
+	newColl := func(t *testing.T, fx *fixture, arrayB bool) Collection {
+		coll, err := fx.CreateCollection(ctx, "test")
+		require.NoError(t, err)
+		require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{"a", "b"}}))
+		var docs []*anyenc.Value
+		for i := 0; i < 500; i++ {
+			var doc string
+			if arrayB {
+				doc = fmt.Sprintf(`{"id":%d,"a":%d,"b":[%d,%d],"pad":"%s"}`, i, (7*i)%500, i%10, (i+3)%10, sortPad)
+			} else {
+				doc = fmt.Sprintf(`{"id":%d,"a":%d,"b":%d,"pad":"%s"}`, i, (7*i)%500, i%10, sortPad)
+			}
+			docs = append(docs, anyenc.MustParseJson(doc))
+		}
+		require.NoError(t, coll.Insert(ctx, docs...))
+		return coll
+	}
+
+	for _, arrayB := range []bool{false, true} {
+		name := "scalar-b"
+		if arrayB {
+			name = "multikey-b" // per-entry equality + DocDedup must stand in for the residual
+		}
+		t.Run(name, func(t *testing.T) {
+			fx := newFixture(t)
+			coll := newColl(t, fx, arrayB)
+
+			elided := coll.Find(`{"b":5}`).Sort("a").Limit(100)
+			shadow := coll.Find(`{"$and":[{"b":5},{"id":{"$exists":true}}]}`).Sort("a").Limit(100)
+			got := collectIds(t, elided)
+			want := collectIds(t, shadow)
+			require.NotEmpty(t, want)
+			assert.Equal(t, want, got)
+
+			// No duplicate ids (multikey entries must still dedup without the
+			// residual filter).
+			seen := map[int]bool{}
+			for _, id := range got {
+				assert.False(t, seen[id], "duplicate id %d", id)
+				seen[id] = true
+			}
+
+			// The covered scalar plan must have IndexFilter and no residual
+			// Filter. A multikey (a,b) index gets no sort-service scan
+			// candidate at all (array order is plan-dependent), so the elided
+			// chain is unreachable there — only the differential equality
+			// above applies.
+			ex, err := elided.Explain(ctx)
+			require.NoError(t, err)
+			if !arrayB && assert.Contains(t, ex.Sql, "IndexFilter") {
+				assert.NotContains(t, ex.Sql, "-> Filter ", "residual filter must be elided: %s", ex.Sql)
+				assert.False(t, strings.HasSuffix(ex.Sql, "-> Filter") || strings.Contains(ex.Sql, "-> Filter -"),
+					"residual filter must be elided: %s", ex.Sql)
+			}
+		})
+	}
+
+	t.Run("negative gates keep the residual", func(t *testing.T) {
+		fx := newFixture(t)
+		coll := newColl(t, fx, false)
+
+		for _, tc := range []struct{ name, filter string }{
+			{"uncovered extra field", `{"b":5,"pad":{"$exists":true}}`},
+			{"two predicates on b", `{"b":{"$gte":5,"$lte":5}}`},
+			{"in with two values", `{"b":{"$in":[5,6]}}`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ex, err := coll.Find(tc.filter).Sort("a").Limit(100).Explain(ctx)
+				require.NoError(t, err)
+				if strings.Contains(ex.Sql, "IndexFilter") {
+					assert.Contains(t, ex.Sql, "-> Filter", "residual must stay for %s: %s", tc.filter, ex.Sql)
+				}
+			})
+		}
+	})
+}

--- a/index_query_test.go
+++ b/index_query_test.go
@@ -2547,7 +2547,7 @@ func TestIndex_LimitOffset_OffsetLargerThanResultSet_InMemorySort(t *testing.T) 
 	t.Run("offset_equals_size", func(t *testing.T) {
 		ex, err := coll.Find(nil).Sort("a").Offset(10).Limit(5).Explain(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "FullScan(filtered) -> TopK(15) -> Limit(offset=10,limit=5)", ex.Sql)
+		assert.Equal(t, "FullScan -> TopK(15) -> Limit(offset=10,limit=5)", ex.Sql)
 
 		got := collectA(coll.Find(nil).Sort("a").Offset(10).Limit(5))
 		assert.Len(t, got, 0)
@@ -2563,7 +2563,7 @@ func TestIndex_LimitOffset_OffsetLargerThanResultSet_InMemorySort(t *testing.T) 
 	t.Run("limit_larger_than_result", func(t *testing.T) {
 		ex, err := coll.Find(nil).Sort("a").Limit(100).Explain(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "FullScan(filtered) -> TopK(100) -> Limit(100)", ex.Sql)
+		assert.Equal(t, "FullScan -> TopK(100) -> Limit(100)", ex.Sql)
 
 		got := collectA(coll.Find(nil).Sort("a").Limit(100))
 		assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, got)
@@ -2617,7 +2617,7 @@ func TestIndex_LimitOffset_TopKStability_DuplicateKeys_NonIndexedSort(t *testing
 		// Confirm the eviction-active TopK path is taken (15 < 30 rows).
 		ex, err := coll.Find(nil).Sort("a").Offset(7).Limit(8).Explain(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "FullScan(filtered) -> TopK(15) -> Limit(offset=7,limit=8)", ex.Sql)
+		assert.Equal(t, "FullScan -> TopK(15) -> Limit(offset=7,limit=8)", ex.Sql)
 
 		run1 := collectIDs(coll.Find(nil).Sort("a").Offset(7).Limit(8))
 		run2 := collectIDs(coll.Find(nil).Sort("a").Offset(7).Limit(8))
@@ -2725,7 +2725,7 @@ func TestIndex_LimitOffset_ExplainTokens_TopKvsSort(t *testing.T) {
 
 		ex, err := coll.Find(nil).Sort("a").Limit(5).Explain(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "FullScan(filtered) -> TopK(5) -> Limit(5)", ex.Sql)
+		assert.Equal(t, "FullScan -> TopK(5) -> Limit(5)", ex.Sql)
 		assert.Contains(t, ex.Sql, "TopK(5)")
 		assert.NotContains(t, ex.Sql, "-> Sort")
 
@@ -2744,7 +2744,7 @@ func TestIndex_LimitOffset_ExplainTokens_TopKvsSort(t *testing.T) {
 
 		ex, err := coll.Find(nil).Sort("a").Explain(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "FullScan(filtered) -> Sort", ex.Sql)
+		assert.Equal(t, "FullScan -> Sort", ex.Sql)
 		assert.Contains(t, ex.Sql, "-> Sort")
 		assert.NotContains(t, ex.Sql, "TopK")
 	})
@@ -2760,7 +2760,7 @@ func TestIndex_LimitOffset_ExplainTokens_TopKvsSort(t *testing.T) {
 
 		ex, err := coll.Find(nil).Sort("-a").Offset(5).Limit(5).Explain(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "FullScan(filtered) -> TopK(10) -> Limit(offset=5,limit=5)", ex.Sql)
+		assert.Equal(t, "FullScan -> TopK(10) -> Limit(offset=5,limit=5)", ex.Sql)
 		assert.Contains(t, ex.Sql, "TopK(10)")
 		assert.NotContains(t, ex.Sql, "-> Sort")
 	})

--- a/internal/qplanner/fullscan_iter.go
+++ b/internal/qplanner/fullscan_iter.go
@@ -23,6 +23,11 @@ type FullScanIter struct {
 	Offset   int // batch-skip offset (only when Filter == nil)
 	Reverse  bool
 	started  bool
+	// RawForSort hands each row's decoded document bytes to the SortIter
+	// directly above via Plan.DocRaw instead of parsing it — the sort key is
+	// then extracted by the RawSort seek path. Set by the planner only for a
+	// filterless (nil/match-all) full scan feeding a RawSort sorter.
+	RawForSort bool
 	// rawFilter is Filter's RawFilter fast path, resolved once on the first
 	// Next (see checkFilter). nil when Filter doesn't implement it. The raw
 	// walk only pays off on REJECTED documents (accepted ones still get the
@@ -98,7 +103,7 @@ func (it *FullScanIter) nextNoBounds() (key []byte, docId []byte, multiKey bool,
 					return nil, nil, false, err
 				}
 				// FullScan walks the data namespace; docId is the primary key — unique by construction.
-			return k, k, false, nil
+				return k, k, false, nil
 			}
 		} else {
 			if it.Reverse {
@@ -255,6 +260,20 @@ func (it *FullScanIter) advanceBound() {
 
 func (it *FullScanIter) checkFilter() (ok bool, err error) {
 	if it.Filter == nil {
+		if it.RawForSort && it.Plan != nil {
+			// Load the row at the cursor and hand the decoded bytes to the
+			// SortIter above. A decode error leaves DocRaw nil: SortIter then
+			// falls back to its own point-lookup path, which reproduces the
+			// error handling of the non-raw pipeline.
+			it.Buf.DocBuf, err = it.cursor.AppendValue(it.Buf.DocBuf[:0])
+			if err != nil {
+				return false, err
+			}
+			it.Plan.DocRaw = nil
+			if raw, derr := it.Buf.Parser.DecodedDoc(it.Buf.DocBuf); derr == nil {
+				it.Plan.DocRaw = raw
+			}
+		}
 		return true, nil
 	}
 	it.Buf.DocBuf, err = it.cursor.AppendValue(it.Buf.DocBuf[:0])

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -1544,7 +1544,13 @@ func buildIndexScanChain(params *PlanParams, idx *CBOIndex, needFilter bool) Ite
 		Buf:    params.Buf,
 	}
 
-	if needFilter {
+	// Covering elision: when the index-side checks (bound prefix +
+	// IndexFilterIter equality fields) fully and exactly represent the
+	// filter, the FilterIter re-evaluation is redundant per accepted entry.
+	// Same principle as the covering count elision in buildIndexSeekChain;
+	// SQLite analog: index-consumed WHERE terms are TERM_CODED and never
+	// re-evaluated.
+	if needFilter && !indexScanCoversFilter(idx, coverFilters, params.Filter) {
 		root = &FilterIter{
 			Source: root,
 			Data:   scanDataSrc,
@@ -1700,6 +1706,40 @@ func indexCoversFilter(idx *CBOIndex, filter query.Filter) bool {
 	// And.IndexBounds then over-approximates and the fast path skips the
 	// FilterIter that would trim the result.
 	for _, field := range boundedFields {
+		if countFilterFieldPreds(filter, field) > 1 {
+			return false
+		}
+	}
+	return true
+}
+
+// indexScanCoversFilter reports whether an ordered-scan chain's index-side
+// checks fully and exactly represent filter, making the post-fetch FilterIter
+// redundant. Two enforcement channels cover a field: the contiguous bound
+// prefix (enforced by IndexIter's Bounds, exactly like indexCoversFilter) and
+// the IndexFilterIter equality fields (byte-equality on the stored key value;
+// coveringFilterFields only emits a field when its bounds are a single fixed
+// point, i.e. the predicate's exact image). Entry-level equality implies
+// doc-level match under array-element semantics, and per-doc duplicates are
+// handled by the dedup wraps that are present regardless of the FilterIter.
+// The single-predicate condition rejects fields whose combined bounds
+// over-approximate (see indexCoversFilter condition 2).
+func indexScanCoversFilter(idx *CBOIndex, coverFilters []IndexFieldFilter, filter query.Filter) bool {
+	if filter == nil || len(coverFilters) == 0 {
+		return false
+	}
+	var fields []string
+	if len(idx.Bounds) > 0 {
+		fields = append(fields, idx.Info.FieldNames[:min(idx.BoundFields, len(idx.Info.FieldNames))]...)
+	}
+	for _, f := range coverFilters {
+		fields = append(fields, idx.Info.FieldNames[f.FieldIdx])
+	}
+	hasFields := false
+	if ok := filterFieldsCoveredBy(filter, fields, &hasFields); !ok || !hasFields {
+		return false
+	}
+	for _, field := range fields {
 		if countFilterFieldPreds(filter, field) > 1 {
 			return false
 		}

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -49,6 +49,12 @@ type Plan struct {
 	Root      Iterator
 	DocParsed *anyenc.Value // set by FilterIter/FetchIter/FullScanIter after parsing
 
+	// DocRaw is the current row's decoded (s2-decompressed) document bytes,
+	// set by a RawForSort FullScanIter instead of parsing. Consumed — and
+	// cleared — by SortIter's raw sort-key path. Valid only until the next
+	// row's decode: the bytes live in the parser's decode buffer.
+	DocRaw []byte
+
 	// Distances is the per-document ANN distance sidecar for a vector query
 	// (docId bytes -> distance). Populated by VectorIter; consumed by the
 	// public iterator's Distance(). nil for non-vector plans.
@@ -1237,6 +1243,19 @@ func buildFullScanChain(params *PlanParams, needFilter, needSort bool) Iterator 
 	}
 
 	if needSort && !idSorted {
+		// Filterless (nil/match-all) scan feeding a raw-capable sorter: the
+		// installed match-all filter would force a full parse of every row
+		// only to read the sort fields. Drop it and let the scan hand decoded
+		// bytes to the SortIter (Plan.DocRaw), whose RawSort path seeks just
+		// the sort fields. Rows are only ever accepted either way.
+		if !needFilter {
+			if fsi, isScan := root.(*FullScanIter); isScan {
+				if _, isRaw := params.Sorter.(query.RawSort); isRaw {
+					fsi.Filter = nil
+					fsi.RawForSort = true
+				}
+			}
+		}
 		root = &SortIter{
 			Source: root,
 			Data: &CursorSource{

--- a/internal/qplanner/sort_iter.go
+++ b/internal/qplanner/sort_iter.go
@@ -42,9 +42,9 @@ type SortIter struct {
 	// liveBytes is the sum of keyLen over the entries currently in the heap.
 	// Used by the compaction guard to detect when arena waste (dead bytes left
 	// by evicted entries whose slot could not be reused in place) is large.
-	liveBytes int
-	order     []int // reusable scratch: live-entry indices sorted by arena offset (compaction)
-	PartiallySorted bool // leading index fields match sort order; pdqsort benefits automatically
+	liveBytes       int
+	order           []int // reusable scratch: live-entry indices sorted by arena offset (compaction)
+	PartiallySorted bool  // leading index fields match sort order; pdqsort benefits automatically
 	inited          bool
 	// rawSorter is Sorter's RawSort fast path, resolved once in collectAndSort.
 	// When the source yields no pre-parsed document, the sort key is built by
@@ -63,10 +63,10 @@ type SortIter struct {
 const sortRawFallbackMax = 8
 
 type sortEntry struct {
-	off      uint32 // offset into arena
-	keyLen   uint16 // total length (sort key + docId suffix)
-	docLen   uint16 // docId length (trailing portion)
-	multiKey uint8  // 1 = upstream marked this entry multiKey; 0 = unique. Forwarded as-is on emit so consumer-side DocDedup can skip the seen-set for unique streams.
+	off      uint32   // offset into arena
+	keyLen   uint16   // total length (sort key + docId suffix)
+	docLen   uint16   // docId length (trailing portion)
+	multiKey uint8    // 1 = upstream marked this entry multiKey; 0 = unique. Forwarded as-is on emit so consumer-side DocDedup can skip the seen-set for unique streams.
 	_        [3]uint8 // explicit padding so the struct size stays predictable across archs
 }
 
@@ -88,9 +88,10 @@ func (it *SortIter) Next() (key []byte, docId []byte, multiKey bool, err error) 
 
 	// Clear DocParsed so planIterator.Doc() does a lazy fetch by docId.
 	// collectAndSort() leaves DocParsed pointing at the last collected doc,
-	// which is NOT the doc for this sorted entry.
+	// which is NOT the doc for this sorted entry. DocRaw likewise.
 	if it.Plan != nil {
 		it.Plan.DocParsed = nil
+		it.Plan.DocRaw = nil
 	}
 
 	return docId, docId, e.multiKey == 1, nil
@@ -172,15 +173,22 @@ func (it *SortIter) collectAndSort() error {
 		doc := it.Plan.DocParsed
 		var raw []byte
 		if doc == nil {
-			// Cursor-free point lookup: avoids Cursor allocation
-			var verr error
-			it.Buf.DocBuf, verr = it.Data.AppendValue(docId, it.Buf.DocBuf[:0])
-			if verr != nil {
-				continue
-			}
-			if it.rawSorter != nil {
-				if d, derr := it.Buf.Parser.DecodedDoc(it.Buf.DocBuf); derr == nil {
-					raw = d
+			// Decoded bytes handed over by a RawForSort FullScanIter: the
+			// scan cursor already read the row, so no point lookup is needed.
+			if it.Plan.DocRaw != nil {
+				raw = it.Plan.DocRaw
+				it.Plan.DocRaw = nil
+			} else {
+				// Cursor-free point lookup: avoids Cursor allocation
+				var verr error
+				it.Buf.DocBuf, verr = it.Data.AppendValue(docId, it.Buf.DocBuf[:0])
+				if verr != nil {
+					continue
+				}
+				if it.rawSorter != nil {
+					if d, derr := it.Buf.Parser.DecodedDoc(it.Buf.DocBuf); derr == nil {
+						raw = d
+					}
 				}
 			}
 		}

--- a/sort_rawscan_test.go
+++ b/sort_rawscan_test.go
@@ -1,0 +1,105 @@
+package anystore
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// The tests below differentially verify the two sort fast paths against
+// equivalent queries that cannot take them:
+//   - a filterless full scan + sort hands decoded bytes to SortIter
+//     (Plan.DocRaw + RawSort) instead of parsing every row;
+//   - an ordered index scan whose IndexFilterIter equality checks fully cover
+//     the filter elides the post-fetch FilterIter.
+// The shadow query carries an extra $exists conjunct on the pk, which every
+// document satisfies but no index covers — forcing the parsed/filtered path
+// while selecting the same documents.
+
+// pad pushes every document above the 256-byte compression threshold so the
+// raw path exercises s2-decoded bytes, matching production-shaped documents.
+var sortPad = strings.Repeat("x", 300)
+
+func sortFastpathFixture(t *testing.T, arrayVal bool) (*fixture, Collection) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	// 7i mod 101 permutes 0..100: unique scalar sort keys, insertion order
+	// decorrelated from key order.
+	var docs []*anyenc.Value
+	for i := 0; i < 101; i++ {
+		v := (7 * i) % 101
+		var doc string
+		if arrayVal {
+			doc = fmt.Sprintf(`{"id":%d,"val":[%d,%d],"pad":"%s"}`, i, v, (v+13)%101, sortPad)
+		} else {
+			doc = fmt.Sprintf(`{"id":%d,"val":%d,"pad":"%s"}`, i, v, sortPad)
+		}
+		docs = append(docs, anyenc.MustParseJson(doc))
+	}
+	require.NoError(t, coll.Insert(ctx, docs...))
+	return fx, coll
+}
+
+func collectIds(t *testing.T, q Query) []int {
+	iter, err := q.Iter(ctx)
+	require.NoError(t, err)
+	defer iter.Close()
+	var ids []int
+	for iter.Next() {
+		doc, err := iter.Doc()
+		require.NoError(t, err)
+		ids = append(ids, doc.Value().GetInt("id"))
+	}
+	require.NoError(t, iter.Err())
+	return ids
+}
+
+func TestSortRawScan_MatchesParsedPath(t *testing.T) {
+	for _, arrayVal := range []bool{false, true} {
+		name := "scalar"
+		if arrayVal {
+			name = "array" // array sort field: raw path must fall back to parse
+		}
+		t.Run(name, func(t *testing.T) {
+			_, coll := sortFastpathFixture(t, arrayVal)
+
+			cases := []struct {
+				sort          string
+				limit, offset uint
+			}{
+				{"val", 10, 0},
+				{"-val", 10, 0},
+				{"val", 10, 25},
+				{"val", 0, 0},  // full sort (TopK disabled)
+				{"-val", 0, 0}, // full sort desc
+			}
+			for _, tc := range cases {
+				t.Run(fmt.Sprintf("sort=%s limit=%d offset=%d", tc.sort, tc.limit, tc.offset), func(t *testing.T) {
+					raw := coll.Find(nil).Sort(tc.sort)
+					shadow := coll.Find(`{"id":{"$exists":true}}`).Sort(tc.sort)
+					if tc.limit > 0 {
+						raw, shadow = raw.Limit(tc.limit), shadow.Limit(tc.limit)
+					}
+					if tc.offset > 0 {
+						raw, shadow = raw.Offset(tc.offset), shadow.Offset(tc.offset)
+					}
+					got := collectIds(t, raw)
+					want := collectIds(t, shadow)
+					require.NotEmpty(t, want)
+					assert.Equal(t, want, got)
+				})
+			}
+
+			// The fast path must actually be planned: filterless scan + sort.
+			ex, err := coll.Find(nil).Sort("val").Limit(10).Explain(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "FullScan -> TopK(10) -> Limit(10)", ex.Sql)
+		})
+	}
+}


### PR DESCRIPTION
Two sort fast paths, born from profiling the unindexed-sort gap vs the SQLite-backed engine:

- **Raw sort-key path for filterless scan+sort.** `Find(nil)+Sort` internally installs a match-all filter, which forced a full parse of every scanned row just to read the sort fields — keeping SortIter's existing RawSort seek path unreachable. The planner now drops the trivial filter and the scan hands each row's decoded bytes to SortIter via `Plan.DocRaw` (no per-row point lookup); the sort key is seeked from the raw document. Unindexed sort over the 500k golden bench: **444ms → 216ms (2.06x)**, now ~1.8x faster than the SQLite-engine baseline; allocs unchanged. Array sort fields fall back to the parsed path as before.
- **Covering FilterIter elision on ordered index scans.** When the bound prefix plus IndexFilterIter's fixed-point equality checks fully and exactly represent the filter (same conditions as the covering-count elision), the post-fetch re-evaluation is dead work and is dropped. Multikey indexes get no sort-service scan candidates, so per-entry verdict divergence cannot reach the elided chain.

Both paths are differentially tested against shadow queries forced onto the old path (identical results for scalar/array sort fields, asc/desc, TopK/full-sort, offset; multikey equality + dedup; negative gates keeping the residual). Full root suite, qplanner suite, any-store-tests `make test-all`, and the sort/filter_sort/fullscan bench groups are green with no regressions outside the target scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)