### PR TITLE
feat: rename the database header magic to "any-store v2"

### DIFF
--- a/docs/btree/NOTES.md
+++ b/docs/btree/NOTES.md
@@ -218,7 +218,7 @@ Both implementations follow the same 100-byte layout:
 
 | Offset | Size | SQLite | Go |
 |--------|------|--------|-----|
-| 0 | 16 | `"SQLite format 3\000"` | `"BTree format 1\000"` |
+| 0 | 16 | `"SQLite format 3\000"` | `"any-store v2\000"`, zero-padded (reads also accept the legacy `"BTree format 1\000"`) |
 | 16 | 2 | Page size | Page size |
 | 18 | 1 | File format write version | File format write version |
 | 19 | 1 | File format read version | File format read version |
@@ -250,7 +250,7 @@ Both implementations follow the same 100-byte layout:
 
 | Aspect | SQLite | Go |
 |--------|--------|-----|
-| Magic string | `"SQLite format 3\000"` | `"BTree format 1\000"` |
+| Magic string | `"SQLite format 3\000"` | `"any-store v2\000"` written; `"BTree format 1\000"` still accepted |
 | Version number (offset 96) | SQLite library version (e.g., 3049000) | Hardcoded `1` |
 | Auto-vacuum field (offset 52) | Largest root B-tree page number | Always 0 |
 | Incremental vacuum (offset 64) | 0 or 1 | Always 0 |

--- a/internal/btree/btree_ops_test.go
+++ b/internal/btree/btree_ops_test.go
@@ -1380,7 +1380,10 @@ func TestRebuildLeafPageOnPage1(t *testing.T) {
 
 	bt := &btree{pager: p, rootPage: 1, writable: true}
 	require.NoError(t, bt.rebuildLeafPage(pg, []cellData{{key: []byte("ns1"), value: []byte{0, 0, 0, 2}}}))
-	assert.Equal(t, byte('B'), pg.data[0])
+	// Page 1 carries the database header; the rebuild must not clobber it.
+	// Literal on purpose: a rename or edit of dbMagicV2 must fail here rather
+	// than pass by comparing the constant against itself.
+	assert.Equal(t, "any-store v2\x00\x00\x00\x00", string(pg.data[0:16]))
 	p.releasePage(pg)
 }
 

--- a/internal/btree/btree_test.go
+++ b/internal/btree/btree_test.go
@@ -1459,7 +1459,10 @@ func TestRebuildInteriorPageOnPage1(t *testing.T) {
 	}
 	bt.rebuildInteriorPage(pg, cells, 6)
 
-	assert.Equal(t, byte('B'), pg.data[0])
+	// Page 1 carries the database header; the rebuild must not clobber it.
+	// Literal on purpose: a rename or edit of dbMagicV2 must fail here rather
+	// than pass by comparing the constant against itself.
+	assert.Equal(t, "any-store v2\x00\x00\x00\x00", string(pg.data[0:16]))
 	assert.Equal(t, uint8(pageTypeIntIdx), pg.data[dbHeaderSize])
 
 	p.releasePage(pg)

--- a/internal/btree/page.go
+++ b/internal/btree/page.go
@@ -5,7 +5,8 @@ package btree
 // Database header (first 100 bytes of page 1):
 //
 //	Offset  Size  Description
-//	0       16    Magic string "BTree format 1\000"
+//	0       16    Magic string "any-store v2\000" (zero-padded to 16;
+//	              "BTree format 1\000" still accepted, see dbMagicV1)
 //	16      2     Page size in bytes
 //	18      1     File format write version (1=legacy, 2=WAL)
 //	19      1     File format read version (1=legacy, 2=WAL)
@@ -71,7 +72,13 @@ const (
 	dbHeaderSize = 100
 
 	// Magic string identifying our database format.
-	dbMagic = "BTree format 1\x00"
+	// dbMagicV2 is the header magic written by newly created databases. The magic
+	// field is 16 bytes, so both constants are zero-padded to that width and the
+	// whole field is compared on read — no byte of it goes unchecked.
+	dbMagicV2 = "any-store v2\x00\x00\x00\x00"
+	// dbMagicV1 is the magic used before the rename. It is still accepted so that
+	// databases created by earlier v2 builds keep opening.
+	dbMagicV1 = "BTree format 1\x00\x00"
 
 	// Page type flags (matching SQLite).
 	pageTypeIntIdx  = 2  // Interior index b-tree page
@@ -180,9 +187,9 @@ type dbHeader struct {
 }
 
 // serialize writes the database header to the first 100 bytes of buf.
-// DRIFT: DB header: 'BTree format 1' magic, version=1, KDF salt at 72-87, auto/incr-vacuum fields z See docs/btree/NOTES.md#old-drift-db-file-header-magic-version-salt-vacuum
+// DRIFT: DB header: 'any-store v2' magic (legacy 'BTree format 1' still read), version=1, KDF salt at 72-87, auto/incr-vacuum fields z See docs/btree/NOTES.md#old-drift-db-file-header-magic-version-salt-vacuum
 func (h *dbHeader) serialize(buf []byte) {
-	copy(buf[0:16], dbMagic)
+	copy(buf[0:16], dbMagicV2)
 
 	var ps uint16
 	if h.PageSize >= 65536 {
@@ -236,7 +243,7 @@ func (h *dbHeader) deserialize(buf []byte) error {
 		return ErrCorrupt
 	}
 
-	if string(buf[0:15]) != dbMagic[:15] {
+	if magic := string(buf[0:16]); magic != dbMagicV2 && magic != dbMagicV1 {
 		return ErrCorrupt
 	}
 

--- a/internal/btree/page_test.go
+++ b/internal/btree/page_test.go
@@ -30,8 +30,10 @@ func TestDBHeaderSerializeDeserialize(t *testing.T) {
 	buf := make([]byte, dbHeaderSize)
 	h.serialize(buf)
 
-	// Verify magic string (dbMagic is 15 bytes; byte 16 is the null terminator from zeroed buf)
-	assert.Equal(t, dbMagic, string(buf[0:len(dbMagic)]))
+	// New databases carry the v2 magic across the whole 16-byte field.
+	// Literal on purpose: a rename or edit of dbMagicV2 must fail here rather
+	// than pass by comparing the constant against itself.
+	assert.Equal(t, "any-store v2\x00\x00\x00\x00", string(buf[0:16]))
 
 	var h2 dbHeader
 	require.NoError(t, h2.deserialize(buf))
@@ -135,7 +137,8 @@ func TestOpenRejectsUsableSizeBelow480(t *testing.T) {
 }
 
 func TestDBHeaderNotSQLiteCompatible(t *testing.T) {
-	assert.NotEqual(t, "SQLite format 3\000", dbMagic)
+	assert.NotEqual(t, "SQLite format 3\000", dbMagicV2)
+	assert.NotEqual(t, "SQLite format 3\000", dbMagicV1)
 }
 
 // TestDBHeaderRejectsGenuineSQLiteMagic pins the assumed invariant that the
@@ -160,11 +163,13 @@ func TestDBHeaderNotSQLiteCompatible(t *testing.T) {
 func TestDBHeaderRejectsGenuineSQLiteMagic(t *testing.T) {
 	const sqliteMagic = "SQLite format 3\x00" // 16 bytes, the genuine SQLite header magic
 
-	// Guard: the two formats' 15-byte magic prefixes (the bytes deserialize
-	// actually compares) must differ. If a refactor ever made them coincide,
-	// the behavioral rejection below could not hold.
-	require.NotEqual(t, sqliteMagic[:15], dbMagic[:15],
-		"magic prefixes coincide: a genuine SQLite file (with 5/13 table pages) could be opened and traversed with index-cell layout")
+	// Guard: neither accepted magic may coincide with SQLite's over the 16 bytes
+	// deserialize compares. If a refactor ever made them coincide, the
+	// behavioral rejection below could not hold.
+	require.NotEqual(t, sqliteMagic, dbMagicV2,
+		"magic coincides with SQLite: a genuine SQLite file (with 5/13 table pages) could be opened and traversed with index-cell layout")
+	require.NotEqual(t, sqliteMagic, dbMagicV1,
+		"legacy magic coincides with SQLite: a genuine SQLite file (with 5/13 table pages) could be opened and traversed with index-cell layout")
 
 	// Build a header that is byte-for-byte acceptable to deserialize EXCEPT for
 	// its magic: start from a valid any-store header (valid page size, valid
@@ -192,8 +197,7 @@ func TestDBHeaderRejectsGenuineSQLiteMagic(t *testing.T) {
 	// Positive control: restoring only the magic to any-store's value makes the
 	// very same buffer deserialize cleanly. This proves the magic bytes are the
 	// gate (the test fails for the right reason, not because of unrelated bytes).
-	copy(buf[0:16], dbMagic)
-	buf[15] = 0 // dbMagic is 15 bytes; ensure byte 15 (null terminator) is zero
+	copy(buf[0:16], dbMagicV2)
 	var h2 dbHeader
 	assert.NoError(t, h2.deserialize(buf),
 		"buffer differing from a valid header only in the magic must parse once the any-store magic is restored")
@@ -388,4 +392,35 @@ func TestPageUsableSize(t *testing.T) {
 	pg := &page{data: make([]byte, 4096)}
 	assert.Equal(t, 4096, pg.usableSize(0))
 	assert.Equal(t, 4088, pg.usableSize(8))
+}
+
+// TestDBHeaderMagicWidth pins both magics to the width of the header field.
+// A constant longer than 16 bytes would silently overwrite the page size at
+// offset 16; a shorter one must be zero-padded so the full-field compare in
+// deserialize still matches what serialize wrote.
+func TestDBHeaderMagicWidth(t *testing.T) {
+	assert.Len(t, dbMagicV2, 16)
+	assert.Len(t, dbMagicV1, 16)
+}
+
+// TestDBHeaderAcceptsLegacyMagic guards backward compatibility: databases
+// created before the rename carry "BTree format 1\0" padded with a zero byte,
+// and must keep opening.
+func TestDBHeaderAcceptsLegacyMagic(t *testing.T) {
+	h := dbHeader{
+		PageSize:     4096,
+		WriteVersion: 2,
+		ReadVersion:  2,
+	}
+	buf := make([]byte, dbHeaderSize)
+	h.serialize(buf)
+	require.Equal(t, "any-store v2\x00\x00\x00\x00", string(buf[0:16]), "serialize must write the new magic")
+
+	// Rewrite the field exactly as an older build left it on disk: the 15-byte
+	// legacy magic copied into a zeroed buffer.
+	copy(buf[0:16], "BTree format 1\x00")
+
+	var h2 dbHeader
+	require.NoError(t, h2.deserialize(buf), "a database written by an earlier v2 build must still open")
+	assert.Equal(t, h.PageSize, h2.PageSize)
 }


### PR DESCRIPTION
Newly created databases carry `any-store v2\0` at offset 0. The previous
`BTree format 1\0` is still accepted on read, so databases written by earlier
v2 builds keep opening unchanged.

```
new:     61 6e 79 2d 73 74 6f 72 65 20 76 32 00 00 00 00   any-store v2....
legacy:  42 54 72 65 65 20 66 6f 72 6d 61 74 20 31 00 00   BTree format 1..
```

The magic field is 16 bytes and page size follows immediately at offset 16, so
`any-store format 2\0` (19 bytes) would not fit. Both constants are declared
zero-padded to the full width, and `deserialize` now compares all 16 bytes —
previously only the first 15 were checked, leaving the 16th unverified.

Safe for existing files: `dbHeader.serialize` is only ever called with a freshly
zeroed page (`pager.go` new-database path) or with page 1 read back from disk,
where byte 15 is already zero. Confirmed on real databases.

Verified against real files rather than synthetic headers — two databases written
by an earlier build open and list their collections, and a newly created one
carries the new magic and reopens:

```
legacy crdt.db        OK  collections=7  hdr: "BTree format 1\x00\x00"
legacy spacestore.db  OK  collections=7  hdr: "BTree format 1\x00\x00"
new database              hdr: "any-store v2\x00\x00\x00\x00"
reopen new:           <nil>
```

Tests assert the on-disk bytes against literals rather than the constants, so a
rename or edit of `dbMagicV2` fails the test instead of comparing the constant
against itself. Adds a width test pinning both constants to 16 bytes (a longer
one would silently overwrite the page size) and a test that opens a header
carrying the legacy magic.

Drift tables in `docs/btree/NOTES.md` and the header layout comment updated.

Companion PR for the v1 side: #167.