### PR TITLE
feat: detect the renamed any-store v2 header magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 A **document‑oriented database** with a MongoDB‑like query language, running on top of a single SQLite file.
 Any Store brings schema‑less flexibility, rich indexes and ACID transactions to embedded Go applications.
 
-> ⚠️ **Status:** pre‑1.0 – APIs may change. We actively dog‑food the library in production and welcome early adopters & contributors.
-
-
 ## Features
 
 * **Mongo‑style queries** – `$in`, `$inc`, comparison & logical operators out of the box.

--- a/db.go
+++ b/db.go
@@ -94,10 +94,14 @@ type DBStats struct {
 // Open opens a database at the specified path with the given configuration.
 // The config parameter can be nil for default settings.
 // Returns a DB instance or an error.
-// v2Magic is the file header any-store v2 writes at offset 0. It is 15 bytes;
-// v2 zero-fills the rest of the 16-byte header slot and validates only these
-// bytes. v1 files start with SQLite's own "SQLite format 3\x00" instead.
-const v2Magic = "BTree format 1\x00"
+// any-store v2 writes a 16-byte magic at offset 0. v2Magic is what current v2
+// builds write; v2MagicLegacy was written before the format was renamed and is
+// still present in databases created by earlier builds. Both are zero-padded to
+// the full field width. v1 files start with SQLite's "SQLite format 3\x00".
+const (
+	v2Magic       = "any-store v2\x00\x00\x00\x00"
+	v2MagicLegacy = "BTree format 1\x00\x00"
+)
 
 // checkNotV2Database reports ErrV2Database when path holds an any-store v2
 // file. Without this, SQLite rejects it with an opaque "file is not a database".
@@ -115,7 +119,8 @@ func checkNotV2Database(path string) error {
 	if _, err = io.ReadFull(f, hdr[:]); err != nil {
 		return nil
 	}
-	if string(hdr[:]) == v2Magic {
+	switch string(hdr[:]) {
+	case v2Magic, v2MagicLegacy:
 		return ErrV2Database
 	}
 	return nil

--- a/db_test.go
+++ b/db_test.go
@@ -258,19 +258,25 @@ func (fx *fixture) finish() {
 func TestOpen_AnyStoreV2File(t *testing.T) {
 	dir := t.TempDir()
 
-	t.Run("v2 file is reported explicitly", func(t *testing.T) {
-		path := filepath.Join(dir, "v2.db")
-		// The header any-store v2 writes: the 15-byte magic, zero-filled to the
-		// 16-byte header slot. Verified against a real v2 file:
-		//   00000000: 4254 7265 6520 666f 726d 6174 2031 0000  BTree format 1..
-		page := make([]byte, 4096)
-		copy(page, "BTree format 1\x00")
-		require.NoError(t, os.WriteFile(path, page, 0o600))
+	// Both magics any-store v2 has written, each zero-filled to the 16-byte
+	// header field. Verified against real v2 files:
+	//   00000000: 616e 792d 7374 6f72 6520 7632 0000 0000  any-store v2....
+	//   00000000: 4254 7265 6520 666f 726d 6174 2031 0000  BTree format 1..
+	for _, tc := range []struct{ name, magic string }{
+		{"current magic", "any-store v2\x00"},
+		{"legacy magic", "BTree format 1\x00"},
+	} {
+		t.Run("v2 file is reported explicitly: "+tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".db")
+			page := make([]byte, 4096)
+			copy(page, tc.magic)
+			require.NoError(t, os.WriteFile(path, page, 0o600))
 
-		db, err := Open(ctx, path, nil)
-		require.ErrorIs(t, err, ErrV2Database)
-		require.Nil(t, db)
-	})
+			db, err := Open(ctx, path, nil)
+			require.ErrorIs(t, err, ErrV2Database)
+			require.Nil(t, db)
+		})
+	}
 
 	t.Run("v1 file still opens", func(t *testing.T) {
 		path := filepath.Join(dir, "v1.db")


### PR DESCRIPTION
Companion to the v2-side rename. v2 now writes `any-store v2\0` (zero-padded to
the 16-byte magic field) in newly created databases and still accepts the
previous `BTree format 1\0`, so `Open` must recognise both to keep returning
`ErrV2Database` instead of SQLite's opaque `file is not a database`.

Verified against real files — one written by the patched v2, one by an earlier
build, one genuine v1 database:

```
"any-store v2\x00\x00\x00\x00"  ErrV2Database=true
"BTree format 1\x00\x00"        ErrV2Database=true
"SQLite format 3\x00"           ErrV2Database=false  (opens normally)
```

Also drops the `pre-1.0 – APIs may change` banner from the README: v1.0.0 is
tagged, this line is frozen and only bug fixes land here.