### PR TITLE
Snapshot-cookie index visibility + index-set publication ratchet

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -328,7 +328,7 @@ func (c *collection) init(ctx context.Context, wtx *btree.WriteTx) error {
 		// one is safe (the slow path admits its readers exactly);
 		// under-stamping an uncommitted one would leak it to every reader at
 		// the begin cookie.
-		validFrom := tx.DiskSchemaCookie()
+		validFrom := tx.SnapshotSchemaCookie()
 		if wtx != nil && wtx.SchemaChanged() {
 			validFrom++
 		}
@@ -1793,11 +1793,11 @@ func (c *collection) reconcileIndexes(tx *btree.ReadTx) {
 			continue
 		}
 		// Reconcile runs at tx begin (checkStale), before any of this tx's
-		// writes: the adopted state is committed as of this snapshot, so its
-		// cookie is the exact visibility bound — an older concurrent reader
-		// resolves per-snapshot in visibleTo and correctly skips a peer index
-		// its snapshot predates.
-		idx.validFromCookie = tx.DiskSchemaCookie()
+		// writes: the adopted state is committed as of this snapshot, so the
+		// SNAPSHOT cookie is the exact visibility bound (the raised one can
+		// exceed it) — an older concurrent reader resolves per-snapshot in
+		// visibleTo and correctly skips a peer index its snapshot predates.
+		idx.validFromCookie = tx.SnapshotSchemaCookie()
 		c.loadSketchAtOpen(tx, idx)
 		rebuilt = append(rebuilt, idx)
 		changed = true

--- a/collection.go
+++ b/collection.go
@@ -198,6 +198,17 @@ type collection struct {
 	// evict the writer's uncommitted indexes. See the guard in reconcileIndexes.
 	indexSetDDLTxs int
 
+	// indexSetCookie is the schema cookie the published index/fts/vector sets
+	// were last built from (a reconcile's snapshot cookie) or published at (a
+	// local DDL's commit cookie). Guarded by c.mu. One-way ratchet for the
+	// staleness pass: a pass whose snapshot is older must not republish —
+	// rebuilt from its older catalog it would resurrect a dropped index or
+	// evict a fresher one db-wide, and readers at current snapshots would
+	// plan against freed namespaces, silently returning wrong results. The
+	// skipped pass consumes only its snapshot counters (see checkStale), so
+	// the verdict stays stale and a fresher begin converges.
+	indexSetCookie uint32
+
 	closed atomic.Bool
 	// userClosed records that Close() was explicitly requested. Drop flips
 	// closed itself (CAS), which makes a Close() racing in AFTER the flip a
@@ -337,6 +348,9 @@ func (c *collection) init(ctx context.Context, wtx *btree.WriteTx) error {
 		// commit cookie, keeping the handle out of reach of staleness passes
 		// whose snapshot predates the create.
 		c.validFromCookie.Store(validFrom)
+		// The loaded sets are as-of the same bound: seed the publication
+		// ratchet (init runs before the handle is published; no c.mu needed).
+		c.indexSetCookie = validFrom
 		for _, info := range idxInfos {
 			if isFulltext(info) {
 				fx, fErr := newFtsIndex(c, info)
@@ -1046,6 +1060,12 @@ func (c *collection) registerIndexSetRestore(wtx WriteTx) {
 	// per outcome (commit → pubs, rollback/failed commit → undo), so the
 	// counter balances.
 	c.indexSetDDLTxs++
+	// The sets this tx publishes become committed state at its commit cookie
+	// (every caller marks schema changed; the cookie bumps once per commit):
+	// ratchet indexSetCookie there so an older-snapshot staleness pass cannot
+	// republish over them. The ratchet never moves mid-tx, so rollback has
+	// nothing to restore.
+	commitCookie := wtx.btreeWriteTx().DiskSchemaCookie() + 1
 	wtx.onRollbackUndo(func() {
 		c.mu.Lock()
 		defer c.mu.Unlock()
@@ -1057,6 +1077,9 @@ func (c *collection) registerIndexSetRestore(wtx WriteTx) {
 	wtx.onCommitPublish(func() {
 		c.mu.Lock()
 		c.indexSetDDLTxs--
+		if commitCookie > c.indexSetCookie {
+			c.indexSetCookie = commitCookie
+		}
 		c.mu.Unlock()
 	})
 }
@@ -1734,6 +1757,16 @@ func (c *collection) reconcileIndexes(tx *btree.ReadTx) {
 		// renameInFlight guard in reconcileIndexSet.
 		return
 	}
+
+	snapSC := tx.SnapshotSchemaCookie()
+	if !tx.IsWriteTx() && snapSC < c.indexSetCookie {
+		// Publication ratchet (see the field): the published sets are newer
+		// than this pass's snapshot — republishing from the older catalog
+		// would resurrect dropped indexes or evict fresher ones. Skip; a
+		// fresher begin reconciles.
+		return
+	}
+	c.indexSetCookie = snapSC
 
 	cur := c.loadIndexes()
 	byName := make(map[string]*index, len(cur))

--- a/db.go
+++ b/db.go
@@ -489,15 +489,7 @@ func (db *db) checkStale(tx *btree.ReadTx) {
 	if !tx.IsSchemaStale() && !tx.IsDataStale() {
 		return
 	}
-	snapFCC, snapSC := tx.DiskFileChangeCounter(), tx.DiskSchemaCookie()
-	if !tx.IsWriteTx() {
-		var err error
-		if snapFCC, snapSC, err = tx.SnapshotHeaderCounters(); err != nil {
-			// Cannot bound the snapshot: reconcile nothing, consume nothing —
-			// the verdict stays stale and the next begin retries.
-			return
-		}
-	}
+	snapFCC, snapSC := tx.SnapshotFileChangeCounter(), tx.SnapshotSchemaCookie()
 	if tx.IsSchemaStale() {
 		db.reconcileIndexSet(tx, snapSC)
 	}

--- a/db.go
+++ b/db.go
@@ -476,6 +476,7 @@ func (db *db) ReadTx(ctx context.Context) (ReadTx, error) {
 //	  sketches over the (now reconciled) index set. A stale sketch only affects
 //	  which index the planner CHOOSES, never query RESULTS (the any-store analog
 //	  of sqlite_stat1), so it runs strictly after the structural reconcile.
+//
 // The begin-time disk counters driving the verdict are RAISED to the newest
 // committed frame (see btree.ReadTx.SnapshotHeaderCounters), so a read tx can
 // detect staleness its own snapshot does not yet contain — a begin racing a

--- a/docs/btree/NOTES.md
+++ b/docs/btree/NOTES.md
@@ -2444,11 +2444,16 @@ pinned behind — reports counters its own snapshot cannot see. SQLite has no su
 (`sqlitec/src/btree.c:3785-3786`), and the `SQLITE_SCHEMA` reload consumes the cookie read
 through that same transaction (`sqlitec/src/prepare.c:288,293`) — detection, reload, and
 consumption are all snapshot-bounded. The raise is kept for cross-process staleness
-detection, but judgments about snapshot contents and the post-reconcile counter consumption
-must use `ReadTx.SnapshotHeaderCounters` (frame bound = the tx's own `walMaxFrame`), which
-restores the SQLite-aligned semantics; consuming the raised counters would mark peer DDL as
-reconciled that the reconcile snapshot never contained, silently detaching later write
-transactions from a peer-created index.
+detection, but judgments about snapshot contents must use the snapshot-bounded pair —
+`ReadTx.SnapshotHeaderCounters`/`SnapshotSchemaCookie`, baked at begin from the tx's captured
+`[minFrame, maxFrame]` window (a second bounded page-1 read is paid only when the detection
+read was actually raised) — which restores the SQLite-aligned semantics. Consumers: the
+staleness pass (reconcile + counter consumption — consuming the raised counters would mark
+peer DDL as reconciled that the reconcile snapshot never contained, silently detaching later
+write transactions from a peer-created index) and the index-visibility fast paths
+(`visibleIndexes`, range/fts `visibleTo`, `vectorIndex.forTx` — judging with the raised
+cookie admits an index whose namespace the snapshot cannot resolve, returning silently wrong
+query results).
 
 <a id="drift-47-checkpoint-omits-open-transaction-guard"></a>
 ### Drift: Checkpoint Omits Open Transaction Guard

--- a/fulltext_index.go
+++ b/fulltext_index.go
@@ -211,7 +211,8 @@ func (fx *ftsIndex) Info() IndexInfo { return fx.info }
 // keep a working index over a transient view — so the two checks stay
 // separate.)
 func (fx *ftsIndex) visibleTo(tx *btree.ReadTx) bool {
-	if tx.IsWriteTx() || tx.DiskSchemaCookie() >= fx.validFromCookie {
+	// Snapshot cookie, not the raised begin-time one — see visibleIndexes.
+	if tx.IsWriteTx() || tx.SnapshotSchemaCookie() >= fx.validFromCookie {
 		return true
 	}
 	raw, err := tx.AppendValue(fx.c.db.systemNS, fx.catalogKey, nil)
@@ -287,11 +288,12 @@ func (c *collection) reconcileFtsIndexesLocked(tx *btree.ReadTx, infos []IndexIn
 		if err == nil {
 			err = fx.bindNamespaces(tx.GetNamespace)
 			// Reconcile runs at tx begin (checkStale), before any of this tx's
-			// writes: the bound state is committed as of this snapshot, so its
-			// cookie is the exact visibility bound. An older concurrent reader
-			// resolves per-snapshot in visibleTo and correctly skips a peer
-			// index its snapshot predates.
-			fx.validFromCookie = tx.DiskSchemaCookie()
+			// writes: the bound state is committed as of this snapshot, so the
+			// SNAPSHOT cookie is the exact visibility bound (the raised one
+			// can exceed it). An older concurrent reader resolves
+			// per-snapshot in visibleTo and correctly skips a peer index its
+			// snapshot predates.
+			fx.validFromCookie = tx.SnapshotSchemaCookie()
 		}
 		if err != nil {
 			// Not resolvable in this snapshot. With no existing object this is

--- a/index.go
+++ b/index.go
@@ -407,7 +407,8 @@ func (idx *index) storePubSketch(s *qplanner.IndexSketch) { idx.sketchPub.Store(
 // a later state. Anything less → invisible; the planner scans, which is
 // always correct. The stamp is a fast-path bound, not the exact commit point.
 func (idx *index) visibleTo(tx *btree.ReadTx) bool {
-	if tx.IsWriteTx() || tx.DiskSchemaCookie() >= idx.validFromCookie {
+	// Snapshot cookie, not the raised begin-time one — see visibleIndexes.
+	if tx.IsWriteTx() || tx.SnapshotSchemaCookie() >= idx.validFromCookie {
 		return true
 	}
 	raw, err := tx.AppendValue(idx.c.db.systemNS, idx.catalogKey, nil)

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -819,14 +819,30 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 	localSC := db.localSchemaCookie.Load()
 	fcc := localFCC
 	sc := localSC
+	snapFCC, snapSC := localFCC, localSC
 	if readCounters {
-		// Read on-disk counters for staleness detection.
-		fcc, sc, err = db.pager.readHeaderCounters(maxFrame)
+		// Read on-disk counters for staleness detection (raised to the
+		// newest committed frame so peer commits are noticed).
+		var effMax uint32
+		fcc, sc, effMax, err = db.pager.readHeaderCountersRaised(maxFrame)
 		if err != nil {
 			db.pager.endRead(slot)
 			db.mu.RUnlock()
 			<-db.readerSem
 			return nil, err
+		}
+		// Snapshot-bounded pair: identical to the raised read unless the
+		// bound was actually raised (rare: begin racing a commit, or a
+		// pinned reader slot) — only then pay a second bounded read.
+		snapFCC, snapSC = fcc, sc
+		if effMax != maxFrame {
+			snapFCC, snapSC, err = db.pager.readHeaderCountersAt(maxFrame, minFrame)
+			if err != nil {
+				db.pager.endRead(slot)
+				db.mu.RUnlock()
+				<-db.readerSem
+				return nil, err
+			}
 		}
 	}
 
@@ -897,6 +913,8 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 	tx.diskSchemaCookie = sc
 	tx.localFileChangeCounter = localFCC
 	tx.localSchemaCookie = localSC
+	tx.snapFileChangeCounter = snapFCC
+	tx.snapSchemaCookie = snapSC
 	return tx, nil
 }
 
@@ -1032,6 +1050,10 @@ func (db *DB) BeginWrite() (*WriteTx, error) {
 	tx.ReadTx.writable = true
 	tx.ReadTx.diskFileChangeCounter = fcc
 	tx.ReadTx.diskSchemaCookie = sc
+	// The write lock excludes concurrent commits: the writer's snapshot IS
+	// the latest state, so the snapshot-bounded pair equals the disk pair.
+	tx.ReadTx.snapFileChangeCounter = fcc
+	tx.ReadTx.snapSchemaCookie = sc
 	tx.ReadTx.localFileChangeCounter = db.localFileChangeCounter.Load()
 	tx.ReadTx.localSchemaCookie = db.localSchemaCookie.Load()
 	tx.dataChanged = false   // pool reuse safety
@@ -1529,6 +1551,15 @@ type ReadTx struct {
 	diskSchemaCookie       uint32
 	localFileChangeCounter uint32 // snapshot of DB's local value
 	localSchemaCookie      uint32 // snapshot of DB's local value
+	// Snapshot-bounded page-1 counters, baked at begin: what THIS tx's tree
+	// reads can actually see. Equal to the disk pair unless the begin-time
+	// read was raised past the snapshot (begin racing a commit, or a pinned
+	// reader slot) — the disk pair serves staleness DETECTION, this pair
+	// serves judgments about snapshot CONTENTS (visibility bounds, staleness
+	// consumption). On a counterless fast begin both pairs are the seeded
+	// local values (see BeginReadFast's contract).
+	snapFileChangeCounter uint32
+	snapSchemaCookie      uint32
 	closed                 bool
 	writable               bool // true when embedded in a WriteTx (MVCC: allows seeing dirty pages)
 }
@@ -1971,21 +2002,27 @@ func (tx *ReadTx) DiskSchemaCookie() uint32 {
 }
 
 // SnapshotHeaderCounters returns the page-1 FileChangeCount and SchemaCookie
-// as of THIS tx's snapshot (bounded by its begin-captured
-// [walMinFrame, walMaxFrame] window, both sides fixed for the tx's life —
-// SQLite's pWal->minFrame/mxFrame). Unlike
+// as of THIS tx's snapshot — baked at begin from the tx's captured
+// [walMinFrame, walMaxFrame] window, both sides fixed for the tx's life
+// (SQLite's pWal->minFrame/mxFrame). Unlike
 // DiskFileChangeCounter/DiskSchemaCookie — whose begin-time read is raised to
 // the newest committed frame so staleness detection notices peer commits —
 // these values never exceed what the tx's tree reads can actually see: a
 // begin that raced a commit, or a reader slot pinned to an older snapshot,
 // reports the older counters here. Judgments about snapshot contents (e.g.
 // whether a catalog key committed at cookie C must be visible) require this
-// bound, not the raised one.
+// bound, not the raised one. Field reads: no I/O, safe on hot paths.
 func (tx *ReadTx) SnapshotHeaderCounters() (fileChangeCount, schemaCookie uint32, err error) {
 	if tx.closed {
 		return 0, 0, ErrTxClosed
 	}
-	return tx.pager.readHeaderCountersAt(tx.walHdr.mxFrame, tx.walMinFrame)
+	return tx.snapFileChangeCounter, tx.snapSchemaCookie, nil
+}
+
+// SnapshotSchemaCookie is the schema-cookie half of SnapshotHeaderCounters
+// without the error plumbing — for per-query visibility checks.
+func (tx *ReadTx) SnapshotSchemaCookie() uint32 {
+	return tx.snapSchemaCookie
 }
 
 // Rollback ends the read transaction (for ReadTx, this is the same as commit).

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -2025,6 +2025,11 @@ func (tx *ReadTx) SnapshotSchemaCookie() uint32 {
 	return tx.snapSchemaCookie
 }
 
+// SnapshotFileChangeCounter is the change-counter half, same contract.
+func (tx *ReadTx) SnapshotFileChangeCounter() uint32 {
+	return tx.snapFileChangeCounter
+}
+
 // Rollback ends the read transaction (for ReadTx, this is the same as commit).
 func (tx *ReadTx) Rollback() error {
 	if tx.closed {

--- a/internal/btree/db.go
+++ b/internal/btree/db.go
@@ -906,7 +906,6 @@ func (db *DB) beginRead(readCounters bool) (*ReadTx, error) {
 	// Dual-write during per-connection-hdr migration. Step 5 will remove
 	// walMaxFrame; until then, tests still read it directly.
 	tx.walMaxFrame = maxFrame
-	tx.walMinFrame = minFrame
 	tx.walHdr = snapHdr
 	tx.walSlot = slot
 	tx.diskFileChangeCounter = fcc
@@ -1035,9 +1034,6 @@ func (db *DB) BeginWrite() (*WriteTx, error) {
 	tx.ReadTx.cache = nil // writer uses shared pcache, not a reader cache
 	tx.ReadTx.closed = false
 	tx.ReadTx.walMaxFrame = maxFrame
-	// Writers hold the write lock, so no restart can race: the live floor
-	// captured here stays valid for the tx's life.
-	tx.ReadTx.walMinFrame = db.pager.wal.index.liveMinFrame()
 	// Reuse the readSnap hdr captured above for BUSY_SNAPSHOT. In-process
 	// mode has readSnap=zero; synthesize minimal hdr so read paths consuming
 	// walHdr.mxFrame see the correct frame ceiling.
@@ -1537,11 +1533,6 @@ type ReadTx struct {
 	cache       *pcache // per-reader private page cache (nil for write transactions)
 	walSlot     int     // reader slot number (for endRead)
 	walMaxFrame uint32  // WAL snapshot for this transaction (TODO: migrate to walHdr.mxFrame)
-	// walMinFrame is the snapshot's checkpoint-frontier floor, captured at
-	// begin like SQLite's pWal->minFrame (slot-0: maxFrame+1). Fixed for the
-	// tx's life so a WAL restart cannot recycle new-generation frame numbers
-	// into the snapshot's [min, max] window — see wal.beginReadHdr.
-	walMinFrame uint32
 	// walHdr is the full SHM header snapshot captured at BeginRead time.
 	// Populated in parallel with walMaxFrame.
 	walHdr WalIndexHdr
@@ -2003,7 +1994,7 @@ func (tx *ReadTx) DiskSchemaCookie() uint32 {
 
 // SnapshotHeaderCounters returns the page-1 FileChangeCount and SchemaCookie
 // as of THIS tx's snapshot — baked at begin from the tx's captured
-// [walMinFrame, walMaxFrame] window, both sides fixed for the tx's life
+// [minFrame, maxFrame] window, both sides fixed for the tx's life
 // (SQLite's pWal->minFrame/mxFrame). Unlike
 // DiskFileChangeCounter/DiskSchemaCookie — whose begin-time read is raised to
 // the newest committed frame so staleness detection notices peer commits —

--- a/internal/btree/pager.go
+++ b/internal/btree/pager.go
@@ -2093,12 +2093,21 @@ func (p *pager) committedCounters() (fileChangeCount, schemaCookie uint32) {
 // cross-process readers), but in single-process mode the Go map with its
 // RWMutex provides safe concurrent access.
 func (p *pager) readHeaderCounters(walMaxFrame uint32) (fileChangeCount, schemaCookie uint32, err error) {
+	fileChangeCount, schemaCookie, _, err = p.readHeaderCountersRaised(walMaxFrame)
+	return
+}
+
+// readHeaderCountersRaised is readHeaderCounters plus the effective frame
+// bound it actually used. beginRead consults it: when the bound was NOT
+// raised past the caller's walMaxFrame, the returned counters are also the
+// snapshot counters — no second read needed for the snapshot-bounded pair.
+func (p *pager) readHeaderCountersRaised(walMaxFrame uint32) (fileChangeCount, schemaCookie, effectiveMaxFrame uint32, err error) {
 	// Determine the effective max frame by checking the SHM header,
 	// which reflects writes from ALL processes sharing this database.
 	// For inProcess mode, the SHM header is not updated by writers
 	// (writeFrames skips writeHeader when inProcess=true), so we use
 	// the in-process walIndex.maxFrame directly.
-	effectiveMaxFrame := walMaxFrame
+	effectiveMaxFrame = walMaxFrame
 	if p.inProcess {
 		// Use mxCommitFrame (not maxFrame) so spilled uncommitted frames are invisible to readers.
 		if mf := p.wal.index.mxCommitFrame.LoadLocal(); mf > effectiveMaxFrame {
@@ -2107,7 +2116,8 @@ func (p *pager) readHeaderCounters(walMaxFrame uint32) (fileChangeCount, schemaC
 	} else if hdr, valid := p.wal.index.readHeader(); valid && hdr.mxFrame > effectiveMaxFrame {
 		effectiveMaxFrame = hdr.mxFrame
 	}
-	return p.readHeaderCountersAt(effectiveMaxFrame, p.wal.index.liveMinFrame())
+	fileChangeCount, schemaCookie, err = p.readHeaderCountersAt(effectiveMaxFrame, p.wal.index.liveMinFrame())
+	return
 }
 
 // readHeaderCountersAt is readHeaderCounters WITHOUT the raise to the latest

--- a/internal/btree/snapshot_counters_test.go
+++ b/internal/btree/snapshot_counters_test.go
@@ -77,7 +77,7 @@ func TestSnapshotHeaderCounters_ImmuneToWALRestart(t *testing.T) {
 
 	rtx, err := db.BeginRead()
 	require.NoError(t, err)
-	require.Equal(t, rtx.WalMaxFrame()+1, rtx.walMinFrame,
+	require.Equal(t, 0, rtx.walSlot,
 		"precondition: reader must hold a slot-0 snapshot (empty WAL range)")
 	baseFCC := rtx.DiskFileChangeCounter()
 	baseSC := rtx.DiskSchemaCookie()

--- a/query.go
+++ b/query.go
@@ -143,7 +143,12 @@ func visibleIndexes(btx *btree.ReadTx, idxs []*index) []*index {
 	if btx.IsWriteTx() {
 		return idxs
 	}
-	cookie := btx.DiskSchemaCookie()
+	// SNAPSHOT cookie, not DiskSchemaCookie: the begin-time disk read is
+	// raised past the snapshot when the begin races a commit or the reader
+	// slot pinned behind — judging with it admits an index whose namespace
+	// this snapshot cannot resolve, and the scan silently returns wrong
+	// results. Same bound as reconcileIndexSet's handle guard.
+	cookie := btx.SnapshotSchemaCookie()
 	pending := false
 	for _, idx := range idxs {
 		if cookie < idx.validFromCookie {

--- a/reconcile_ratchet_test.go
+++ b/reconcile_ratchet_test.go
@@ -1,0 +1,86 @@
+package anystore
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+// These tests guard the index-set publication ratchet: a staleness pass
+// whose snapshot is older than the published sets must not republish from
+// its older catalog. Rebuilt from that snapshot it would resurrect a
+// dropped index (readers at current snapshots then plan against freed
+// namespaces — silently wrong results) or evict a fresher one (a concurrent
+// DropIndex fails ErrIndexNotFound; writes stop maintaining it).
+
+func ratchetFixture(t *testing.T) (*fixture, *db, Collection) {
+	t.Helper()
+	if os.Getenv("ANYSTORE_TEST_INMEMORY") == "1" {
+		t.Skip("staleness counters model cross-process commits; not applicable in-memory")
+	}
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "c")
+	require.NoError(t, err)
+	docs := make([]*anyenc.Value, 0, 10)
+	for i := 0; i < 10; i++ {
+		docs = append(docs, anyenc.MustParseJson(fmt.Sprintf(`{"id":%d,"a":%d}`, i, i)))
+	}
+	require.NoError(t, coll.Insert(ctx, docs...))
+	return fx, fx.DB.(*db), coll
+}
+
+// A stale pass with a snapshot from when the index still existed must not
+// resurrect it after DropIndex committed.
+func TestReconcileRatchet_NoResurrectionAfterDrop(t *testing.T) {
+	_, dbi, coll := ratchetFixture(t)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{"a"}}))
+
+	// Reader begun while the index exists, with a stale-baked verdict.
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+	reader, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+
+	require.NoError(t, coll.DropIndex(ctx, "a"))
+
+	dbi.checkStale(reader)
+	require.NoError(t, reader.Rollback())
+
+	require.Empty(t, coll.(*collection).loadIndexes(),
+		"stale pass resurrected a dropped index into the live set")
+	n, err := coll.Find(`{"a":{"$gte":0}}`).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+}
+
+// A stale pass with a snapshot predating CreateIndex must not evict the
+// freshly created index from the live set.
+func TestReconcileRatchet_NoEvictionAfterCreate(t *testing.T) {
+	_, dbi, coll := ratchetFixture(t)
+
+	// Reader begun before the index exists, with a stale-baked verdict.
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+	reader, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{"a"}}))
+
+	dbi.checkStale(reader)
+	require.NoError(t, reader.Rollback())
+
+	require.Len(t, coll.(*collection).loadIndexes(), 1,
+		"stale pass evicted a freshly created index from the live set")
+	// The observed production symptom of the eviction: DropIndex not found.
+	require.NoError(t, coll.DropIndex(ctx, "a"))
+}

--- a/reconcile_ratchet_test.go
+++ b/reconcile_ratchet_test.go
@@ -84,3 +84,34 @@ func TestReconcileRatchet_NoEvictionAfterCreate(t *testing.T) {
 	// The observed production symptom of the eviction: DropIndex not found.
 	require.NoError(t, coll.DropIndex(ctx, "a"))
 }
+
+// A rolled-back DDL tx must leave the ratchet where it was: the bump happens
+// only in the commit publication, which a rollback drops. A moved ratchet
+// would make later same-cookie staleness passes skip reconciles for state
+// that never committed.
+func TestReconcileRatchet_RollbackLeavesRatchetUntouched(t *testing.T) {
+	fx, dbi, coll := ratchetFixture(t)
+	before := coll.(*collection).indexSetCookie
+
+	wtx, err := fx.WriteTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(wtx.Context(), IndexInfo{Fields: []string{"a"}}))
+	require.NoError(t, wtx.Rollback())
+
+	cc := coll.(*collection)
+	require.Empty(t, cc.loadIndexes(), "rollback must restore the published set")
+	require.Equal(t, before, cc.indexSetCookie, "rollback must not move the ratchet")
+
+	// The unmoved ratchet must not block a genuine staleness reconcile at the
+	// unchanged cookie (peer-bump emulation), and real DDL still works.
+	rtx, err := dbi.btreeDB.BeginRead()
+	require.NoError(t, err)
+	fcc, sc := rtx.DiskFileChangeCounter(), rtx.DiskSchemaCookie()
+	require.NoError(t, rtx.Rollback())
+	dbi.btreeDB.UpdateLocalCounters(fcc, sc-1)
+	n, err := coll.Find(`{"a":{"$gte":0}}`).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{"a"}}))
+	require.NoError(t, coll.DropIndex(ctx, "a"))
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -435,12 +435,12 @@ func (c *collection) loadVectorIndexAs(tx *btree.ReadTx, collName string, info I
 		return nil, err
 	}
 	vi.bindIdentity(collName)
-	// The opened state is visible from this snapshot's cookie on (reconcile
+	// The opened state is visible from this SNAPSHOT's cookie on (reconcile
 	// calls at tx begin, before any of this tx's writes; forTx's transient
-	// rebuild never republishes). A caller whose view may already hold
-	// uncommitted DDL must re-stamp begin+1 — init and createIndexes'
-	// publish block do.
-	vi.validFromCookie = tx.DiskSchemaCookie()
+	// rebuild never republishes; the raised begin-time cookie can exceed the
+	// snapshot). A caller whose view may already hold uncommitted DDL must
+	// re-stamp begin+1 — init and createIndexes' publish block do.
+	vi.validFromCookie = tx.SnapshotSchemaCookie()
 	return vi, nil
 }
 
@@ -769,7 +769,8 @@ func (vi *vectorIndex) forTx(tx *btree.ReadTx) (*vectorIndex, error) {
 	if tx.IsWriteTx() {
 		return vi, nil
 	}
-	cookie := tx.DiskSchemaCookie()
+	// Snapshot cookie, not the raised begin-time one — see visibleIndexes.
+	cookie := tx.SnapshotSchemaCookie()
 	for h := vi; h != nil; h = h.prev.Load() {
 		if cookie >= h.validFromCookie {
 			return h, nil


### PR DESCRIPTION
Fixes SYN-111 and SYN-112 — two silently-wrong-query-results mechanisms around index visibility under DDL churn, quantified by a demo (100 static docs, one index created/dropped 1500x, 8 concurrent readers): 1700–3500 silent `Count=0` per run, zero errors surfaced. Fixed: 0 across repeated runs.

**SYN-111 — visibility judged with the raised cookie.** `visibleIndexes`, range/fts `visibleTo`, and `vectorIndex.forTx` compared `DiskSchemaCookie` — the begin-time read raised to the newest committed frame — against `validFromCookie` as if it were the snapshot cookie. A begin racing a CreateIndex commit (or a pinned reader slot) then admits an index whose namespace the snapshot cannot resolve, and the scan silently returns wrong results. Foundation: the snapshot-bounded counter pair is now baked into the tx at begin (`SnapshotSchemaCookie` — a field read, hot-path safe; the raised read and the snapshot read coincide unless the bound was actually raised, so the common case costs nothing and only a racing begin pays a second bounded page-1 read). All visibility fast paths and the reconcile/open adopt-stamps switch to it; `checkStale` simplifies onto the baked fields.

**SYN-112 — stale-snapshot reconcile republication.** The dominant mechanism: a staleness pass with an older snapshot rebuilt the index sets from its older catalog and republished them db-wide — resurrecting a just-dropped index (readers at current snapshots pass `cookie >= validFrom`, there being no valid-until bound, and scan freed pages) or evicting a just-created one (concurrent `DropIndex` fails `ErrIndexNotFound`). Fix: per-collection publication ratchet (`indexSetCookie`) — an older-snapshot pass skips publication entirely (it consumes only its snapshot counters, so the verdict stays stale and a fresher begin converges); DDL publications ratchet to their commit cookie via `registerIndexSetRestore`. Rollback-safe by construction: the ratchet moves only in the commit publication, which rollback and failed commits drop.

Tests: three deterministic ratchet regressions (resurrection, eviction, rollback-immobility — each sabotage-verified to bite), btree pins updated for the baked fields, and the acceptance stress `TestRegression_IndexVisibilityUnderDDLChurn` in the test repo (fails on base, green on this branch). Full suite green plain and `-race` in both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)