### PR TITLE
feat: add $size, $strLenBytes and $strLenCP expression operators

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -98,7 +98,7 @@ Inside `$project`/`$addFields` values, `$group` keys and accumulator arguments:
 | `$replaceAll` | `{"$replaceAll": {"input": e, "find": e, "replacement": e}}` | Replaces **every** occurrence of `find`, left to right, non-overlapping; replaced regions are not rescanned. Same contract as `$replaceOne` otherwise; an empty `find` prepends the replacement **once** (pinned; Mongo docs leave the case unstated). |
 | `$split` | `{"$split": [string, delimiter]}` | Array of the substrings between delimiter occurrences: adjacent delimiters produce empty strings, no occurrence yields `[input]`. Exactly two operands; the delimiter must be a non-empty string — an empty **literal** delimiter is a parse error, a delimiter expression evaluating to `""` → `null` (Mongo errors at runtime; regex delimiters are not supported). |
 | `$size` | `{"$size": e}` | Number of elements in the array operand. A null/missing or non-array operand → `null` (Mongo errors). `{"$size": {"$split": ["$notes", "\n"]}}` counts lines. |
-| `$strLenBytes`, `$strLenCP` | `{"$strLenCP": e}` | Length of the string operand in UTF-8 bytes (`$strLenBytes`) or code points (`$strLenCP`). |
+| `$strLenBytes`, `$strLenCP` | `{"$strLenCP": e}` | Length of the string operand in UTF-8 bytes (`$strLenBytes`) or code points (`$strLenCP`). A `$strLenCP` operand that is not valid UTF-8 → `null` (Mongo errors); `$strLenBytes` counts bytes verbatim, valid or not. |
 | `$trim`, `$ltrim`, `$rtrim` | `{"$trim": {"input": e, "chars"?: e}}` | Strips leading and trailing (`$ltrim`/`$rtrim`: one side) **code points** — UTF-8 aware, never mid-rune. Without `chars`: exactly Mongo's documented whitespace set (U+0000, U+0009–U+000D, U+0020, U+00A0, U+1680, U+2000–U+200A — not full Unicode `White_Space`). With `chars`: the set of code points in that string; `chars: ""` trims nothing (pinned; Mongo docs leave the case unstated). |
 | `$cond` | `{"$cond": [if, then, else]}` or `{"$cond": {"if": e, "then": e, "else": e}}` | All three parts required. Lazy: only the taken branch is evaluated. Truthiness is Mongo's: `false`, `0`, `null`, missing → false; everything else — including `""`, `[]`, `{}` — true. |
 | `$switch` | `{"$switch": {"branches": [{"case": e, "then": e}, ...], "default": e?}}` | At least one branch; cases evaluate lazily in order, first truthy case wins; no match falls to `default`. |
@@ -133,11 +133,14 @@ A single non-array operand is Mongo's shorthand for a one-element list
 > `$replaceOne`/`$replaceAll`, `$split`, `$strLenBytes`/`$strLenCP`,
 > `$trim`/`$ltrim`/`$rtrim` — including
 > a `$trim` `chars` and a `$split` delimiter expression, where an empty-string
-> delimiter counts too), a non-array `$size` operand, division by
+> delimiter counts too), a non-array `$size` operand, a `$strLenCP` operand
+> that is not valid UTF-8, division by
 > zero, a non-finite
 > result (overflow, NaN), an out-of-range or non-integer `$round` place, and a
 > `$switch` with no matching case and no `default` (Mongo raises). Null and
-> missing operands also yield `null` (as in Mongo).
+> missing operands also yield `null` — as in Mongo, except for `$size` and
+> `$strLenBytes`/`$strLenCP`, where Mongo errors for null/missing operands
+> too.
 >
 > `$round` precision is float64: values round by their binary double value
 > (`{"$round": [2.345, 2]}` is `2.35` — the stored double sits above the

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -97,6 +97,8 @@ Inside `$project`/`$addFields` values, `$group` keys and accumulator arguments:
 | `$replaceOne` | `{"$replaceOne": {"input": e, "find": e, "replacement": e}}` | Replaces the **first** occurrence of `find` in `input`; no occurrence leaves `input` unchanged. All three required (object form only). An empty `find` matches at position 0 and prepends the replacement. Null/missing operands → `null` (as in Mongo); a non-string operand → `null` too (Mongo errors; regex `find` is not supported). |
 | `$replaceAll` | `{"$replaceAll": {"input": e, "find": e, "replacement": e}}` | Replaces **every** occurrence of `find`, left to right, non-overlapping; replaced regions are not rescanned. Same contract as `$replaceOne` otherwise; an empty `find` prepends the replacement **once** (pinned; Mongo docs leave the case unstated). |
 | `$split` | `{"$split": [string, delimiter]}` | Array of the substrings between delimiter occurrences: adjacent delimiters produce empty strings, no occurrence yields `[input]`. Exactly two operands; the delimiter must be a non-empty string — an empty **literal** delimiter is a parse error, a delimiter expression evaluating to `""` → `null` (Mongo errors at runtime; regex delimiters are not supported). |
+| `$size` | `{"$size": e}` | Number of elements in the array operand. A null/missing or non-array operand → `null` (Mongo errors). `{"$size": {"$split": ["$notes", "\n"]}}` counts lines. |
+| `$strLenBytes`, `$strLenCP` | `{"$strLenCP": e}` | Length of the string operand in UTF-8 bytes (`$strLenBytes`) or code points (`$strLenCP`). |
 | `$trim`, `$ltrim`, `$rtrim` | `{"$trim": {"input": e, "chars"?: e}}` | Strips leading and trailing (`$ltrim`/`$rtrim`: one side) **code points** — UTF-8 aware, never mid-rune. Without `chars`: exactly Mongo's documented whitespace set (U+0000, U+0009–U+000D, U+0020, U+00A0, U+1680, U+2000–U+200A — not full Unicode `White_Space`). With `chars`: the set of code points in that string; `chars: ""` trims nothing (pinned; Mongo docs leave the case unstated). |
 | `$cond` | `{"$cond": [if, then, else]}` or `{"$cond": {"if": e, "then": e, "else": e}}` | All three parts required. Lazy: only the taken branch is evaluated. Truthiness is Mongo's: `false`, `0`, `null`, missing → false; everything else — including `""`, `[]`, `{}` — true. |
 | `$switch` | `{"$switch": {"branches": [{"case": e, "then": e}, ...], "default": e?}}` | At least one branch; cases evaluate lazily in order, first truthy case wins; no match falls to `default`. |
@@ -128,9 +130,10 @@ A single non-array operand is Mongo's shorthand for a one-element list
 > streaming with no per-document error channel, so conditions Mongo reports as
 > query errors yield `null` instead — a non-numeric operand of an arithmetic
 > operator, a non-string operand of a string operator (`$concat`,
-> `$replaceOne`/`$replaceAll`, `$split`, `$trim`/`$ltrim`/`$rtrim` — including
+> `$replaceOne`/`$replaceAll`, `$split`, `$strLenBytes`/`$strLenCP`,
+> `$trim`/`$ltrim`/`$rtrim` — including
 > a `$trim` `chars` and a `$split` delimiter expression, where an empty-string
-> delimiter counts too), division by
+> delimiter counts too), a non-array `$size` operand, division by
 > zero, a non-finite
 > result (overflow, NaN), an out-of-range or non-integer `$round` place, and a
 > `$switch` with no matching case and no `default` (Mongo raises). Null and

--- a/internal/aggregate/expr_ops.go
+++ b/internal/aggregate/expr_ops.go
@@ -677,8 +677,9 @@ func (e *SplitExpr) String() string { return opString("$split", []Expr{e.Input, 
 
 // StrLenExpr evaluates $strLenBytes/$strLenCP: the length of the string
 // operand in UTF-8 bytes or code points. A missing, null, or non-string
-// operand → null (Mongo errors for non-strings; no-error-channel policy, see
-// evalNumber).
+// operand → null, and so is a $strLenCP operand that is not valid UTF-8
+// (Mongo errors for both; no-error-channel policy, see evalNumber).
+// $strLenBytes counts bytes verbatim, valid UTF-8 or not, as Mongo does.
 type StrLenExpr struct {
 	CP  bool // count code points ($strLenCP) instead of bytes ($strLenBytes)
 	Arg Expr
@@ -711,6 +712,9 @@ func (e *StrLenExpr) Eval(a *anyenc.Arena, doc *anyenc.Value) (*anyenc.Value, er
 	}
 	b := v.GetStringBytes()
 	if e.CP {
+		if !utf8.Valid(b) {
+			return a.NewNull(), nil
+		}
 		return a.NewNumberInt(utf8.RuneCount(b)), nil
 	}
 	return a.NewNumberInt(len(b)), nil

--- a/internal/aggregate/expr_ops.go
+++ b/internal/aggregate/expr_ops.go
@@ -21,34 +21,37 @@ var exprOpParsers map[string]func(*anyenc.Value) (Expr, error)
 
 func init() {
 	exprOpParsers = map[string]func(*anyenc.Value) (Expr, error){
-		"$add":        func(v *anyenc.Value) (Expr, error) { return parseArith(OpAdd, v) },
-		"$subtract":   func(v *anyenc.Value) (Expr, error) { return parseArith(OpSubtract, v) },
-		"$multiply":   func(v *anyenc.Value) (Expr, error) { return parseArith(OpMultiply, v) },
-		"$divide":     func(v *anyenc.Value) (Expr, error) { return parseArith(OpDivide, v) },
-		"$abs":        parseAbs,
-		"$round":      parseRound,
-		"$concat":     parseConcat,
-		"$replaceOne": parseReplaceOne,
-		"$replaceAll": parseReplaceAll,
-		"$split":      parseSplit,
-		"$trim":       func(v *anyenc.Value) (Expr, error) { return parseTrim(TrimBoth, v) },
-		"$ltrim":      func(v *anyenc.Value) (Expr, error) { return parseTrim(TrimLeft, v) },
-		"$rtrim":      func(v *anyenc.Value) (Expr, error) { return parseTrim(TrimRight, v) },
-		"$cond":       parseCond,
-		"$switch":     parseSwitch,
-		"$ifNull":     parseIfNull,
-		"$eq":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpEq, v) },
-		"$ne":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpNe, v) },
-		"$gt":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpGt, v) },
-		"$gte":        func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpGte, v) },
-		"$lt":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpLt, v) },
-		"$lte":        func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpLte, v) },
-		"$cmp":        func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpCmp, v) },
-		"$dateAdd":    parseDateAdd,
-		"$dateDiff":   parseDateDiff,
-		"$dateTrunc":  parseDateTrunc,
-		"$year":       func(v *anyenc.Value) (Expr, error) { return parseDatePart(partYear, v) },
-		"$week":       func(v *anyenc.Value) (Expr, error) { return parseDatePart(partWeek, v) },
+		"$add":         func(v *anyenc.Value) (Expr, error) { return parseArith(OpAdd, v) },
+		"$subtract":    func(v *anyenc.Value) (Expr, error) { return parseArith(OpSubtract, v) },
+		"$multiply":    func(v *anyenc.Value) (Expr, error) { return parseArith(OpMultiply, v) },
+		"$divide":      func(v *anyenc.Value) (Expr, error) { return parseArith(OpDivide, v) },
+		"$abs":         parseAbs,
+		"$round":       parseRound,
+		"$concat":      parseConcat,
+		"$replaceOne":  parseReplaceOne,
+		"$replaceAll":  parseReplaceAll,
+		"$split":       parseSplit,
+		"$trim":        func(v *anyenc.Value) (Expr, error) { return parseTrim(TrimBoth, v) },
+		"$ltrim":       func(v *anyenc.Value) (Expr, error) { return parseTrim(TrimLeft, v) },
+		"$rtrim":       func(v *anyenc.Value) (Expr, error) { return parseTrim(TrimRight, v) },
+		"$strLenBytes": func(v *anyenc.Value) (Expr, error) { return parseStrLen(false, v) },
+		"$strLenCP":    func(v *anyenc.Value) (Expr, error) { return parseStrLen(true, v) },
+		"$size":        parseSize,
+		"$cond":        parseCond,
+		"$switch":      parseSwitch,
+		"$ifNull":      parseIfNull,
+		"$eq":          func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpEq, v) },
+		"$ne":          func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpNe, v) },
+		"$gt":          func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpGt, v) },
+		"$gte":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpGte, v) },
+		"$lt":          func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpLt, v) },
+		"$lte":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpLte, v) },
+		"$cmp":         func(v *anyenc.Value) (Expr, error) { return parseCompare(CmpCmp, v) },
+		"$dateAdd":     parseDateAdd,
+		"$dateDiff":    parseDateDiff,
+		"$dateTrunc":   parseDateTrunc,
+		"$year":        func(v *anyenc.Value) (Expr, error) { return parseDatePart(partYear, v) },
+		"$week":        func(v *anyenc.Value) (Expr, error) { return parseDatePart(partWeek, v) },
 	}
 }
 
@@ -671,6 +674,76 @@ func (e *SplitExpr) Eval(a *anyenc.Arena, doc *anyenc.Value) (*anyenc.Value, err
 }
 
 func (e *SplitExpr) String() string { return opString("$split", []Expr{e.Input, e.Delim}) }
+
+// StrLenExpr evaluates $strLenBytes/$strLenCP: the length of the string
+// operand in UTF-8 bytes or code points. A missing, null, or non-string
+// operand → null (Mongo errors for non-strings; no-error-channel policy, see
+// evalNumber).
+type StrLenExpr struct {
+	CP  bool // count code points ($strLenCP) instead of bytes ($strLenBytes)
+	Arg Expr
+}
+
+func parseStrLen(cp bool, v *anyenc.Value) (Expr, error) {
+	e := &StrLenExpr{CP: cp}
+	args, err := parseOperands(e.op(), v, 1, 1)
+	if err != nil {
+		return nil, err
+	}
+	e.Arg = args[0]
+	return e, nil
+}
+
+func (e *StrLenExpr) op() string {
+	if e.CP {
+		return "$strLenCP"
+	}
+	return "$strLenBytes"
+}
+
+func (e *StrLenExpr) Eval(a *anyenc.Arena, doc *anyenc.Value) (*anyenc.Value, error) {
+	v, err := e.Arg.Eval(a, doc)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil || v.Type() != anyenc.TypeString {
+		return a.NewNull(), nil
+	}
+	b := v.GetStringBytes()
+	if e.CP {
+		return a.NewNumberInt(utf8.RuneCount(b)), nil
+	}
+	return a.NewNumberInt(len(b)), nil
+}
+
+func (e *StrLenExpr) String() string { return opString(e.op(), []Expr{e.Arg}) }
+
+// SizeExpr evaluates $size: the number of elements in its array operand. A
+// missing, null, or non-array operand → null (Mongo errors; no-error-channel
+// policy, see evalNumber).
+type SizeExpr struct{ Arg Expr }
+
+func parseSize(v *anyenc.Value) (Expr, error) {
+	args, err := parseOperands("$size", v, 1, 1)
+	if err != nil {
+		return nil, err
+	}
+	return &SizeExpr{Arg: args[0]}, nil
+}
+
+func (e *SizeExpr) Eval(a *anyenc.Arena, doc *anyenc.Value) (*anyenc.Value, error) {
+	v, err := e.Arg.Eval(a, doc)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil || v.Type() != anyenc.TypeArray {
+		return a.NewNull(), nil
+	}
+	items, _ := v.Array()
+	return a.NewNumberInt(len(items)), nil
+}
+
+func (e *SizeExpr) String() string { return opString("$size", []Expr{e.Arg}) }
 
 // TrimMode selects which side(s) $trim/$ltrim/$rtrim strip.
 type TrimMode uint8

--- a/internal/aggregate/expr_test.go
+++ b/internal/aggregate/expr_test.go
@@ -1194,6 +1194,10 @@ func TestExprEvalAllocFree(t *testing.T) {
 		{"replaceAll no match", `{"$replaceAll": {"input": "$csv", "find": "zz", "replacement": "A"}}`},
 		{"split", `{"$split": ["$csv", ","]}`},
 		{"split no match", `{"$split": ["$csv", ";"]}`},
+		{"strLenBytes", `{"$strLenBytes": "$s1"}`},
+		{"strLenCP", `{"$strLenCP": "$s1"}`},
+		{"size", `{"$size": "$arr"}`},
+		{"size of split", `{"$size": {"$split": ["$csv", ","]}}`},
 		{"trim default set", `{"$trim": {"input": "$pad"}}`},
 		{"trim chars set", `{"$trim": {"input": "$csv", "chars": "aélon"}}`},
 		{"ltrim", `{"$ltrim": {"input": "$pad"}}`},
@@ -1405,6 +1409,42 @@ func BenchmarkSplitExprEval(b *testing.B) {
 		b.Fatal(err)
 	}
 	doc := anyenc.MustParseJson(`{"csv": "alpha,beta,gamma,delta,epsilon"}`)
+	a := &anyenc.Arena{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.Reset()
+		if v, err := e.Eval(a, doc); err != nil || v == nil {
+			b.Fatal(v, err)
+		}
+	}
+}
+
+// BenchmarkStrLenExprEval counts code points of a multibyte string.
+func BenchmarkStrLenExprEval(b *testing.B) {
+	e, err := ParseExpr(anyenc.MustParseJson(`{"$strLenCP": "$s"}`))
+	if err != nil {
+		b.Fatal(err)
+	}
+	doc := anyenc.MustParseJson(`{"s": "héllo → wörld → 0123456789"}`)
+	a := &anyenc.Arena{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.Reset()
+		if v, err := e.Eval(a, doc); err != nil || v == nil {
+			b.Fatal(v, err)
+		}
+	}
+}
+
+// BenchmarkSizeExprEval counts the lines of a string via $size over $split.
+func BenchmarkSizeExprEval(b *testing.B) {
+	e, err := ParseExpr(anyenc.MustParseJson(`{"$size": {"$split": ["$notes", "\n"]}}`))
+	if err != nil {
+		b.Fatal(err)
+	}
+	doc := anyenc.MustParseJson(`{"notes": "alpha\nbeta\ngamma\ndelta\nepsilon"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/internal/aggregate/expr_test.go
+++ b/internal/aggregate/expr_test.go
@@ -1233,7 +1233,7 @@ func TestExprEvalAllocFree(t *testing.T) {
 			}
 			res := testing.Benchmark(func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					a.Reset()
 					v, err := e.Eval(a, doc)
 					if err != nil || v == nil {
@@ -1254,8 +1254,7 @@ func BenchmarkArithExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"a": 3, "b": 4}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1279,8 +1278,7 @@ func BenchmarkFieldRefEval(b *testing.B) {
 			}
 			a := &anyenc.Arena{}
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				a.Reset()
 				if v, err := e.Eval(a, doc); err != nil || v == nil {
 					b.Fatal(v, err)
@@ -1298,8 +1296,7 @@ func BenchmarkCondExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"a": 3, "b": 4}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1319,8 +1316,7 @@ func BenchmarkSwitchExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"a": 5}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1337,8 +1333,7 @@ func BenchmarkDateAddExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"d": {"$date": "2026-03-28T12:00:00Z"}}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1356,8 +1351,7 @@ func BenchmarkDateDiffExprEval(b *testing.B) {
 		`{"d": {"$date": "2026-03-28T12:00:00Z"}, "d2": {"$date": "2026-08-05T06:00:00Z"}}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1374,8 +1368,7 @@ func BenchmarkReplaceOneExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"rel": "x://longer-prefixed-identifier-value-0123456789"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1393,8 +1386,7 @@ func BenchmarkReplaceAllExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"s": "one://two://three://tail-0123456789"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1411,8 +1403,7 @@ func BenchmarkSplitExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"csv": "alpha,beta,gamma,delta,epsilon"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if v, err := e.Eval(a, doc); err != nil || v == nil {
 			b.Fatal(v, err)
@@ -1429,8 +1420,7 @@ func BenchmarkStrLenExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"s": "héllo → wörld → 0123456789"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if v, err := e.Eval(a, doc); err != nil || v == nil {
 			b.Fatal(v, err)
@@ -1447,8 +1437,7 @@ func BenchmarkSizeExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"notes": "alpha\nbeta\ngamma\ndelta\nepsilon"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if v, err := e.Eval(a, doc); err != nil || v == nil {
 			b.Fatal(v, err)
@@ -1465,8 +1454,7 @@ func BenchmarkTrimExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"s": "\t  héllo wörld \r\n "}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)
@@ -1482,8 +1470,7 @@ func BenchmarkConcatExprEval(b *testing.B) {
 	doc := anyenc.MustParseJson(`{"s1": "héllo → w", "s2": "0123456789"}`)
 	a := &anyenc.Arena{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		a.Reset()
 		if _, err := e.Eval(a, doc); err != nil {
 			b.Fatal(err)

--- a/internal/aggregate/expr_test.go
+++ b/internal/aggregate/expr_test.go
@@ -766,6 +766,18 @@ func TestStrLenExprEval(t *testing.T) {
 	t.Run("nests with other operators", func(t *testing.T) {
 		assert.Equal(t, float64(7), num(t, `{"$strLenCP": {"$concat": ["$s", "-", "$s"]}}`))
 	})
+	t.Run("invalid UTF-8: $strLenCP is null, $strLenBytes counts bytes", func(t *testing.T) {
+		// Not representable in JSON: build the doc with raw string bytes.
+		a := &anyenc.Arena{}
+		bad := a.NewObject()
+		bad.Set("bad", a.NewStringBytes([]byte{0xff, 0xfe, 'a'}))
+		v := evalExprOn(t, `{"$strLenCP": "$bad"}`, bad)
+		require.NotNil(t, v)
+		assert.Equal(t, anyenc.TypeNull, v.Type())
+		v = evalExprOn(t, `{"$strLenBytes": "$bad"}`, bad)
+		require.Equal(t, anyenc.TypeNumber, v.Type())
+		assert.Equal(t, float64(3), v.GetFloat64())
+	})
 }
 
 func TestSizeExprEval(t *testing.T) {

--- a/internal/aggregate/expr_test.go
+++ b/internal/aggregate/expr_test.go
@@ -731,6 +731,74 @@ func TestSplitExprEval(t *testing.T) {
 	})
 }
 
+func TestStrLenExprEval(t *testing.T) {
+	doc := anyenc.MustParseJson(`{"s": "abc", "multi": "héllo", "empty": "", "n": 5,
+		"arr": ["a"], "nul": null}`)
+	num := func(t *testing.T, exprJson string) float64 {
+		v := evalExprOn(t, exprJson, doc)
+		require.Equal(t, anyenc.TypeNumber, v.Type(), exprJson)
+		return v.GetFloat64()
+	}
+	null := func(t *testing.T, exprJson string) {
+		v := evalExprOn(t, exprJson, doc)
+		require.NotNil(t, v, exprJson)
+		assert.Equal(t, anyenc.TypeNull, v.Type(), exprJson)
+	}
+
+	t.Run("ascii: bytes and code points agree", func(t *testing.T) {
+		assert.Equal(t, float64(3), num(t, `{"$strLenBytes": "$s"}`))
+		assert.Equal(t, float64(3), num(t, `{"$strLenCP": "$s"}`))
+		assert.Equal(t, float64(0), num(t, `{"$strLenBytes": "$empty"}`))
+		assert.Equal(t, float64(0), num(t, `{"$strLenCP": "$empty"}`))
+	})
+	t.Run("multibyte: bytes and code points differ", func(t *testing.T) {
+		assert.Equal(t, float64(6), num(t, `{"$strLenBytes": "$multi"}`))
+		assert.Equal(t, float64(5), num(t, `{"$strLenCP": "$multi"}`))
+	})
+	t.Run("null, missing, non-string", func(t *testing.T) {
+		for _, op := range []string{"$strLenBytes", "$strLenCP"} {
+			null(t, `{"`+op+`": "$nul"}`)
+			null(t, `{"`+op+`": "$nope"}`)
+			null(t, `{"`+op+`": "$n"}`)
+			null(t, `{"`+op+`": "$arr"}`)
+		}
+	})
+	t.Run("nests with other operators", func(t *testing.T) {
+		assert.Equal(t, float64(7), num(t, `{"$strLenCP": {"$concat": ["$s", "-", "$s"]}}`))
+	})
+}
+
+func TestSizeExprEval(t *testing.T) {
+	doc := anyenc.MustParseJson(`{"tags": ["a", "b", "c"], "empty": [],
+		"nested": [[1, 2], [3]], "notes": "l1\nl2\nl3", "s": "abc", "n": 5, "nul": null}`)
+	num := func(t *testing.T, exprJson string) float64 {
+		v := evalExprOn(t, exprJson, doc)
+		require.Equal(t, anyenc.TypeNumber, v.Type(), exprJson)
+		return v.GetFloat64()
+	}
+	null := func(t *testing.T, exprJson string) {
+		v := evalExprOn(t, exprJson, doc)
+		require.NotNil(t, v, exprJson)
+		assert.Equal(t, anyenc.TypeNull, v.Type(), exprJson)
+	}
+
+	t.Run("array operand", func(t *testing.T) {
+		assert.Equal(t, float64(3), num(t, `{"$size": "$tags"}`))
+		assert.Equal(t, float64(0), num(t, `{"$size": "$empty"}`))
+		assert.Equal(t, float64(2), num(t, `{"$size": "$nested"}`))
+		assert.Equal(t, float64(2), num(t, `{"$size": [["x", "y"]]}`))
+	})
+	t.Run("null, missing, non-array", func(t *testing.T) {
+		null(t, `{"$size": "$nul"}`)
+		null(t, `{"$size": "$nope"}`)
+		null(t, `{"$size": "$s"}`)
+		null(t, `{"$size": "$n"}`)
+	})
+	t.Run("line count: size of split", func(t *testing.T) {
+		assert.Equal(t, float64(3), num(t, `{"$size": {"$split": ["$notes", "\n"]}}`))
+	})
+}
+
 func TestTrimExprEval(t *testing.T) {
 	doc := anyenc.MustParseJson(`{"pad": "  héllo  ",
 		"ws": "\u0000\t\n\u000b\f\r \u00a0\u1680\u2000\u2005\u200ax y\u200a\u00a0\r\n ",

--- a/internal/aggregate/pipeline_parse_test.go
+++ b/internal/aggregate/pipeline_parse_test.go
@@ -511,6 +511,9 @@ func TestParseExprOperators(t *testing.T) {
 			{`{"$trim": {"input": "$a"}}`, &TrimExpr{}},
 			{`{"$ltrim": {"input": "$a", "chars": "x"}}`, &TrimExpr{}},
 			{`{"$rtrim": {"input": "$a"}}`, &TrimExpr{}},
+			{`{"$strLenBytes": ["$a"]}`, &StrLenExpr{}},
+			{`{"$strLenCP": "$a"}`, &StrLenExpr{}},
+			{`{"$size": ["$a"]}`, &SizeExpr{}},
 			{`{"$cond": ["$a", 1, 2]}`, &CondExpr{}},
 			{`{"$cond": {"if": "$a", "then": 1, "else": 2}}`, &CondExpr{}},
 			{`{"$switch": {"branches": [{"case": "$a", "then": 1}]}}`, &SwitchExpr{}},
@@ -554,6 +557,9 @@ func TestParseExprOperators(t *testing.T) {
 			{`{"$trim": {"input": "$a"}}`, `{$trim:{input:$a}}`},
 			{`{"$ltrim": {"input": "$a"}}`, `{$ltrim:{input:$a}}`},
 			{`{"$rtrim": {"input": "$a", "chars": "é "}}`, `{$rtrim:{input:$a,chars:"é "}}`},
+			{`{"$strLenBytes": "$a"}`, `{$strLenBytes:[$a]}`},
+			{`{"$strLenCP": "$a"}`, `{$strLenCP:[$a]}`},
+			{`{"$size": {"$split": ["$a", "-"]}}`, `{$size:[{$split:[$a,"-"]}]}`},
 			// Both $cond spellings render the canonical array form.
 			{`{"$cond": [{"$lt": ["$a", 1]}, "$a", "$b"]}`, `{$cond:[{$lt:[$a,1]},$a,$b]}`},
 			{`{"$cond": {"if": "$a", "then": 1, "else": 2}}`, `{$cond:[$a,1,2]}`},
@@ -893,6 +899,18 @@ func TestPipelineParseError(t *testing.T) {
 			json:     `[{"$project":{"a":{"$abs":[1,2]}}}]`,
 			wantPath: "0.$project.a.$abs", wantOp: "$abs",
 			wantReason: "$abs requires exactly 1 operand, got 2",
+		},
+		{
+			name:     "$size wrong arity",
+			json:     `[{"$project":{"a":{"$size":["$x","$y"]}}}]`,
+			wantPath: "0.$project.a.$size", wantOp: "$size",
+			wantReason: "$size requires exactly 1 operand, got 2",
+		},
+		{
+			name:     "$strLenCP wrong arity",
+			json:     `[{"$project":{"a":{"$strLenCP":[]}}}]`,
+			wantPath: "0.$project.a.$strLenCP", wantOp: "$strLenCP",
+			wantReason: "$strLenCP requires exactly 1 operand, got 0",
 		},
 		{
 			name:     "$cond array wrong arity",

--- a/internal/aggregate/stage_group_test.go
+++ b/internal/aggregate/stage_group_test.go
@@ -266,7 +266,7 @@ func TestGroupSteadyStateAllocs(t *testing.T) {
 	}
 	res := testing.Benchmark(func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			if _, err := stage.stepOne(ctx); err != nil {
 				b.Fatal(err)
 			}

--- a/internal/aggregate/stage_test.go
+++ b/internal/aggregate/stage_test.go
@@ -369,7 +369,7 @@ func TestStreamingStagesAllocFree(t *testing.T) {
 	}
 	res := testing.Benchmark(func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			v, err := root.Next(ctx)
 			if err != nil || v == nil {
 				b.Fatal(v, err)
@@ -406,7 +406,7 @@ func TestMatchExprAllocFree(t *testing.T) {
 	}
 	res := testing.Benchmark(func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			v, err := root.Next(ctx)
 			if err != nil || v == nil {
 				b.Fatal(v, err)
@@ -426,8 +426,7 @@ func BenchmarkMatchExprStage(b *testing.B) {
 	defer root.Close()
 	ctx := newTestCtx()
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		v, err := root.Next(ctx)
 		if err != nil || v == nil {
 			b.Fatal(v, err)


### PR DESCRIPTION
Adds three unary compute operators to the aggregation expression vocabulary, enabling e.g. the canonical Mongo line-count `{"$size": {"$split": ["$notes", "\n"]}}` server-side.

- `$size` — number of elements in the array operand.
- `$strLenBytes` / `$strLenCP` — string length in UTF-8 bytes / code points.

All three follow the existing operator contract: single-operand shorthand, parse-time arity errors, and the engine's error-to-null policy — a missing/null or wrong-typed operand yields `null` (Mongo errors for these, including for null/missing, which for `$size`/`$strLen*` is stricter than the older operators; the docs blockquote now carves that out). A `$strLenCP` operand that is not valid UTF-8 also yields `null`; `$strLenBytes` counts bytes verbatim, as Mongo does.

Docs table and null-policy notes updated; eval + parse tests added, including multibyte, invalid-UTF-8, and size-of-split line-count cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8E1eznXEPPzdqnqXWHehn