### PR TITLE
Spare fresh collection handles from read-tx staleness-pass invalidation

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -166,6 +166,18 @@ type collection struct {
 	// the token with the collection).
 	catalogID []byte
 
+	// validFromCookie is the earliest schema cookie at which this handle's
+	// registered name is KNOWN to resolve to this collection on disk: the
+	// snapshot cookie at open, the commit cookie (begin+1) at create, and
+	// re-stamped to the commit cookie by Rename's publication. Same contract
+	// as index.validFromCookie. The staleness pass consults it: a read tx
+	// whose snapshot predates this bound cannot judge existence — the catalog
+	// key is legitimately absent there — and must skip the handle instead of
+	// invalidating it (see reconcileIndexSet). Atomic because Rename's commit
+	// publication stores it while lock-free staleness passes read it; taking
+	// c.mu there would invert the c.mu→db.mu order Rename establishes.
+	validFromCookie atomic.Uint32
+
 	// primaryKey is the document field whose value is the btree key. Resolved
 	// once in init (default "id") and never mutated after, so the data and query
 	// paths read it lock-free.
@@ -320,6 +332,11 @@ func (c *collection) init(ctx context.Context, wtx *btree.WriteTx) error {
 		if wtx != nil && wtx.SchemaChanged() {
 			validFrom++
 		}
+		// The collection handle carries the same bound: for a create-in-flight
+		// (CreateCollection marks schema changed before init) this is the
+		// commit cookie, keeping the handle out of reach of staleness passes
+		// whose snapshot predates the create.
+		c.validFromCookie.Store(validFrom)
 		for _, info := range idxInfos {
 			if isFulltext(info) {
 				fx, fErr := newFtsIndex(c, info)
@@ -1382,7 +1399,14 @@ func (c *collection) Rename(ctx context.Context, newName string) error {
 		// handles — root pages are unchanged and nothing derives keys from
 		// their stale internal names; fts pending buffers flush at commit
 		// through those handles into the renamed namespaces.
+		renameValidFrom := tx.DiskSchemaCookie() + 1
 		wtx.onCommitPublish(func() {
+			// The registry key flips to newName, which resolves only in
+			// snapshots at or past this commit: raise the handle's visibility
+			// bound so an older-snapshot staleness pass skips it instead of
+			// invalidating a just-renamed live handle (keyNotFound on the new
+			// name). See reconcileIndexSet.
+			c.validFromCookie.Store(renameValidFrom)
 			c.db.mu.Lock()
 			if cur, ok := c.db.openedCollections[oldName]; ok && cur == Collection(c) {
 				delete(c.db.openedCollections, oldName)

--- a/db.go
+++ b/db.go
@@ -476,14 +476,33 @@ func (db *db) ReadTx(ctx context.Context) (ReadTx, error) {
 //	  sketches over the (now reconciled) index set. A stale sketch only affects
 //	  which index the planner CHOOSES, never query RESULTS (the any-store analog
 //	  of sqlite_stat1), so it runs strictly after the structural reconcile.
+// The begin-time disk counters driving the verdict are RAISED to the newest
+// committed frame (see btree.ReadTx.SnapshotHeaderCounters), so a read tx can
+// detect staleness its own snapshot does not yet contain — a begin racing a
+// commit, or a reader slot pinned behind. The pass therefore reconciles and
+// consumes only up to the SNAPSHOT counters: reconciling judges what this
+// snapshot can see, and recording anything newer as consumed would mark DDL
+// as reconciled that never was — later txs (including writers) would trust an
+// index set missing a peer's index and stop maintaining it. Left short, the
+// verdict stays stale and the next begin (with a newer snapshot) converges.
 func (db *db) checkStale(tx *btree.ReadTx) {
+	if !tx.IsSchemaStale() && !tx.IsDataStale() {
+		return
+	}
+	snapFCC, snapSC := tx.DiskFileChangeCounter(), tx.DiskSchemaCookie()
+	if !tx.IsWriteTx() {
+		var err error
+		if snapFCC, snapSC, err = tx.SnapshotHeaderCounters(); err != nil {
+			// Cannot bound the snapshot: reconcile nothing, consume nothing —
+			// the verdict stays stale and the next begin retries.
+			return
+		}
+	}
 	if tx.IsSchemaStale() {
-		db.reconcileIndexSet(tx)
+		db.reconcileIndexSet(tx, snapSC)
 	}
-	if tx.IsSchemaStale() || tx.IsDataStale() {
-		db.reloadSketches(tx)
-		db.btreeDB.UpdateLocalCounters(tx.DiskFileChangeCounter(), tx.DiskSchemaCookie())
-	}
+	db.reloadSketches(tx)
+	db.btreeDB.UpdateLocalCounters(snapFCC, snapSC)
 }
 
 // reconcileIndexSet rebuilds the in-memory index set of every open collection
@@ -495,7 +514,7 @@ func (db *db) checkStale(tx *btree.ReadTx) {
 // collection is reconciled under its own c.mu and the result published
 // atomically (copy-on-write), so lock-free query readers always observe a
 // complete index generation.
-func (db *db) reconcileIndexSet(tx *btree.ReadTx) {
+func (db *db) reconcileIndexSet(tx *btree.ReadTx, snapCookie uint32) {
 	type namedColl struct {
 		name string
 		c    *collection
@@ -519,6 +538,19 @@ func (db *db) reconcileIndexSet(tx *btree.ReadTx) {
 			// checking c.name against this tx's older snapshot would
 			// spuriously invalidate the handle, and reconciling its index
 			// set under the flipped name would publish an empty one.
+			continue
+		}
+		if !tx.IsWriteTx() && snapCookie < nc.c.validFromCookie.Load() {
+			// The snapshot predates the handle's visibility bound: a create
+			// or rename committed after — or is still committing while —
+			// this reader began, so its catalog key is legitimately absent
+			// here. Judging existence needs a snapshot at or past the bound
+			// (same tolerance rule as index.forTx); skip. snapCookie is the
+			// SNAPSHOT cookie, not the raised begin-time one — the raised
+			// value can exceed what this tx's reads see and would let the
+			// vanished check judge a handle whose catalog key sits in frames
+			// past the snapshot. A write tx always sees latest state and
+			// needs no skip.
 			continue
 		}
 		if db.collectionVanished(tx, nc.name, nc.c) {

--- a/docs/btree/NOTES.md
+++ b/docs/btree/NOTES.md
@@ -2436,6 +2436,20 @@ tracking: a caller who forgets to call `MarkDataChanged`/`MarkSchemaChanged` wil
 cross-process change counters unbumped, so other connections' staleness checks silently fail
 to observe the change.
 
+A second divergence inside this surface: the begin-time counters behind
+`DiskFileChangeCounter`/`DiskSchemaCookie` are read with the frame bound RAISED to the newest
+committed frame (`pager.readHeaderCounters`), so a begin racing a commit — or a reader slot
+pinned behind — reports counters its own snapshot cannot see. SQLite has no such raise:
+`sqlite3BtreeBeginTrans` returns the cookie from the transaction's own page 1
+(`sqlitec/src/btree.c:3785-3786`), and the `SQLITE_SCHEMA` reload consumes the cookie read
+through that same transaction (`sqlitec/src/prepare.c:288,293`) — detection, reload, and
+consumption are all snapshot-bounded. The raise is kept for cross-process staleness
+detection, but judgments about snapshot contents and the post-reconcile counter consumption
+must use `ReadTx.SnapshotHeaderCounters` (frame bound = the tx's own `walMaxFrame`), which
+restores the SQLite-aligned semantics; consuming the raised counters would mark peer DDL as
+reconciled that the reconcile snapshot never contained, silently detaching later write
+transactions from a peer-created index.
+
 <a id="drift-47-checkpoint-omits-open-transaction-guard"></a>
 ### Drift: Checkpoint Omits Open Transaction Guard
 - **Category:** changed-logic  -  **Severity:** low

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -890,6 +890,7 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 	// Dual-write during per-connection-hdr migration. Step 5 will remove
 	// walMaxFrame; until then, tests still read it directly.
 	tx.walMaxFrame = maxFrame
+	tx.walMinFrame = minFrame
 	tx.walHdr = snapHdr
 	tx.walSlot = slot
 	tx.diskFileChangeCounter = fcc
@@ -1016,6 +1017,9 @@ func (db *DB) BeginWrite() (*WriteTx, error) {
 	tx.ReadTx.cache = nil // writer uses shared pcache, not a reader cache
 	tx.ReadTx.closed = false
 	tx.ReadTx.walMaxFrame = maxFrame
+	// Writers hold the write lock, so no restart can race: the live floor
+	// captured here stays valid for the tx's life.
+	tx.ReadTx.walMinFrame = db.pager.wal.index.liveMinFrame()
 	// Reuse the readSnap hdr captured above for BUSY_SNAPSHOT. In-process
 	// mode has readSnap=zero; synthesize minimal hdr so read paths consuming
 	// walHdr.mxFrame see the correct frame ceiling.
@@ -1511,6 +1515,11 @@ type ReadTx struct {
 	cache       *pcache // per-reader private page cache (nil for write transactions)
 	walSlot     int     // reader slot number (for endRead)
 	walMaxFrame uint32  // WAL snapshot for this transaction (TODO: migrate to walHdr.mxFrame)
+	// walMinFrame is the snapshot's checkpoint-frontier floor, captured at
+	// begin like SQLite's pWal->minFrame (slot-0: maxFrame+1). Fixed for the
+	// tx's life so a WAL restart cannot recycle new-generation frame numbers
+	// into the snapshot's [min, max] window — see wal.beginReadHdr.
+	walMinFrame uint32
 	// walHdr is the full SHM header snapshot captured at BeginRead time.
 	// Populated in parallel with walMaxFrame.
 	walHdr WalIndexHdr
@@ -1962,7 +1971,9 @@ func (tx *ReadTx) DiskSchemaCookie() uint32 {
 }
 
 // SnapshotHeaderCounters returns the page-1 FileChangeCount and SchemaCookie
-// as of THIS tx's snapshot (bounded by its walMaxFrame). Unlike
+// as of THIS tx's snapshot (bounded by its begin-captured
+// [walMinFrame, walMaxFrame] window, both sides fixed for the tx's life —
+// SQLite's pWal->minFrame/mxFrame). Unlike
 // DiskFileChangeCounter/DiskSchemaCookie — whose begin-time read is raised to
 // the newest committed frame so staleness detection notices peer commits —
 // these values never exceed what the tx's tree reads can actually see: a
@@ -1974,7 +1985,7 @@ func (tx *ReadTx) SnapshotHeaderCounters() (fileChangeCount, schemaCookie uint32
 	if tx.closed {
 		return 0, 0, ErrTxClosed
 	}
-	return tx.pager.readHeaderCountersAt(tx.walHdr.mxFrame)
+	return tx.pager.readHeaderCountersAt(tx.walHdr.mxFrame, tx.walMinFrame)
 }
 
 // Rollback ends the read transaction (for ReadTx, this is the same as commit).

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -1961,6 +1961,22 @@ func (tx *ReadTx) DiskSchemaCookie() uint32 {
 	return tx.diskSchemaCookie
 }
 
+// SnapshotHeaderCounters returns the page-1 FileChangeCount and SchemaCookie
+// as of THIS tx's snapshot (bounded by its walMaxFrame). Unlike
+// DiskFileChangeCounter/DiskSchemaCookie — whose begin-time read is raised to
+// the newest committed frame so staleness detection notices peer commits —
+// these values never exceed what the tx's tree reads can actually see: a
+// begin that raced a commit, or a reader slot pinned to an older snapshot,
+// reports the older counters here. Judgments about snapshot contents (e.g.
+// whether a catalog key committed at cookie C must be visible) require this
+// bound, not the raised one.
+func (tx *ReadTx) SnapshotHeaderCounters() (fileChangeCount, schemaCookie uint32, err error) {
+	if tx.closed {
+		return 0, 0, ErrTxClosed
+	}
+	return tx.pager.readHeaderCountersAt(tx.walHdr.mxFrame)
+}
+
 // Rollback ends the read transaction (for ReadTx, this is the same as commit).
 func (tx *ReadTx) Rollback() error {
 	if tx.closed {

--- a/internal/btree/pager.go
+++ b/internal/btree/pager.go
@@ -2107,22 +2107,28 @@ func (p *pager) readHeaderCounters(walMaxFrame uint32) (fileChangeCount, schemaC
 	} else if hdr, valid := p.wal.index.readHeader(); valid && hdr.mxFrame > effectiveMaxFrame {
 		effectiveMaxFrame = hdr.mxFrame
 	}
-	return p.readHeaderCountersAt(effectiveMaxFrame)
+	return p.readHeaderCountersAt(effectiveMaxFrame, p.wal.index.liveMinFrame())
 }
 
 // readHeaderCountersAt is readHeaderCounters WITHOUT the raise to the latest
-// committed frame: it reads page 1 strictly as of maxFrame, so a reader tx
-// passing its own walMaxFrame gets the counters its snapshot actually
-// contains. readHeaderCounters raises the bound to discover the true WAL
-// state for STALENESS DETECTION — the raised counters may exceed what the
-// caller's snapshot can see, and must not be used to judge snapshot contents.
-func (p *pager) readHeaderCountersAt(effectiveMaxFrame uint32) (fileChangeCount, schemaCookie uint32, err error) {
+// committed frame: it reads page 1 strictly within [minFrame, maxFrame], so
+// a reader tx passing its begin-captured bounds gets the counters its
+// snapshot actually contains. Both sides matter: the max side excludes
+// commits past the snapshot; the min side must be the snapshot's captured
+// floor, NOT liveMinFrame (see its doc) — a WAL restart racing a slot-0
+// reader recycles new-generation frame numbers below the old maxFrame, and
+// a live floor would admit them, serving post-restart counters.
+// readHeaderCounters raises the max bound (and may use the live floor: its
+// callers hold no snapshot to protect) to discover the true WAL state for
+// STALENESS DETECTION — those counters may exceed what a snapshot can see,
+// and must not be used to judge snapshot contents.
+func (p *pager) readHeaderCountersAt(effectiveMaxFrame, minFrame uint32) (fileChangeCount, schemaCookie uint32, err error) {
 	// Look up page 1's latest frame.
 	// walIndex.get() merges the local page map with SHM, preferring newer SHM
 	// frames. After an external state change, beginWrite rebuilds the local page
 	// map from the WAL so page-1 refreshes do not depend solely on SHM hashes.
 	if effectiveMaxFrame > 0 {
-		frame, gerr := p.wal.index.get(1, effectiveMaxFrame, p.wal.index.liveMinFrame())
+		frame, gerr := p.wal.index.get(1, effectiveMaxFrame, minFrame)
 		if gerr != nil {
 			// ErrCorrupt from a full/over-probed SHM hash chain is a hard error,
 			// not a "WAL has no page 1" miss: fail rather than reading stale

--- a/internal/btree/pager.go
+++ b/internal/btree/pager.go
@@ -2107,7 +2107,16 @@ func (p *pager) readHeaderCounters(walMaxFrame uint32) (fileChangeCount, schemaC
 	} else if hdr, valid := p.wal.index.readHeader(); valid && hdr.mxFrame > effectiveMaxFrame {
 		effectiveMaxFrame = hdr.mxFrame
 	}
+	return p.readHeaderCountersAt(effectiveMaxFrame)
+}
 
+// readHeaderCountersAt is readHeaderCounters WITHOUT the raise to the latest
+// committed frame: it reads page 1 strictly as of maxFrame, so a reader tx
+// passing its own walMaxFrame gets the counters its snapshot actually
+// contains. readHeaderCounters raises the bound to discover the true WAL
+// state for STALENESS DETECTION — the raised counters may exceed what the
+// caller's snapshot can see, and must not be used to judge snapshot contents.
+func (p *pager) readHeaderCountersAt(effectiveMaxFrame uint32) (fileChangeCount, schemaCookie uint32, err error) {
 	// Look up page 1's latest frame.
 	// walIndex.get() merges the local page map with SHM, preferring newer SHM
 	// frames. After an external state change, beginWrite rebuilds the local page

--- a/internal/btree/snapshot_counters_test.go
+++ b/internal/btree/snapshot_counters_test.go
@@ -1,0 +1,102 @@
+package btree
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SnapshotHeaderCounters must be bounded by the reader's own snapshot on the
+// MAX side: a commit that lands after the reader began is invisible to it,
+// while the raised detection read (pager.readHeaderCounters) sees it. A
+// regression that routes the snapshot read through the raised path returns
+// the post-commit cookie here.
+func TestSnapshotHeaderCounters_BoundedByReaderSnapshot(t *testing.T) {
+	db := tempDB(t)
+
+	tx, err := db.BeginWrite()
+	require.NoError(t, err)
+	_, err = tx.CreateNamespace("a")
+	require.NoError(t, err)
+	tx.MarkDataChanged()
+	tx.MarkSchemaChanged()
+	require.NoError(t, tx.Commit())
+
+	rtx, err := db.BeginRead()
+	require.NoError(t, err)
+	baseSC := rtx.DiskSchemaCookie()
+
+	// Commit more DDL while the reader is open.
+	tx, err = db.BeginWrite()
+	require.NoError(t, err)
+	_, err = tx.CreateNamespace("b")
+	require.NoError(t, err)
+	tx.MarkDataChanged()
+	tx.MarkSchemaChanged()
+	require.NoError(t, tx.Commit())
+
+	_, sc, err := rtx.SnapshotHeaderCounters()
+	require.NoError(t, err)
+	assert.Equal(t, baseSC, sc, "snapshot counters must not see a post-begin commit")
+
+	// The raised detection read at the same frame bound DOES see it — the
+	// divergence the snapshot-bounded accessor exists for.
+	_, raisedSC, err := db.pager.readHeaderCounters(rtx.WalMaxFrame())
+	require.NoError(t, err)
+	assert.Equal(t, baseSC+1, raisedSC, "raised read should see the newer commit")
+
+	require.NoError(t, rtx.Rollback())
+}
+
+// SnapshotHeaderCounters must be bounded on the MIN side by the reader's
+// begin-captured floor, not the live checkpoint frontier: a slot-0 reader
+// (WAL fully backfilled at begin, minFrame = maxFrame+1) that survives a WAL
+// restart must not admit new-generation frame numbers that recycle below its
+// old maxFrame. A regression to liveMinFrame returns post-restart counters.
+func TestSnapshotHeaderCounters_ImmuneToWALRestart(t *testing.T) {
+	db := tempDB(t)
+
+	// Build a WAL noticeably longer than the post-restart one so recycled
+	// frame numbers land below the old maxFrame.
+	tx, err := db.BeginWrite()
+	require.NoError(t, err)
+	ns, err := tx.CreateNamespace("a")
+	require.NoError(t, err)
+	val := make([]byte, 1024)
+	for i := 0; i < 64; i++ {
+		require.NoError(t, tx.Put(ns, fmt.Appendf(nil, "k%03d", i), val))
+	}
+	tx.MarkDataChanged()
+	tx.MarkSchemaChanged()
+	require.NoError(t, tx.Commit())
+
+	// Backfill everything, keep the WAL: the next reader takes slot 0.
+	require.NoError(t, db.Checkpoint(CheckpointFull))
+
+	rtx, err := db.BeginRead()
+	require.NoError(t, err)
+	require.Equal(t, rtx.WalMaxFrame()+1, rtx.walMinFrame,
+		"precondition: reader must hold a slot-0 snapshot (empty WAL range)")
+	baseFCC := rtx.DiskFileChangeCounter()
+	baseSC := rtx.DiskSchemaCookie()
+
+	// Restart the WAL under the held reader (the reset waits only on slots
+	// 1-4; slot 0 does not block it), then recycle low frame numbers.
+	require.NoError(t, db.Checkpoint(CheckpointRestart))
+	tx, err = db.BeginWrite()
+	require.NoError(t, err)
+	_, err = tx.CreateNamespace("b")
+	require.NoError(t, err)
+	tx.MarkDataChanged()
+	tx.MarkSchemaChanged()
+	require.NoError(t, tx.Commit())
+
+	fcc, sc, err := rtx.SnapshotHeaderCounters()
+	require.NoError(t, err)
+	assert.Equal(t, baseSC, sc, "slot-0 snapshot must not see post-restart schema cookie")
+	assert.Equal(t, baseFCC, fcc, "slot-0 snapshot must not see post-restart change counter")
+
+	require.NoError(t, rtx.Rollback())
+}

--- a/reconcile_create_inflight_test.go
+++ b/reconcile_create_inflight_test.go
@@ -1,0 +1,139 @@
+package anystore
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests guard the create-in-flight gap in reconcileIndexSet: a read tx
+// whose staleness verdict was baked at begin (an unconsumed schema-cookie
+// delta — a peer commit, or a local commit racing beginRead between snapshot
+// capture and the local-counter load) reconciles ALL registered handles
+// against its own, older snapshot. A collection created after that snapshot
+// has no catalog key there yet, so collectionVanished reports true via the
+// keyNotFound branch and the staleness pass invalidates a live handle. The
+// create commits fine; disk is correct; the cached handle is dead — every
+// later op fails ErrCollectionClosed until the caller reopens.
+//
+// reconcileIndexSet guards rename-in-flight explicitly but not
+// create-in-flight, though the same safety argument transfers: the creating
+// writer holds the cross-process write lock, so any cookie bump a concurrent
+// read pass consumes predates the creating tx's begin.
+
+// The in-flight variant: the create sits inside an open write tx (handle
+// registered mid-tx, catalog write uncommitted) while a plain read op begins
+// with a stale local-counter cache and runs the full production
+// ReadTx→checkStale path.
+func TestReconcile_ReadTxSparesCreateInFlightHandle(t *testing.T) {
+	if os.Getenv("ANYSTORE_TEST_INMEMORY") == "1" {
+		t.Skip("staleness counters model cross-process commits; not applicable in-memory")
+	}
+	fx := newFixture(t)
+	dbi := fx.DB.(*db)
+
+	seed, err := fx.CreateCollection(ctx, "seed")
+	require.NoError(t, err)
+
+	// Committed counters, to rewind against below.
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+
+	// Create in-flight: handle registered in openedCollections, catalog write
+	// pending until wtx.Commit. The write tx's own begin ran checkStale with
+	// counters in sync, so nothing is consumed yet.
+	wtx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	fresh, err := fx.CreateCollection(wtx.Context(), "fresh")
+	require.NoError(t, err)
+
+	// Emulate an unconsumed cookie bump: the state a reader captures when its
+	// beginRead races a commit (snapshot fields baked before the writer's
+	// counter store lands) or when a peer process committed DDL.
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+
+	// Any read op now begins a read tx that sees IsSchemaStale and runs
+	// reconcileIndexSet against a snapshot that predates the create.
+	_, err = seed.Count(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, wtx.Commit())
+
+	// The create committed; the handle must still be live.
+	_, err = fresh.Count(ctx)
+	require.NoError(t, err, "read-tx staleness pass invalidated a create-in-flight handle")
+}
+
+// The post-commit variant: the create commits normally, but the reader's
+// snapshot predates it (begun before the create, checkStale preempted until
+// after — the gap between BeginRead and checkStale inside db.ReadTx is a real
+// preemption point). The committed handle must survive the pass.
+func TestReconcile_ReadTxSparesFreshlyCommittedHandle(t *testing.T) {
+	if os.Getenv("ANYSTORE_TEST_INMEMORY") == "1" {
+		t.Skip("staleness counters model cross-process commits; not applicable in-memory")
+	}
+	fx := newFixture(t)
+	dbi := fx.DB.(*db)
+
+	_, err := fx.CreateCollection(ctx, "seed")
+	require.NoError(t, err)
+
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+
+	// Stale verdict baked at begin; snapshot predates the create below.
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+	reader, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	require.True(t, reader.IsSchemaStale())
+
+	fresh, err := fx.CreateCollection(ctx, "fresh")
+	require.NoError(t, err)
+
+	// The reader resumes exactly where db.ReadTx would: checkStale on its own
+	// pre-create snapshot.
+	dbi.checkStale(reader)
+	require.NoError(t, reader.Rollback())
+
+	_, err = fresh.Count(ctx)
+	require.NoError(t, err, "read-tx staleness pass invalidated a freshly committed handle")
+}
+
+// The rename analog: after Rename commits, the handle is registered under its
+// NEW name, which a pre-rename snapshot cannot resolve (keyNotFound on the
+// new key). Rename's publication raises the handle's visibility bound to the
+// rename commit cookie so older-snapshot passes skip it.
+func TestReconcile_ReadTxSparesFreshlyRenamedHandle(t *testing.T) {
+	if os.Getenv("ANYSTORE_TEST_INMEMORY") == "1" {
+		t.Skip("staleness counters model cross-process commits; not applicable in-memory")
+	}
+	fx := newFixture(t)
+	dbi := fx.DB.(*db)
+
+	coll, err := fx.CreateCollection(ctx, "before")
+	require.NoError(t, err)
+
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+
+	// Stale verdict baked at begin; snapshot predates the rename below.
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+	reader, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	require.True(t, reader.IsSchemaStale())
+
+	require.NoError(t, coll.Rename(ctx, "after"))
+
+	dbi.checkStale(reader)
+	require.NoError(t, reader.Rollback())
+
+	_, err = coll.Count(ctx)
+	require.NoError(t, err, "read-tx staleness pass invalidated a freshly renamed handle")
+}

--- a/reconcile_create_inflight_test.go
+++ b/reconcile_create_inflight_test.go
@@ -137,3 +137,59 @@ func TestReconcile_ReadTxSparesFreshlyRenamedHandle(t *testing.T) {
 	_, err = coll.Count(ctx)
 	require.NoError(t, err, "read-tx staleness pass invalidated a freshly renamed handle")
 }
+
+// The consumption pin: a stale pass on a reader whose snapshot predates
+// later DDL must consume only up to the SNAPSHOT counters — recording the
+// raised/live values would mark the later DDL as reconciled though this pass
+// never saw it, and no subsequent tx would ever reconcile it. The next begin
+// must still report schema staleness and converge.
+func TestCheckStale_ConsumesOnlySnapshotCounters(t *testing.T) {
+	if os.Getenv("ANYSTORE_TEST_INMEMORY") == "1" {
+		t.Skip("staleness counters model cross-process commits; not applicable in-memory")
+	}
+	fx := newFixture(t)
+	dbi := fx.DB.(*db)
+
+	_, err := fx.CreateCollection(ctx, "seed")
+	require.NoError(t, err)
+
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+
+	// Stale verdict baked at begin; snapshot predates the DDL below.
+	// Assertions run after each tx is released so a failure cannot leave a
+	// reader open (Close would block in the fixture cleanup).
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+	reader, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	readerStale := reader.IsSchemaStale()
+
+	later, err := fx.CreateCollection(ctx, "later")
+	require.NoError(t, err)
+
+	// The pass runs with a snapshot that lacks the create: it must neither
+	// invalidate the new handle nor consume the create's cookie bump.
+	dbi.checkStale(reader)
+	require.NoError(t, reader.Rollback())
+	require.True(t, readerStale)
+
+	next, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	nextStale := next.IsSchemaStale()
+	// A full-vision pass converges.
+	dbi.checkStale(next)
+	require.NoError(t, next.Rollback())
+	require.True(t, nextStale,
+		"stale pass must not consume DDL its snapshot never contained")
+
+	settled, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	settledStale := settled.IsSchemaStale()
+	require.NoError(t, settled.Rollback())
+	require.False(t, settledStale)
+
+	_, err = later.Count(ctx)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
A read tx whose begin races a DDL commit — or whose reader slot pinned an older snapshot — carries a staleness verdict its own snapshot cannot judge. `reconcileIndexSet` swept ALL registered handles against that older snapshot: a collection created (or renamed) after it has no catalog key there, so `collectionVanished` invalidated a live handle via the keyNotFound branch. The create commits fine and disk is correct, but every later op on the cached handle fails `ErrCollectionClosed` until reopen. Under rapid same-process DDL with concurrent reads, ~5% of creates lost their handle; in the SDK this broke space creation outright and silently killed parked-change drainage.

Root cause is a snapshot/verdict split with two consequences:

- `readHeaderCounters` raises its frame bound to the newest committed frame, so `DiskSchemaCookie` can exceed what the tx's tree reads see. Judging catalog existence with it is unsound.
- `checkStale` consumed the raised counters after reconciling from the older snapshot, recording peer DDL as reconciled that the reconcile never saw — later txs (including writers) then trusted an index set missing a peer index and stopped maintaining it.

Fix, mirroring SQLite's snapshot-bounded `SQLITE_SCHEMA` handling (cookie read through the tx's own page 1, btree.c:3785; consumption from the same snapshot, prepare.c:288,293 — drift-46 NOTES addendum):

- `btree.ReadTx.SnapshotHeaderCounters`: page-1 counters strictly as of the tx's `walMaxFrame`.
- `collection.validFromCookie` (same contract as `index.validFromCookie`): stamped at init — commit cookie for a create-in-flight — and raised by Rename's commit publication. The staleness pass skips handles whose bound exceeds the snapshot cookie; same safety argument as the existing rename-in-flight guard.
- `checkStale` consumes only up to the snapshot counters; left short, the verdict stays stale and the next begin converges.

Tests: three deterministic regressions (create-in-flight via ambient write tx, freshly committed create, freshly renamed handle — each fails without its guard), plus a natural-race stress in the test repo (`TestRegression_CreateVsReadStaleInvalidation`: 143/3000 dead handles unfixed → 0/3000 fixed, 5 consecutive runs). Full suite, race-detector concurrency tests, and all storetest multiprocess suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)