### PR TITLE
chore(cli): bump any-store to v2.0.0

### DIFF
--- a/cmd/any-store-cli2/go.mod
+++ b/cmd/any-store-cli2/go.mod
@@ -3,7 +3,7 @@ module github.com/anyproto/any-store/cmd/any-store-cli2/v2
 go 1.25.0
 
 require (
-	github.com/anyproto/any-store/v2 v2.0.0-beta.6
+	github.com/anyproto/any-store/v2 v2.0.0
 	github.com/fatih/color v1.19.0
 	github.com/peterh/liner v1.2.2
 	github.com/robertkrimen/otto v0.5.1

--- a/cmd/any-store-cli2/go.sum
+++ b/cmd/any-store-cli2/go.sum
@@ -1,5 +1,5 @@
-github.com/anyproto/any-store/v2 v2.0.0-beta.6 h1:ne8GRCfaR2hYIdaHQ2Vw3F8h3DkPTA4/oB0Rp1Se4kE=
-github.com/anyproto/any-store/v2 v2.0.0-beta.6/go.mod h1:vVxA3PD7k2vAt07zk4n7Zdt6LANmSSIlSWMNuLOLAT0=
+github.com/anyproto/any-store/v2 v2.0.0 h1:AcJ7WRJqOiWFD0CKeo66hsQsMlJ+Wb+R2MsdthUe6E4=
+github.com/anyproto/any-store/v2 v2.0.0/go.mod h1:vVxA3PD7k2vAt07zk4n7Zdt6LANmSSIlSWMNuLOLAT0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=


### PR DESCRIPTION
Pins the CLI to the published `any-store/v2 v2.0.0` instead of `v2.0.0-beta.6`.

Required before tagging `cmd/any-store-cli2/v2.0.0`, which is what triggers the
release workflow — a library tag such as `v2.0.0` matches no workflow trigger.

Built and tested with `GOWORK=off` so it resolves the published module rather
than the in-tree one via `go.work`.