### PR TITLE
feat: report any-store v2 files explicitly on Open

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -92,7 +94,37 @@ type DBStats struct {
 // Open opens a database at the specified path with the given configuration.
 // The config parameter can be nil for default settings.
 // Returns a DB instance or an error.
+// v2Magic is the file header any-store v2 writes at offset 0. It is 15 bytes;
+// v2 zero-fills the rest of the 16-byte header slot and validates only these
+// bytes. v1 files start with SQLite's own "SQLite format 3\x00" instead.
+const v2Magic = "BTree format 1\x00"
+
+// checkNotV2Database reports ErrV2Database when path holds an any-store v2
+// file. Without this, SQLite rejects it with an opaque "file is not a database".
+// Anything that is not a readable v2 header is left to the normal open path,
+// which also covers a missing file (Open creates one).
+func checkNotV2Database(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	var hdr [len(v2Magic)]byte
+	if _, err = io.ReadFull(f, hdr[:]); err != nil {
+		return nil
+	}
+	if string(hdr[:]) == v2Magic {
+		return ErrV2Database
+	}
+	return nil
+}
+
 func Open(ctx context.Context, path string, config *Config) (DB, error) {
+	if err := checkNotV2Database(path); err != nil {
+		return nil, err
+	}
 	if config == nil {
 		config = &Config{}
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -254,3 +254,44 @@ func (fx *fixture) finish() {
 		}
 	}
 }
+
+func TestOpen_AnyStoreV2File(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("v2 file is reported explicitly", func(t *testing.T) {
+		path := filepath.Join(dir, "v2.db")
+		// The header any-store v2 writes: the 15-byte magic, zero-filled to the
+		// 16-byte header slot. Verified against a real v2 file:
+		//   00000000: 4254 7265 6520 666f 726d 6174 2031 0000  BTree format 1..
+		page := make([]byte, 4096)
+		copy(page, "BTree format 1\x00")
+		require.NoError(t, os.WriteFile(path, page, 0o600))
+
+		db, err := Open(ctx, path, nil)
+		require.ErrorIs(t, err, ErrV2Database)
+		require.Nil(t, db)
+	})
+
+	t.Run("v1 file still opens", func(t *testing.T) {
+		path := filepath.Join(dir, "v1.db")
+		db, err := Open(ctx, path, nil)
+		require.NoError(t, err)
+		coll, err := db.CreateCollection(ctx, "test")
+		require.NoError(t, err)
+		require.NoError(t, coll.Close())
+		require.NoError(t, db.Close())
+
+		db, err = Open(ctx, path, nil)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+	})
+
+	t.Run("other garbage keeps the generic error", func(t *testing.T) {
+		path := filepath.Join(dir, "garbage.db")
+		require.NoError(t, os.WriteFile(path, []byte("this is not a database at all"), 0o600))
+
+		_, err := Open(ctx, path, nil)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrV2Database)
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -52,6 +52,10 @@ var (
 
 	ErrDBIsNotOpened       = driver.ErrDBIsNotOpened
 	ErrIncompatibleVersion = driver.ErrIncompatibleVersion
+
+	// ErrV2Database is returned by Open when the file was created by any-store
+	// v2, which uses a different storage engine and cannot be read by v1.
+	ErrV2Database = errors.New("any-store: file is an any-store v2 database, not readable by v1; use github.com/anyproto/any-store/v2")
 )
 
 func replaceUniqErr(err, replaceTo error) error {


### PR DESCRIPTION
Opening a v2 database with v1 failed with SQLite's opaque `file is not a
database`, giving no hint that the file is just a newer format:

```
sqlite: open "crdt.db": sqlite: prepare: file is not a database
```

`Open` now checks the 15-byte header any-store v2 writes at offset 0 and
returns `ErrV2Database`, which names the format and points at the v2 module:

```
any-store: file is an any-store v2 database, not readable by v1; use github.com/anyproto/any-store/v2
```

Anything that is not a readable v2 header falls through to the normal open path,
so a missing file still creates a database and other garbage keeps the generic
SQLite error.

Verified against real v2 files produced by a v1→v2 migration, and against a real
v1 file to confirm it still opens.