### PR TITLE
feat: report any-store v1 files explicitly on Open

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 A **document-oriented embedded database** for Go with a MongoDB-like query language, built on an in-tree btree/pager/WAL storage engine derived from SQLite (aligned with its design, not a literal port — the on-disk format is our own).
 Schema-less documents, rich indexes, full-text and vector search, ACID transactions, multi-process access, page-level integrity and optional encryption — pure Go, no CGO.
 
-> **Status:** v2 is in beta (`v2.0.0-beta.x`) — the API is stabilizing; remaining changes before GA are expected to be minor. We actively dog-food the library in production and welcome early adopters & contributors.
-
 ## Features
 
 * **Mongo-style queries** — `$eq/$in/$gt/...`, logical operators, dot-path fields, modifiers (`$set`, `$inc`, ...). Formal semantics in [docs/query-filter-contract.md](docs/query-filter-contract.md).

--- a/db.go
+++ b/db.go
@@ -188,6 +188,9 @@ func Open(ctx context.Context, path string, config *Config) (DB, error) {
 		if errors.Is(err, btree.ErrPageSlabNotInitialized) {
 			return nil, ErrPageBufferNotInitialized
 		}
+		if errors.Is(err, btree.ErrSQLiteFormat) {
+			return nil, ErrV1Database
+		}
 		return nil, err
 	}
 	// ContinueOnIntegrityError only applies to checksum mode. AEAD mode

--- a/db_test.go
+++ b/db_test.go
@@ -340,3 +340,44 @@ func TestInspectIndexSketch_AccumulatesOnInsertAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(20), info.DocCount)
 }
+
+func TestOpen_AnyStoreV1File(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("v1 file is reported explicitly", func(t *testing.T) {
+		path := filepath.Join(dir, "v1.db")
+		// The SQLite header every any-store v1 database starts with. Literal on
+		// purpose: a rename or edit of v1Magic must fail here rather than pass
+		// by comparing the constant against itself.
+		page := make([]byte, 4096)
+		copy(page, "SQLite format 3\x00")
+		require.NoError(t, os.WriteFile(path, page, 0o600))
+
+		db, err := Open(ctx, path, nil)
+		require.ErrorIs(t, err, ErrV1Database)
+		require.Nil(t, db)
+	})
+
+	t.Run("v2 file still opens", func(t *testing.T) {
+		path := filepath.Join(dir, "v2.db")
+		db, err := Open(ctx, path, nil)
+		require.NoError(t, err)
+		coll, err := db.CreateCollection(ctx, "test")
+		require.NoError(t, err)
+		require.NoError(t, coll.Close())
+		require.NoError(t, db.Close())
+
+		db, err = Open(ctx, path, nil)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+	})
+
+	t.Run("other garbage keeps the generic error", func(t *testing.T) {
+		path := filepath.Join(dir, "garbage.db")
+		require.NoError(t, os.WriteFile(path, []byte("this is not a database at all"), 0o600))
+
+		_, err := Open(ctx, path, nil)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrV1Database)
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -110,6 +110,11 @@ var (
 	ErrDBIsNotOpened       = errors.New("any-store: database is not opened")
 	ErrIncompatibleVersion = errors.New("any-store: incompatible version")
 
+	// ErrV1Database is returned by Open when the file was created by any-store
+	// v1, which is SQLite-backed and cannot be read by v2. See
+	// docs/migration-v1-to-v2.md for moving the data across.
+	ErrV1Database = errors.New("any-store: file is an any-store v1 database, not readable by v2; use github.com/anyproto/any-store or migrate (docs/migration-v1-to-v2.md)")
+
 	// ErrPageBufferNotInitialized is returned when UseGlobalPageBuffer is set
 	// but InitPageBuffer was not called before opening the database.
 	ErrPageBufferNotInitialized = errors.New("any-store: global page buffer not initialized (call InitPageBuffer first)")

--- a/internal/btree/errors.go
+++ b/internal/btree/errors.go
@@ -6,6 +6,12 @@ var (
 	// ErrCorrupt indicates the database file is corrupted.
 	ErrCorrupt = errors.New("btree: database is corrupt")
 
+	// ErrSQLiteFormat reports a file carrying SQLite's header magic — an
+	// any-store v1 database. Deliberately NOT wrapping ErrCorrupt: the file is
+	// intact, only older, and a caller that responds to corruption by discarding
+	// and rebuilding the database must not be told to throw it away.
+	ErrSQLiteFormat = errors.New("btree: SQLite-format file (any-store v1 database)")
+
 	// ErrReadOnly indicates a write was attempted on a read-only transaction.
 	ErrReadOnly = errors.New("btree: read-only transaction")
 

--- a/internal/btree/page.go
+++ b/internal/btree/page.go
@@ -79,6 +79,9 @@ const (
 	// dbMagicV1 is the magic used before the rename. It is still accepted so that
 	// databases created by earlier v2 builds keep opening.
 	dbMagicV1 = "BTree format 1\x00\x00"
+	// sqliteMagic is the header any-store v1 databases start with. Recognised
+	// only so it can be reported distinctly; never accepted.
+	sqliteMagic = "SQLite format 3\x00"
 
 	// Page type flags (matching SQLite).
 	pageTypeIntIdx  = 2  // Interior index b-tree page
@@ -244,6 +247,9 @@ func (h *dbHeader) deserialize(buf []byte) error {
 	}
 
 	if magic := string(buf[0:16]); magic != dbMagicV2 && magic != dbMagicV1 {
+		if magic == sqliteMagic {
+			return ErrSQLiteFormat
+		}
 		return ErrCorrupt
 	}
 

--- a/internal/btree/page_test.go
+++ b/internal/btree/page_test.go
@@ -153,9 +153,10 @@ func TestDBHeaderNotSQLiteCompatible(t *testing.T) {
 // any-store, those pages would be traversed with INDEX-cell layout, silently
 // misparsing payloads. any-store has no decodeFlags-equivalent load-time
 // page-type whitelist; the *only* thing that makes this case unreachable for
-// real SQLite files is that dbHeader.deserialize (page.go:239) rejects them at
-// header parse, before any page is ever loaded, because the 15-byte magic
-// prefix differs ("BTree format 1\000" vs SQLite's "SQLite format 3\000",
+// real SQLite files is that dbHeader.deserialize (page.go:246) rejects them at
+// header parse, before any page is ever loaded, because neither accepted magic
+// matches SQLite's over the full 16-byte field ("any-store v2\000" written,
+// "BTree format 1\000" still read, vs SQLite's "SQLite format 3\000",
 // NOTES.md:253). That rejection is an *assumed* invariant, not an explicit
 // whitelist — so we pin it here. A refactor that widens/weakens the magic
 // comparison (e.g. accepts SQLite's magic, or compares too few bytes) would
@@ -191,8 +192,13 @@ func TestDBHeaderRejectsGenuineSQLiteMagic(t *testing.T) {
 	// THE PINNED INVARIANT: a genuine-SQLite-magic header is rejected at parse,
 	// before any page (and thus any 5/13 table page) can be loaded.
 	var h dbHeader
-	assert.ErrorIs(t, h.deserialize(buf), ErrCorrupt,
+	err := h.deserialize(buf)
+	assert.Error(t, err,
 		"deserialize must reject a genuine SQLite header so real SQLite table pages (type 5/13) never reach the index-only readers")
+	assert.ErrorIs(t, err, ErrSQLiteFormat,
+		"a SQLite header is reported as an any-store v1 file, not as generic corruption")
+	assert.NotErrorIs(t, err, ErrCorrupt,
+		"a v1 database is intact, only older: callers that discard corrupt databases must not be told to throw it away")
 
 	// Positive control: restoring only the magic to any-store's value makes the
 	// very same buffer deserialize cleanly. This proves the magic bytes are the


### PR DESCRIPTION
Mirror of #167 on the v2 side. Opening a SQLite-backed v1 database with v2 gave:

```
btree: read header: btree: database is corrupt
```

The file is not corrupt — it is merely an older format, and that message points
a reader at data recovery. Now:

```
any-store: file is an any-store v1 database, not readable by v2; use github.com/anyproto/any-store or migrate (docs/migration-v1-to-v2.md)
```

**No extra I/O.** The magic is recognised in `dbHeader.deserialize`, where
`readInitialHeader` has already read the header during `btree.Open`; the error
travels up the existing `read header: %w` wrapper and `Open` maps it to the
public `ErrV1Database`.

**`ErrSQLiteFormat` deliberately does not wrap `ErrCorrupt.`** A v1 file is
intact, only older. Consumers that treat corruption as "discard and rebuild"
(anytype-heart has exactly such a helper) must not be told to throw away a
perfectly good user database. The test pins both directions — `ErrorIs`
`ErrSQLiteFormat`, `NotErrorIs` `ErrCorrupt`.

Verified on real databases rather than synthetic headers: two production v1
files are reported as v1, a real v2 file still opens, and neither path leaves
`-wal`/`-wal-shm` beside the rejected file.

Also drops the `v2 is in beta` banner from the README.