### PR TITLE
fix: roll back and mark modified correctly in query Update/Delete

### DIFF
--- a/query.go
+++ b/query.go
@@ -182,9 +182,12 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	defer func() {
 		if err != nil {
 			_ = tx.Rollback()
-		} else {
-			err = tx.Commit()
+			return
 		}
+		if result.Modified > 0 {
+			tx.SetModified()
+		}
+		err = tx.Commit()
 	}()
 
 	if err = q.c.checkStmts(tx.Context(), tx.conn()); err != nil {
@@ -200,7 +203,11 @@ func (q *collQuery) Update(ctx context.Context, modifier any) (result ModifyResu
 	for i, val := range qb.values {
 		stmt.BindBytes(i+1, val)
 	}
-	iter := q.newIterator(stmt, tx, qb)
+	// tx ownership stays with the deferred commit/rollback above, so the
+	// iterator gets no tx: iterator.Close is deferred later and therefore runs
+	// first, and if it committed the tx the rollback below would find the tx
+	// already done and silently no-op
+	iter := q.newIterator(stmt, nil, qb)
 	defer func() {
 		_ = iter.Close()
 	}()
@@ -256,9 +263,12 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	defer func() {
 		if err != nil {
 			_ = tx.Rollback()
-		} else {
-			err = tx.Commit()
+			return
 		}
+		if result.Modified > 0 {
+			tx.SetModified()
+		}
+		err = tx.Commit()
 	}()
 
 	if err = q.c.checkStmts(tx.Context(), tx.conn()); err != nil {
@@ -274,7 +284,11 @@ func (q *collQuery) Delete(ctx context.Context) (result ModifyResult, err error)
 	for i, val := range qb.values {
 		stmt.BindBytes(i+1, val)
 	}
-	iter := q.newIterator(stmt, tx, qb)
+	// tx ownership stays with the deferred commit/rollback above, so the
+	// iterator gets no tx: iterator.Close is deferred later and therefore runs
+	// first, and if it committed the tx the rollback below would find the tx
+	// already done and silently no-op
+	iter := q.newIterator(stmt, nil, qb)
 	defer func() {
 		_ = iter.Close()
 	}()

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,8 @@
 package anystore
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -436,4 +438,105 @@ func TestCollQuery_IterReleasesTxOnQueryError(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("read blocked: Iter leaked the read connection")
 	}
+}
+
+func TestCollQuery_UpdateRollsBackOnError(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Fields: []string{"u"}, Unique: true}))
+	require.NoError(t, coll.Insert(ctx,
+		anyenc.MustParseJson(`{"id":1, "u":1}`),
+		anyenc.MustParseJson(`{"id":2, "u":2}`),
+	))
+
+	// $set u:9 succeeds for the first doc, then collides with it on the second,
+	// so the update fails after having already written
+	_, err = coll.Find(nil).Update(ctx, `{"$set": {"u": 9}}`)
+	require.Error(t, err)
+
+	// the write of the first doc must not survive the failed update
+	doc, err := coll.FindId(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), doc.Value().GetFloat64("u"))
+}
+
+func TestCollQuery_UpdateDeleteMarkTxModified(t *testing.T) {
+	// Update/Delete run their own write tx. Without SetModified the tx is
+	// released as EventReleaseWriteWithoutChanges, so the durability controller
+	// never marks the db dirty for writes made through a query.
+	insert := func(t *testing.T, fx *fixture, name string) Collection {
+		coll, err := fx.CreateCollection(ctx, name)
+		require.NoError(t, err)
+		require.NoError(t, coll.Insert(ctx,
+			anyenc.MustParseJson(`{"id":1, "a":1}`),
+			anyenc.MustParseJson(`{"id":2, "a":2}`),
+		))
+		return coll
+	}
+
+	// white-box: run inside a caller-supplied tx so the flag is observable
+	t.Run("update marks the tx", func(t *testing.T) {
+		fx := newFixture(t)
+		coll := insert(t, fx, "test")
+		tx, err := fx.WriteTx(ctx)
+		require.NoError(t, err)
+		res, err := coll.Find(nil).Update(tx.Context(), `{"$set": {"a": 42}}`)
+		require.NoError(t, err)
+		require.Equal(t, 2, res.Modified)
+		assert.True(t, tx.(writeTx).modified, "tx not marked modified")
+		require.NoError(t, tx.Commit())
+	})
+
+	t.Run("delete marks the tx", func(t *testing.T) {
+		fx := newFixture(t)
+		coll := insert(t, fx, "test")
+		tx, err := fx.WriteTx(ctx)
+		require.NoError(t, err)
+		res, err := coll.Find(nil).Delete(tx.Context())
+		require.NoError(t, err)
+		require.Equal(t, 2, res.Modified)
+		assert.True(t, tx.(writeTx).modified, "tx not marked modified")
+		require.NoError(t, tx.Commit())
+	})
+
+	t.Run("no match leaves the tx unmarked", func(t *testing.T) {
+		fx := newFixture(t)
+		coll := insert(t, fx, "test")
+		tx, err := fx.WriteTx(ctx)
+		require.NoError(t, err)
+		res, err := coll.Find(`{"a": 999}`).Update(tx.Context(), `{"$set": {"a": 42}}`)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Modified)
+		assert.False(t, tx.(writeTx).modified, "tx marked modified without writes")
+		require.NoError(t, tx.Commit())
+	})
+
+	// end-to-end: the sentinel file is the observable consequence of the
+	// EventReleaseWriteWithChanges the standalone tx must emit
+	t.Run("standalone update marks the db dirty", func(t *testing.T) {
+		conf := &Config{Durability: DurabilityConfig{Sentinel: true}}
+		tmpDir, err := os.MkdirTemp("", "any-store-*")
+		require.NoError(t, err)
+		dbPath := filepath.Join(tmpDir, "any-store-test.db")
+		sentinelPath := dbPath + ".lock"
+
+		fx := newFixturePath(t, tmpDir, conf)
+		insert(t, fx, "test")
+		// the inserts above mark the db dirty; closing clears the sentinel so
+		// the query update below is the only thing that can set it again
+		require.NoError(t, fx.DB.Close())
+		require.NoFileExists(t, sentinelPath)
+
+		reopened, err := Open(ctx, dbPath, conf)
+		require.NoError(t, err)
+		defer func() { _ = reopened.Close() }()
+		coll, err := reopened.OpenCollection(ctx, "test")
+		require.NoError(t, err)
+
+		res, err := coll.Find(nil).Update(ctx, `{"$set": {"a": 42}}`)
+		require.NoError(t, err)
+		require.Equal(t, 2, res.Modified)
+		assert.FileExists(t, sentinelPath, "query update did not mark the db dirty")
+	})
 }


### PR DESCRIPTION
> **Stacked on #159.** Base is `fix-iter-read-conn-leak` so the `query_test.go` appends don't conflict; GitHub will retarget this to `main` once #159 merges. The diff below is only this change.

Two problems in `collQuery.Update` and `collQuery.Delete`, both from the write tx being owned in two places at once. Follow-up to the review on #159.

## 1. The rollback never ran — errors committed their partial writes

`query.go:182` registers the commit/rollback defer, then `query.go:204` registers the `iter.Close()` defer. LIFO means `iter.Close()` runs **first**, and `iterator.Close()` calls `i.tx.Commit()` — which here is `writeTx.Commit()`, since the iterator was handed the write tx. That zeroes the tx version via `CompareAndSwap`. The outer `tx.Rollback()` then finds the tx already done and returns `nil` without touching anything.

Measured on `main` by instrumenting the real defers, with a unique-index collision on the second document:

```
PROBE iter.Close() about to run: tx.Done() = false
PROBE iter.Close() done:         tx.Done() = true
PROBE outer defer runs: err!=nil = true | tx.Done() already = true
PROBE Rollback returned; tx.Done() = true
Update returned err: any-store: unique constraint violation
doc1 after FAILED update: {"id":1,"u":9}
```

The first document kept the value written by the update that failed. `collection.update` has no internal savepoint or commit, so that persistence comes from the tx commit itself.

The same ordering also **swallowed commit errors**: the real commit happened inside the discarded `_ = iter.Close()`, and the outer `err = tx.Commit()` then no-opped to `nil`. A failing COMMIT would have been reported as success.

This also affected the nested case, where `WriteTx` returns a `savepointWrapper` — `iter.Close()` released the savepoint (keeping the changes) instead of rolling back to it.

**Fix:** don't hand the tx to the iterator. The deferred commit/rollback becomes the single owner, and `iterator.Close()` already guards with `if i.tx != nil`. Statement teardown still happens before commit or rollback, because the `iter.Close()` defer keeps running first.

## 2. `SetModified` was never called — these writes skipped durability bookkeeping

The only `SetModified()` call sites were `db.go:476` and `db.go:492`, both inside `doWriteTx`/`doWriteTxModified`. A query `Update`/`Delete` runs its own tx and never called it, so `writeTx.Commit()` released with `noChanges = !w.modified` → `true`:

```
--- direct coll.UpdateId (goes through doWriteTx) ---
PROBE writeTx.Commit: modified = true  -> releases with noChanges = false
--- query Update (own tx) ---
PROBE writeTx.Commit: modified = false -> releases with noChanges = true
query Update modified 1 docs
```

That emits `EventReleaseWriteWithoutChanges`, and `durability.Controller.OnWriteEvent` (`internal/durability/controller.go:119`) only reacts to `EventReleaseWriteWithChanges`. So documents written through a query never marked the sentinel dirty, never updated `lastWriteTime`, and never armed the auto-flush timer — an unclean shutdown after a query-only write would not be detected on the next open.

(Not a stale-flag artifact: `newWriteTx` resets `tx.modified = false` at `db.go:241`.)

**Fix:** mark the tx modified when the operation actually changed something, keyed on `result.Modified` so a query matching nothing stays unmarked — preserving the point of the flag.

## Tests

All four assertions fail on the parent commit and pass with the fix:

| Test | Failure without the fix |
|---|---|
| `TestCollQuery_UpdateRollsBackOnError` | doc keeps the value written by the failed update |
| `.../update_marks_the_tx` | `tx not marked modified` |
| `.../delete_marks_the_tx` | `tx not marked modified` |
| `.../standalone_update_marks_the_db_dirty` | `unable to find file ...any-store-test.db.lock` |

The `modified` flag is asserted white-box by running the query inside a caller-supplied `WriteTx`. The standalone path is covered end-to-end through the sentinel file, which is the observable consequence of the release event — the subtest closes and reopens the db first, since the setup inserts already mark it dirty.

Full suite passes with `-race`; the new tests are stable over `-count=10 -race`.

## Not covered

`Delete`'s rollback path has no dedicated test. Deletes can't violate a constraint, so there's no deterministic way to fail mid-loop without a racy cancellation. The fix is structurally identical to `Update`'s and `Delete`'s tx-ownership change is exercised by the `delete_marks_the_tx` test, but the rollback-on-error behaviour itself is verified only for `Update`.