### PR TITLE
docs: add NOTICE.md with SQLite/SQLCipher provenance

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,100 @@
+# Third-Party Notices
+
+Any Store is licensed under the MIT License (see [LICENSE.md](LICENSE.md)). Its
+storage engine derives from two upstream projects, noted below.
+
+Per-site provenance is tracked in
+[`docs/btree/mappings/`](docs/btree/mappings/) and cited inline in
+`internal/btree/`. Pinned upstream versions:
+[`docs/btree/UPSTREAM.md`](docs/btree/UPSTREAM.md).
+
+---
+
+## SQLite — Public Domain
+
+Any Store's btree, pager and WAL are a Go implementation aligned with SQLite's
+design. The on-disk format is our own and is not SQLite-compatible.
+
+SQLite's source is released into the public domain by its authors, so no
+attribution is required. It is recorded here for transparency.
+
+> The author disclaims copyright to this source code. In place of
+> a legal notice, here is a blessing:
+>
+> * May you do good and not evil.
+> * May you find forgiveness for yourself and forgive others.
+> * May you share freely, never taking more than you give.
+
+SQLite is a trademark of Hipp, Wyrick & Company, Inc. Any Store is not
+affiliated with or endorsed by them.
+
+---
+
+## SQLCipher — BSD-3-Clause
+
+Any Store's optional page-level encryption is an independent Go implementation
+following design conventions established by SQLCipher. **No SQLCipher source
+code is included, translated, or linked.**
+
+**Reused** — conventions, re-implemented from scratch:
+
+* reserved-tail page overhead, 16-byte aligned;
+* the page-1 plaintext-prefix rule, keeping the DB header readable before key
+  derivation;
+* PBKDF2-HMAC-SHA256 key derivation with SQLCipher 4.x's default iteration
+  count;
+* placement of codec invocation points in the pager and WAL write paths — 5 of
+  35 upstream codec hook sites; the other 30 are deliberately omitted.
+
+**Not reused** — SQLCipher's cryptographic implementation (`sqlcipher.c`,
+`crypto_*.c`) is not ported. Any Store uses Go standard-library and
+`golang.org/x/crypto` primitives.
+
+**Divergent** — Any Store uses AEAD ciphers (AES-256-GCM, ChaCha20-Poly1305,
+XChaCha20-Poly1305) rather than SQLCipher's AES-256-CBC + HMAC-SHA512, with a
+different per-page layout. Any Store cannot read or write SQLCipher databases.
+
+SQLCipher is a trademark of Zetetic LLC. Any Store is not affiliated with,
+endorsed by, or sponsored by Zetetic LLC; the name is used only to describe the
+origin of these design conventions.
+
+```
+Copyright (c) 2025, ZETETIC LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the ZETETIC LLC nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ZETETIC LLC BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## Go dependencies
+
+Every module in the shipped build graph is under MIT, BSD-2-Clause or
+BSD-3-Clause. Test-only dependencies add ISC and Apache-2.0. No dependency,
+shipped or test-only, is copyleft.
+
+Regenerate the per-module list with `go-licenses`, or:
+
+```sh
+go list -deps -f '{{if .Module}}{{.Module.Path}}{{end}}' ./... | sort -u
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/anyproto/any-store/v2.svg)](https://pkg.go.dev/github.com/anyproto/any-store/v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/anyproto/any-store/v2)](https://goreportcard.com/report/github.com/anyproto/any-store/v2)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 
 A **document-oriented embedded database** for Go with a MongoDB-like query language, built on an in-tree btree/pager/WAL storage engine derived from SQLite (aligned with its design, not a literal port — the on-disk format is our own).
 Schema-less documents, rich indexes, full-text and vector search, ACID transactions, multi-process access, page-level integrity and optional encryption — pure Go, no CGO.
@@ -218,6 +218,8 @@ db, _ := anystore.Open(ctx, "data.db", &anystore.Config{
 
 Whole-file page-level AEAD; bring-your-own key management via `EncryptionConfig.Codec`.
 
+An independent Go implementation following design conventions from [SQLCipher](https://www.zetetic.net/sqlcipher/) (BSD-3-Clause) — reserved-tail page overhead, the page-1 plaintext-prefix rule, PBKDF2-HMAC-SHA256 key derivation. No SQLCipher code is included; the cryptography is Go-native and uses AEAD rather than SQLCipher's encrypt-then-MAC construction. Not SQLCipher-compatible on disk. See [NOTICE.md](NOTICE.md).
+
 ## Documentation
 
 * **API reference** — [pkg.go.dev/github.com/anyproto/any-store/v2](https://pkg.go.dev/github.com/anyproto/any-store/v2)
@@ -238,4 +240,6 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ## ⚖️ License
 
-Any Store is released under the MIT License — see [LICENSE](LICENSE) for details.
+Any Store is released under the MIT License — see [LICENSE.md](LICENSE.md).
+
+The storage engine derives from SQLite (public domain) and follows page-encryption design conventions from SQLCipher (BSD-3-Clause). Neither project's source is included. Attribution and scope: [NOTICE.md](NOTICE.md).

--- a/internal/btree/codec.go
+++ b/internal/btree/codec.go
@@ -1,5 +1,12 @@
 package btree
 
+// Page encryption in this package is an independent Go implementation that
+// follows design conventions from SQLCipher (BSD-3-Clause, Zetetic LLC) —
+// reserved-tail page overhead, the page-1 plaintext-prefix rule, and PBKDF2
+// key derivation — using Go-native AEAD primitives. No SQLCipher code is
+// included. Scope and attribution: NOTICE.md. Per-site provenance:
+// docs/btree/mappings/sqlcipher_codec.json.
+
 import (
 	"crypto/rand"
 	"errors"


### PR DESCRIPTION
Documents the SQLite and SQLCipher provenance of the v2 storage engine.

any-store remains MIT. SQLite's source is public domain — no obligations. SQLCipher is BSD-3-Clause: permissive and MIT-compatible, requiring only that its notice be retained and its non-endorsement clause respected. `LICENSE.md` is unchanged.

`NOTICE.md` scopes the SQLCipher relationship, each point verifiable against `docs/btree/mappings/sqlcipher_codec.json`:

- **Reused** — conventions re-implemented in Go: 16-byte-aligned reserved-tail page overhead, page-1 plaintext-prefix rule, PBKDF2-HMAC-SHA256 with SQLCipher 4.x default iterations, and codec hook placement (5 of 35 upstream sites; the other 30 deliberately omitted).
- **Not reused** — `sqlcipher.c` and `crypto_*.c` are not ported. Crypto is Go stdlib + `golang.org/x/crypto`.
- **Divergent** — AEAD (AES-256-GCM, ChaCha20/XChaCha20-Poly1305) instead of AES-256-CBC + HMAC-SHA512, different per-page layout, no SQLCipher on-disk compatibility.

License texts are reproduced verbatim from the pinned upstreams in `../sqlcipher`. Trademark disclaimers included for both Zetetic and Hipp, Wyrick & Company.

Also:

- README — provenance in the Encryption and License sections.
- `internal/btree/codec.go` — package comment pointing at `NOTICE.md`.
- Fixed the README license badge and footer, which linked to `LICENSE` (the file is `LICENSE.md`).
