### PR TITLE
fix: release read tx when Iter fails to prepare the statement

### DIFF
--- a/query.go
+++ b/query.go
@@ -136,9 +136,16 @@ func (q *collQuery) Iter(ctx context.Context) (iter Iterator, err error) {
 		qb.Close()
 		return
 	}
+	// the iterator owns tx on success and releases it on Close; until then any
+	// error path must release the connection back to the pool itself
+	defer func() {
+		if err != nil {
+			_ = tx.Commit()
+			qb.Close()
+		}
+	}()
 	stmt, err := tx.conn().Query(ctx, sqlRes)
 	if err != nil {
-		qb.Close()
 		return
 	}
 	for i, val := range qb.values {

--- a/query_test.go
+++ b/query_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -408,4 +409,31 @@ func TestFilterIn(t *testing.T) {
 		assert.Equal(t, 3, length)
 	})
 
+}
+
+func TestCollQuery_IterReleasesTxOnQueryError(t *testing.T) {
+	// With a single read connection, leaking the read tx on a failed Iter makes
+	// every subsequent read block forever in GetRead.
+	fx := newFixture(t, &Config{ReadConnections: 1})
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(`{"id":1, "a":1}`)))
+
+	// dropping the collection removes the underlying table, so preparing the
+	// query below fails inside Iter after the read tx has been acquired
+	require.NoError(t, coll.Drop(ctx))
+
+	_, err = coll.Find(nil).Iter(ctx)
+	require.Error(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = fx.GetCollectionNames(ctx)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("read blocked: Iter leaked the read connection")
+	}
 }


### PR DESCRIPTION
## Problem

`collQuery.Iter` acquires a read tx and hands ownership to the returned `Iterator`, which releases it on `Close()`. On the `tx.conn().Query(...)` error path the tx was dropped without `Commit`:

```go
tx, err := q.c.db.getReadTx(ctx)
if err != nil {
    qb.Close()
    return
}
stmt, err := tx.conn().Query(ctx, sqlRes)
if err != nil {
    qb.Close()
    return   // <- tx never committed or rolled back
}
```

`readTx.Commit()` (`tx.go:88-95`) is the only thing that calls `db.cm.ReleaseRead(conn)`, so the connection never returns to the pool.

Any `Query` failure triggers it — a missing table after `Drop`, an interrupted prepare from a cancelled context (`sqlite: prepare: interrupted`), an I/O error, `SQLITE_CORRUPT` on the schema.

## Why one leak is fatal rather than merely wasteful

With `Config.ReadConnections: 1`, that is the entire read pool. A single occurrence means every subsequent reader parks in `ConnManager.GetRead` waiting for a connection that will never come back, and the database is permanently unreadable for the life of the process.

This was hit in production via a shutdown path that cancels a replay context mid-prepare by design. The failed `Iter` wedged the store, and the code that runs during shutdown then hung on reads that could never complete.

Minimal repro, no cancellation involved:

```go
coll.Drop(ctx)                 // underlying table is gone
coll.Find(nil).Iter(ctx)       // -> "sqlite: prepare: SQL logic error: no such table: _c_docs"

store.Manifest(ctx)            // never returns
```

## Fix

Release the tx from a deferred cleanup keyed on the named return, so the whole window between acquiring the tx and handing ownership to the iterator is covered rather than just today's single error path.

`Commit` rather than a rollback because `ReadTx` has no `Rollback`, and this matches what `doReadTx` already does on its error path (`db.go:530-534`). It is also correct for the nested-transaction case: `getReadTx` returns a `noOpTx` when the caller supplied an ambient tx, and that `Commit` is a no-op, so we never commit someone else's transaction.

## Test

`TestCollQuery_IterReleasesTxOnQueryError` runs the repro above against a db configured with a single read connection and puts a watchdog on a following read. It fails on `main` with `read blocked: Iter leaked the read connection`, and passes with the fix under `-race`.

## Notes

- The prepare error is deliberately **not** routed through `replaceInterruptErr` here, even though `iterator.Next()` does that for step-time interrupts. It would convert `prepare: interrupted` into `ErrDBIsClosed` and change what callers observe, which does not belong in a leak fix. Worth a separate change if the two interrupt sites should agree.
- Full suite passes with `-race`. Two failures are pre-existing on `main` (verified by stashing): the `go vet` `unsafe.Pointer` warnings in `internal/driver/sqlite.go`, and `TestSyncPools_GetDocBuf`, which asserts `sync.Pool` retention that `-race` disables.