### PR TITLE
qplanner: cost-based driver/probe plan selection for $text and $knn

### DIFF
--- a/fulltext_probe.go
+++ b/fulltext_probe.go
@@ -140,17 +140,30 @@ func (fx *ftsIndex) newFtsProber(tx *btree.ReadTx, text query.Text) (*ftsProber,
 			pg.dead = len(pg.terms) == 0
 			return pg, nil
 		}
-		pg.phrase = true
+		// Mirror scoreGroup's dispatch exactly: only a MULTI-token group is a
+		// phrase; a quoted clause that analyzes to one token is scored by the
+		// driver as a plain scanTerm (weighted TF), so the prober must route
+		// it through the per-term path too.
+		pg.phrase = len(g.terms) > 1
 		for _, t := range g.terms {
 			pt, terr := termOf(t, 0)
 			if terr != nil {
 				return pg, terr
 			}
-			if pt.df == 0 {
+			if pt.df == 0 && pg.phrase {
 				pg.dead = true // driver's scorePhrase: any absent term → no matches
 			}
 			pg.idfSum += pt.idf
 			pg.terms = append(pg.terms, pt)
+		}
+		if !pg.phrase {
+			dead := true
+			for _, pt := range pg.terms {
+				if pt.df > 0 {
+					dead = false
+				}
+			}
+			pg.dead = dead
 		}
 		return pg, nil
 	}
@@ -175,22 +188,24 @@ func (fx *ftsIndex) newFtsProber(tx *btree.ReadTx, text query.Text) (*ftsProber,
 }
 
 // termTF returns the term's frequency in document intId (the weighted
-// pseudo-frequency under BM25F, matching scanTerm's weighted branch), or 0 when
-// the document does not contain the term. Positions, when dst is non-nil, are
-// decoded into *dst for phrase adjacency.
-func (p *ftsProber) termTF(term string, intId uint64, dst *[]uint32) (float64, error) {
+// pseudo-frequency under BM25F, matching scanTerm's weighted branch) and
+// whether a posting for the document EXISTS. found is the driver's semantic
+// trigger: scanTerm scores/tombstones/sets required bits for every posting it
+// visits regardless of the computed tf (a zero-weight field yields tf == 0
+// with found == true), so callers must gate on found, never on tf > 0.
+// Positions, when dst is non-nil, are decoded into *dst for phrase adjacency.
+func (p *ftsProber) termTF(term string, intId uint64, dst *[]uint32) (tf float64, found bool, err error) {
 	p.keyBuf = postingsKey(p.keyBuf, term, fts.ChunkID(intId))
-	var err error
 	p.valBuf, err = p.tx.AppendValue(p.fx.nsPost, p.keyBuf, p.valBuf[:0])
 	if err != nil {
 		if errors.Is(err, btree.ErrKeyNotFound) {
-			return 0, nil
+			return 0, false, nil
 		}
-		return 0, err
+		return 0, false, err
 	}
-	it, err := p.e.chunkReader(p.valBuf)
-	if err != nil {
-		return 0, ftsMapFormatErr(err)
+	it, rerr := p.e.chunkReader(p.valBuf)
+	if rerr != nil {
+		return 0, false, ftsMapFormatErr(rerr)
 	}
 	for it.Next() {
 		docID := it.DocID()
@@ -200,7 +215,6 @@ func (p *ftsProber) termTF(term string, intId uint64, dst *[]uint32) (float64, e
 		if docID != intId {
 			continue
 		}
-		var tf float64
 		if p.e.weighted {
 			for f := 0; f < p.e.nFields; f++ {
 				if w := p.e.weights[f]; w != 0 {
@@ -216,11 +230,11 @@ func (p *ftsProber) termTF(term string, intId uint64, dst *[]uint32) (float64, e
 			*dst = it.AppendPositions((*dst)[:0])
 		}
 		if it.Err() != nil {
-			return 0, it.Err()
+			return 0, false, it.Err()
 		}
-		return tf, nil
+		return tf, true, nil
 	}
-	return 0, it.Err()
+	return 0, false, it.Err()
 }
 
 // phrasePresent reports the phrase's adjacency-confirmed occurrence count in
@@ -231,11 +245,13 @@ func (p *ftsProber) phraseCount(g *probeGroup, intId uint64) (uint32, error) {
 	}
 	lists := p.posBufB[:0]
 	for i, t := range g.terms {
-		tf, err := p.termTF(t.term, intId, &p.posBufs[i])
+		_, found, err := p.termTF(t.term, intId, &p.posBufs[i])
 		if err != nil {
 			return 0, err
 		}
-		if tf == 0 {
+		// Presence, not tf: the driver's scorePhrase matches on positions
+		// alone and never consults the (possibly zero-weighted) tf.
+		if !found {
 			p.posBufB = lists
 			return 0, nil
 		}
@@ -294,11 +310,13 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 		if pt.df == 0 {
 			continue
 		}
-		tf, terr := p.termTF(pt.term, intId, nil)
+		tf, hit, terr := p.termTF(pt.term, intId, nil)
 		if terr != nil {
 			return 0, 0, false, terr
 		}
-		if tf > 0 {
+		if hit {
+			// Presence-gated like scanTerm: a zero-weight-field posting still
+			// enters the doc (score += 0) and sets the required bit.
 			if err = add(pt.idf, tf, pt.reqBit); err != nil {
 				return 0, 0, false, err
 			}
@@ -326,11 +344,11 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 			if pt.df == 0 {
 				continue
 			}
-			tf, terr := p.termTF(pt.term, intId, nil)
+			tf, hit, terr := p.termTF(pt.term, intId, nil)
 			if terr != nil {
 				return 0, 0, false, terr
 			}
-			if tf > 0 {
+			if hit {
 				if err = add(pt.idf, tf, g.reqBit); err != nil {
 					return 0, 0, false, err
 				}
@@ -362,11 +380,11 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 			if pt.df == 0 {
 				continue
 			}
-			tf, terr := p.termTF(pt.term, intId, nil)
+			_, hit, terr := p.termTF(pt.term, intId, nil)
 			if terr != nil {
 				return 0, 0, false, terr
 			}
-			if tf > 0 {
+			if hit {
 				return 0, 0, false, nil
 			}
 		}

--- a/fulltext_probe.go
+++ b/fulltext_probe.go
@@ -61,11 +61,45 @@ type ftsProber struct {
 	// matching the driver's empty candidate stream.
 	hasPositive bool
 
-	keyBuf  []byte
-	valBuf  []byte
-	fwdBuf  []byte
-	posBufs [][]uint32
-	posBufB [][]uint32
+	keyBuf    []byte
+	valBuf    []byte
+	fwdBuf    []byte
+	mapValBuf []byte
+	posBufs   [][]uint32
+	posBufB   [][]uint32
+
+	// per-Probe scoring state (fields, not closures: Probe runs once per
+	// candidate in the planner's inner loop and must not allocate).
+	curScore    float64
+	curMask     uint64
+	curMatched  bool
+	curDl       float64
+	curDlLoaded bool
+}
+
+// curDocLen returns the probed document's token length, loading it once.
+func (p *ftsProber) curDocLen(intId uint64) (float64, error) {
+	if !p.curDlLoaded {
+		dl, err := p.e.docLen(intId)
+		if err != nil {
+			return 0, err
+		}
+		p.curDl = float64(dl)
+		p.curDlLoaded = true
+	}
+	return p.curDl, nil
+}
+
+// addContribution mirrors the driver's addScore for the probed document.
+func (p *ftsProber) addContribution(intId uint64, idf, tf float64, reqBit uint64) error {
+	d, err := p.curDocLen(intId)
+	if err != nil {
+		return err
+	}
+	p.curScore += p.e.bm25(idf, tf, d)
+	p.curMask |= reqBit
+	p.curMatched = true
+	return nil
 }
 
 // newFtsProber compiles the $text predicate for probing on the given snapshot.
@@ -269,39 +303,12 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 		return 0, 0, false, nil
 	}
 	p.fwdBuf = ftsMapForwardKey(p.fwdBuf, docId)
-	intId, found, err := ftsGetUintOk(p.tx, p.fx.nsMap, p.fwdBuf)
+	var found bool
+	intId, found, p.mapValBuf, err = ftsGetUintOkBuf(p.tx, p.fx.nsMap, p.fwdBuf, p.mapValBuf)
 	if err != nil || !found {
 		return 0, 0, false, err
 	}
-
-	// Doc length: fetched once; identical value to the driver's per-posting
-	// docLen reads.
-	var dl uint32
-	dlLoaded := false
-	docLen := func() (float64, error) {
-		if !dlLoaded {
-			var derr error
-			dl, derr = p.e.docLen(intId)
-			if derr != nil {
-				return 0, derr
-			}
-			dlLoaded = true
-		}
-		return float64(dl), nil
-	}
-
-	var mask uint64
-	matched := false
-	add := func(idf, tf float64, reqBit uint64) error {
-		d, derr := docLen()
-		if derr != nil {
-			return derr
-		}
-		score += p.e.bm25(idf, tf, d)
-		mask |= reqBit
-		matched = true
-		return nil
-	}
+	p.curScore, p.curMask, p.curMatched, p.curDlLoaded = 0, 0, false, false
 
 	// Positive contributions, in the driver's exact order: plain terms
 	// (first-seen order), then groups (each prefix expansion in order).
@@ -317,7 +324,7 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 		if hit {
 			// Presence-gated like scanTerm: a zero-weight-field posting still
 			// enters the doc (score += 0) and sets the required bit.
-			if err = add(pt.idf, tf, pt.reqBit); err != nil {
+			if err = p.addContribution(intId, pt.idf, tf, pt.reqBit); err != nil {
 				return 0, 0, false, err
 			}
 		}
@@ -333,7 +340,7 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 				return 0, 0, false, cerr
 			}
 			if cnt > 0 {
-				if err = add(g.idfSum, float64(cnt), g.reqBit); err != nil {
+				if err = p.addContribution(intId, g.idfSum, float64(cnt), g.reqBit); err != nil {
 					return 0, 0, false, err
 				}
 			}
@@ -349,13 +356,13 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 				return 0, 0, false, terr
 			}
 			if hit {
-				if err = add(pt.idf, tf, g.reqBit); err != nil {
+				if err = p.addContribution(intId, pt.idf, tf, g.reqBit); err != nil {
 					return 0, 0, false, err
 				}
 			}
 		}
 	}
-	if !matched {
+	if !p.curMatched {
 		return 0, 0, false, nil
 	}
 
@@ -391,10 +398,10 @@ func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, e
 	}
 
 	// Required-clause gate (the driver's appendTo mask check).
-	if p.requiredAll != 0 && mask&p.requiredAll != p.requiredAll {
+	if p.requiredAll != 0 && p.curMask&p.requiredAll != p.requiredAll {
 		return 0, 0, false, nil
 	}
-	return score, intId, true, nil
+	return p.curScore, intId, true, nil
 }
 
 func (p *ftsProber) Close() {}

--- a/fulltext_probe.go
+++ b/fulltext_probe.go
@@ -1,0 +1,500 @@
+package anystore
+
+import (
+	"errors"
+	"math"
+
+	"github.com/anyproto/any-store/v2/internal/btree"
+	"github.com/anyproto/any-store/v2/internal/fts"
+	"github.com/anyproto/any-store/v2/internal/qplanner"
+	"github.com/anyproto/any-store/v2/query"
+)
+
+// fulltext_probe.go implements the probe (predicate) form of a $text query:
+// given ONE document id, decide whether the compiled $text predicate matches it
+// and compute its BM25 score — without walking any posting list. Each probe
+// costs a docmap point-get, a docinfo point-get, and one postings-chunk
+// point-get per query term. The planner uses this to drive a $text query from
+// a selective index or a primary-key restriction instead of the posting lists.
+//
+// PARITY CONTRACT: for any document, the prober must produce EXACTLY the same
+// match verdict and BIT-IDENTICAL score as the driver scan (searchCandidates).
+// Both sides share ftsExec.compileClauses (clause order, required bits) and
+// ftsExec.bm25 (formula and float evaluation order), and this file adds each
+// doc's per-clause contributions in the same order the driver's scans would
+// have: plain terms in first-seen order, then groups in clause order (each
+// prefix expansion in expansion order). A bounded write verb selects rows by
+// (score desc, IntDocID asc), so an epsilon here is wrong rows, not noise —
+// the differential test in fulltext_probe_test.go pins this.
+
+// probeTerm is one plain term (or prefix expansion) with its precomputed IDF.
+type probeTerm struct {
+	term   string
+	idf    float64
+	df     uint64
+	reqBit uint64
+}
+
+// probeGroup is one compiled phrase or prefix clause, resolved for probing:
+// a prefix is already expanded to its vocabulary completions.
+type probeGroup struct {
+	phrase bool
+	terms  []probeTerm // phrase: constituents (idf unused); prefix: expansions
+	idfSum float64     // phrase: summed constituent IDF
+	dead   bool        // some phrase constituent has df == 0 → can't match
+	reqBit uint64
+}
+
+// ftsProber evaluates the compiled $text predicate against single documents.
+// Not safe for concurrent use; one per query execution.
+type ftsProber struct {
+	e  ftsExec
+	fx *ftsIndex
+	tx *btree.ReadTx
+
+	plain       []probeTerm
+	groups      []probeGroup
+	negs        []probeGroup
+	requiredAll uint64
+	// hasPositive is false when no positive clause can match anything (all
+	// df == 0 or the query analyzed to nothing): every probe is then a miss,
+	// matching the driver's empty candidate stream.
+	hasPositive bool
+
+	keyBuf  []byte
+	valBuf  []byte
+	fwdBuf  []byte
+	posBufs [][]uint32
+	posBufB [][]uint32
+}
+
+// newFtsProber compiles the $text predicate for probing on the given snapshot.
+// Corpus stats (N, avgdl) and prefix expansions are resolved against tx, so a
+// prober and a driver scan on the same snapshot see identical vocabularies.
+func (fx *ftsIndex) newFtsProber(tx *btree.ReadTx, text query.Text) (*ftsProber, error) {
+	clauses := text.ParsedClauses()
+	p := &ftsProber{fx: fx, tx: tx}
+
+	n, err := ftsGetUint(tx, fx.nsMeta, ftsMetaCount)
+	if err != nil {
+		return nil, err
+	}
+	totalTokens, err := ftsGetUint(tx, fx.nsMeta, ftsMetaTokens)
+	if err != nil {
+		return nil, err
+	}
+	avgdl := float64(totalTokens) / float64(n)
+	if avgdl == 0 || math.IsNaN(avgdl) {
+		avgdl = 1
+	}
+	k1, b := ftsResolveBM25(fx.info.Fulltext)
+	weights, weighted := ftsResolveWeights(fx.info.Fulltext, fx.info.Fields)
+	p.e = ftsExec{
+		tx: tx, fx: fx, n: float64(n), avgdl: avgdl, az: fts.NewAnalyzer(),
+		k1: k1, b: b, nFields: fx.nFields, weights: weights, weighted: weighted,
+	}
+	if n == 0 || len(clauses) == 0 {
+		return p, nil // hasPositive stays false: probes never match
+	}
+
+	cq := p.e.compileClauses(clauses, text.DefaultAnd)
+	p.requiredAll = cq.requiredAll
+
+	termOf := func(term string, reqBit uint64) (probeTerm, error) {
+		df, derr := ftsGetUint(tx, fx.nsVocab, []byte(term))
+		if derr != nil {
+			return probeTerm{}, derr
+		}
+		pt := probeTerm{term: term, df: df, reqBit: reqBit}
+		if df > 0 {
+			pt.idf = math.Log(1 + (p.e.n-float64(df)+0.5)/(float64(df)+0.5))
+		}
+		return pt, nil
+	}
+
+	for _, term := range cq.plainOrder {
+		pt, terr := termOf(term, cq.plainBit[term])
+		if terr != nil {
+			return nil, terr
+		}
+		p.plain = append(p.plain, pt)
+		if pt.df > 0 {
+			p.hasPositive = true
+		}
+	}
+	buildGroup := func(g ftsClauseGroup) (probeGroup, error) {
+		pg := probeGroup{reqBit: g.reqBit}
+		if g.prefix {
+			// Same expansion set and order as the driver's scorePrefix.
+			terms, xerr := p.e.expandPrefix(g.stem)
+			if xerr != nil {
+				return pg, xerr
+			}
+			for _, t := range terms {
+				pt, terr := termOf(t, g.reqBit)
+				if terr != nil {
+					return pg, terr
+				}
+				pg.terms = append(pg.terms, pt)
+			}
+			pg.dead = len(pg.terms) == 0
+			return pg, nil
+		}
+		pg.phrase = true
+		for _, t := range g.terms {
+			pt, terr := termOf(t, 0)
+			if terr != nil {
+				return pg, terr
+			}
+			if pt.df == 0 {
+				pg.dead = true // driver's scorePhrase: any absent term → no matches
+			}
+			pg.idfSum += pt.idf
+			pg.terms = append(pg.terms, pt)
+		}
+		return pg, nil
+	}
+	for _, g := range cq.posGroups {
+		pg, gerr := buildGroup(g)
+		if gerr != nil {
+			return nil, gerr
+		}
+		p.groups = append(p.groups, pg)
+		if !pg.dead && len(pg.terms) > 0 {
+			p.hasPositive = true
+		}
+	}
+	for _, g := range cq.negGroups {
+		pg, gerr := buildGroup(g)
+		if gerr != nil {
+			return nil, gerr
+		}
+		p.negs = append(p.negs, pg)
+	}
+	return p, nil
+}
+
+// termTF returns the term's frequency in document intId (the weighted
+// pseudo-frequency under BM25F, matching scanTerm's weighted branch), or 0 when
+// the document does not contain the term. Positions, when dst is non-nil, are
+// decoded into *dst for phrase adjacency.
+func (p *ftsProber) termTF(term string, intId uint64, dst *[]uint32) (float64, error) {
+	p.keyBuf = postingsKey(p.keyBuf, term, fts.ChunkID(intId))
+	var err error
+	p.valBuf, err = p.tx.AppendValue(p.fx.nsPost, p.keyBuf, p.valBuf[:0])
+	if err != nil {
+		if errors.Is(err, btree.ErrKeyNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	it, err := p.e.chunkReader(p.valBuf)
+	if err != nil {
+		return 0, ftsMapFormatErr(err)
+	}
+	for it.Next() {
+		docID := it.DocID()
+		if docID > intId {
+			break
+		}
+		if docID != intId {
+			continue
+		}
+		var tf float64
+		if p.e.weighted {
+			for f := 0; f < p.e.nFields; f++ {
+				if w := p.e.weights[f]; w != 0 {
+					if ftf := it.FieldTF(f); ftf != 0 {
+						tf += w * float64(ftf)
+					}
+				}
+			}
+		} else {
+			tf = float64(it.TF())
+		}
+		if dst != nil {
+			*dst = it.AppendPositions((*dst)[:0])
+		}
+		if it.Err() != nil {
+			return 0, it.Err()
+		}
+		return tf, nil
+	}
+	return 0, it.Err()
+}
+
+// phrasePresent reports the phrase's adjacency-confirmed occurrence count in
+// intId (0 when any constituent is absent or no adjacent run exists).
+func (p *ftsProber) phraseCount(g *probeGroup, intId uint64) (uint32, error) {
+	for len(p.posBufs) < len(g.terms) {
+		p.posBufs = append(p.posBufs, nil)
+	}
+	lists := p.posBufB[:0]
+	for i, t := range g.terms {
+		tf, err := p.termTF(t.term, intId, &p.posBufs[i])
+		if err != nil {
+			return 0, err
+		}
+		if tf == 0 {
+			p.posBufB = lists
+			return 0, nil
+		}
+		lists = append(lists, p.posBufs[i])
+	}
+	p.posBufB = lists
+	return countAdjacent(lists), nil
+}
+
+// Probe evaluates the $text predicate for one document. ok reports a match;
+// score is the document's BM25 score and intId its stable IntDocID (the
+// driver-order tie-break key). docId is the document's data-namespace key.
+func (p *ftsProber) Probe(docId []byte) (score float64, intId uint64, ok bool, err error) {
+	if !p.hasPositive {
+		return 0, 0, false, nil
+	}
+	p.fwdBuf = ftsMapForwardKey(p.fwdBuf, docId)
+	intId, found, err := ftsGetUintOk(p.tx, p.fx.nsMap, p.fwdBuf)
+	if err != nil || !found {
+		return 0, 0, false, err
+	}
+
+	// Doc length: fetched once; identical value to the driver's per-posting
+	// docLen reads.
+	var dl uint32
+	dlLoaded := false
+	docLen := func() (float64, error) {
+		if !dlLoaded {
+			var derr error
+			dl, derr = p.e.docLen(intId)
+			if derr != nil {
+				return 0, derr
+			}
+			dlLoaded = true
+		}
+		return float64(dl), nil
+	}
+
+	var mask uint64
+	matched := false
+	add := func(idf, tf float64, reqBit uint64) error {
+		d, derr := docLen()
+		if derr != nil {
+			return derr
+		}
+		score += p.e.bm25(idf, tf, d)
+		mask |= reqBit
+		matched = true
+		return nil
+	}
+
+	// Positive contributions, in the driver's exact order: plain terms
+	// (first-seen order), then groups (each prefix expansion in order).
+	for i := range p.plain {
+		pt := &p.plain[i]
+		if pt.df == 0 {
+			continue
+		}
+		tf, terr := p.termTF(pt.term, intId, nil)
+		if terr != nil {
+			return 0, 0, false, terr
+		}
+		if tf > 0 {
+			if err = add(pt.idf, tf, pt.reqBit); err != nil {
+				return 0, 0, false, err
+			}
+		}
+	}
+	for gi := range p.groups {
+		g := &p.groups[gi]
+		if g.dead {
+			continue
+		}
+		if g.phrase {
+			cnt, cerr := p.phraseCount(g, intId)
+			if cerr != nil {
+				return 0, 0, false, cerr
+			}
+			if cnt > 0 {
+				if err = add(g.idfSum, float64(cnt), g.reqBit); err != nil {
+					return 0, 0, false, err
+				}
+			}
+			continue
+		}
+		for ti := range g.terms {
+			pt := &g.terms[ti]
+			if pt.df == 0 {
+				continue
+			}
+			tf, terr := p.termTF(pt.term, intId, nil)
+			if terr != nil {
+				return 0, 0, false, terr
+			}
+			if tf > 0 {
+				if err = add(pt.idf, tf, g.reqBit); err != nil {
+					return 0, 0, false, err
+				}
+			}
+		}
+	}
+	if !matched {
+		return 0, 0, false, nil
+	}
+
+	// Negated clauses: any match excludes the doc (the driver's tombstone).
+	for gi := range p.negs {
+		g := &p.negs[gi]
+		if g.dead {
+			continue
+		}
+		if g.phrase {
+			cnt, cerr := p.phraseCount(g, intId)
+			if cerr != nil {
+				return 0, 0, false, cerr
+			}
+			if cnt > 0 {
+				return 0, 0, false, nil
+			}
+			continue
+		}
+		for ti := range g.terms {
+			pt := &g.terms[ti]
+			if pt.df == 0 {
+				continue
+			}
+			tf, terr := p.termTF(pt.term, intId, nil)
+			if terr != nil {
+				return 0, 0, false, terr
+			}
+			if tf > 0 {
+				return 0, 0, false, nil
+			}
+		}
+	}
+
+	// Required-clause gate (the driver's appendTo mask check).
+	if p.requiredAll != 0 && mask&p.requiredAll != p.requiredAll {
+		return 0, 0, false, nil
+	}
+	return score, intId, true, nil
+}
+
+func (p *ftsProber) Close() {}
+
+// ftsPhraseMatchFraction estimates what fraction of documents containing every
+// phrase constituent also contain them adjacently. Coarse by design: it prices
+// the plan-time yield estimate, never correctness.
+const ftsPhraseMatchFraction = 0.25
+
+// planStats compiles the predicate and reads the per-term document frequencies
+// (one vocab point-get per term; a prefix pays one bounded vocab scan — the
+// same reads the chosen plan repeats at execution). SumDF and ProbeTerms are
+// exact; only EstMatches is an estimate.
+func (fx *ftsIndex) planStats(tx *btree.ReadTx, text query.Text) (st qplanner.FtsPlanStats, err error) {
+	clauses := text.ParsedClauses()
+	if len(clauses) == 0 {
+		return st, nil
+	}
+	n, err := ftsGetUint(tx, fx.nsMeta, ftsMetaCount)
+	if err != nil || n == 0 {
+		return st, err
+	}
+	st.CorpusDocs = float64(n)
+	e := ftsExec{tx: tx, fx: fx, az: fts.NewAnalyzer(), nFields: fx.nFields}
+	cq := e.compileClauses(clauses, text.DefaultAnd)
+
+	df := func(term string) (float64, error) {
+		v, derr := ftsGetUint(tx, fx.nsVocab, []byte(term))
+		return float64(v), derr
+	}
+
+	// Per-clause match estimates: OR-combined for should clauses, intersected
+	// (independence) for required ones.
+	orSum := 0.0  // Σ df over non-required positive clauses
+	andSel := 1.0 // ∏ (df_i / N) over required clauses
+	hasAnd := false
+
+	account := func(clauseDF float64, required bool) {
+		if required {
+			hasAnd = true
+			andSel *= min(clauseDF/float64(n), 1.0)
+		} else {
+			orSum += clauseDF
+		}
+	}
+
+	for _, term := range cq.plainOrder {
+		d, derr := df(term)
+		if derr != nil {
+			return st, derr
+		}
+		st.SumDF += d
+		st.ProbeTerms++
+		account(d, cq.plainBit[term] != 0)
+	}
+	groupStats := func(g ftsClauseGroup, positive bool) error {
+		if g.prefix {
+			terms, xerr := e.expandPrefix(g.stem)
+			if xerr != nil {
+				return xerr
+			}
+			var sum float64
+			for _, t := range terms {
+				d, derr := df(t)
+				if derr != nil {
+					return derr
+				}
+				sum += d
+				st.SumDF += d
+				st.ProbeTerms++
+			}
+			if positive {
+				account(sum, g.reqBit != 0)
+			}
+			return nil
+		}
+		// Phrase: the zig-zag advances every stream at most min-df times.
+		minDF := math.MaxFloat64
+		for _, t := range g.terms {
+			d, derr := df(t)
+			if derr != nil {
+				return derr
+			}
+			minDF = min(minDF, d)
+			st.ProbeTerms++
+		}
+		if minDF == math.MaxFloat64 {
+			minDF = 0
+		}
+		st.SumDF += minDF * float64(len(g.terms))
+		if positive {
+			account(minDF*ftsPhraseMatchFraction, g.reqBit != 0)
+		}
+		return nil
+	}
+	for _, g := range cq.posGroups {
+		if gerr := groupStats(g, true); gerr != nil {
+			return st, gerr
+		}
+	}
+	for _, g := range cq.negGroups {
+		if gerr := groupStats(g, false); gerr != nil {
+			return st, gerr
+		}
+	}
+
+	est := min(orSum, float64(n))
+	if hasAnd {
+		// Required clauses bound the yield multiplicatively; a pure-AND query
+		// has no OR contribution.
+		andEst := float64(n) * andSel
+		if orSum > 0 {
+			est = min(est, andEst)
+		} else {
+			est = andEst
+		}
+	}
+	st.EstMatches = max(est, 1)
+	st.Valid = true
+	return st, nil
+}

--- a/fulltext_probe_test.go
+++ b/fulltext_probe_test.go
@@ -192,12 +192,17 @@ func assertSamePlanResults(t *testing.T, coll Collection, cond map[string]any, l
 				"plan %s: score not bit-identical for %v row %d (%s): %v vs %v", p.name, cond, i, ids[i], baseScores[i], scores[i])
 		}
 
-		// Count must agree with the row count of the unwindowed query.
-		if limit == 0 && offset == 0 {
-			n, err := coll.Find(cond).IndexHint(p.hint...).Count(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, len(baseIds), n, "plan %s: count diverged for %v", p.name, cond)
+		// Count must agree with the row count of the same (windowed) query.
+		cq := coll.Find(cond).IndexHint(p.hint...)
+		if limit > 0 {
+			cq = cq.Limit(limit)
 		}
+		if offset > 0 {
+			cq = cq.Offset(offset)
+		}
+		n, err := cq.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, len(baseIds), n, "plan %s: count diverged for %v limit=%d offset=%d", p.name, cond, limit, offset)
 	}
 }
 
@@ -372,6 +377,33 @@ func TestFtsProbe_RequiredBitExhaustion(t *testing.T) {
 		"id":    map[string]any{"$in": manyIds(40)},
 	}
 	assertSamePlanResults(t, coll, cond, 0, 0, nil)
+}
+
+// A REVERSE-declared unique index chosen as the probe driver goes through
+// CoverIter, which must receive un-finalized bounds — the reverse-tail pad
+// would double-pad its seek and silently return zero rows.
+func TestFtsProbe_ReverseUniqueCoverDriver(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+	coll, err := fx.CreateCollection(ctx, "revcover")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ft", Kind: IndexKindFulltext, Fields: []string{"body"}}))
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "sku", Fields: []string{"-sku"}, Unique: true}))
+	var docs []string
+	for i := 0; i < 40; i++ {
+		docs = append(docs, fmt.Sprintf(`{"id":"r%02d","sku":"s%02d","body":"alpha common text"}`, i, i))
+	}
+	insertJSON(t, coll, docs...)
+
+	for _, cond := range []map[string]any{
+		{"$text": map[string]any{"$search": "alpha"}, "sku": "s07"},
+		{"$text": map[string]any{"$search": "alpha"}, "sku": map[string]any{"$in": []any{"s03", "s11", "s25"}}},
+	} {
+		driverIds, _ := collectIter(t, coll.Find(cond).IndexHint(IndexHint{IndexName: "ft", Boost: ftsProbeBoost}))
+		probeIds, _ := collectIter(t, coll.Find(cond).IndexHint(IndexHint{IndexName: "sku", Boost: ftsProbeBoost}))
+		require.NotEmpty(t, driverIds)
+		assert.Equal(t, driverIds, probeIds, "reverse-unique cover probe lost rows for %v", cond)
+	}
 }
 
 // Logical-work guard: a Count whose residual is covered by the probe driver

--- a/fulltext_probe_test.go
+++ b/fulltext_probe_test.go
@@ -1,0 +1,326 @@
+package anystore
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/internal/qplanner"
+)
+
+func qplannerEnableCounters(t *testing.T) {
+	qplanner.ResetPerfCounters()
+	qplanner.EnablePerfCounters(true)
+	t.Cleanup(func() { qplanner.EnablePerfCounters(false) })
+}
+
+func qplannerSnapshot() qplanner.PerfCounters {
+	return qplanner.SnapshotPerfCounters()
+}
+
+// Differential tests for the $text driver/probe plan duality: every legal plan
+// for the same query must produce byte-identical rows, order, and scores. A
+// bounded write selects rows by (score desc, IntDocID asc), so any divergence
+// here is cross-device data divergence, not a perf bug. Plans are forced via
+// IndexHint: the fulltext index name forces the driver, the primary-key field
+// name the pk probe, and a secondary index name its probe.
+
+const ftsProbeBoost = 1 << 30
+
+// ftsProbeColl builds a corpus exercising every clause kind: zipf-ish plain
+// terms, phrase pairs, a prefix family, docs with identical text (score ties),
+// docs missing the text field, and a multikey tags index.
+func ftsProbeColl(t *testing.T) (*fixture, Collection) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "probe")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ft", Kind: IndexKindFulltext, Fields: []string{"title", "body"}}))
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "a", Fields: []string{"a"}}))
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "tags", Fields: []string{"tags"}}))
+
+	vocab := []string{"alpha", "beta", "gamma", "delta", "omega", "prefixone", "prefixtwo", "prefixthree"}
+	var docs []string
+	for i := 0; i < 120; i++ {
+		var words []string
+		for w, word := range vocab {
+			if i%(w+2) == 0 {
+				words = append(words, word)
+			}
+		}
+		if i%3 == 0 {
+			words = append(words, "alpha", "beta") // adjacent → phrase "alpha beta"
+		}
+		if i%17 == 0 {
+			words = append(words, fmt.Sprintf("uniq%d", i))
+		}
+		body := strings.Join(words, " ")
+		if i%29 == 0 {
+			body = "" // empty text
+		}
+		title := "doc"
+		if i%4 == 0 {
+			title = "alpha title"
+		}
+		docs = append(docs, fmt.Sprintf(
+			`{"id":"d%03d","a":%d,"s":%d,"tags":["t%d","t%d"],"title":%q,"body":%q}`,
+			i, i%10, (i*37)%50, i%5, i%7, title, body))
+	}
+	// A tie group: identical text, distinct ids — order must fall back to
+	// IntDocID (insertion order) identically under every plan.
+	for i := 0; i < 8; i++ {
+		docs = append(docs, fmt.Sprintf(`{"id":"tie%d","a":%d,"s":0,"tags":["t0"],"title":"doc","body":"omega omega gamma"}`, i, i%10))
+	}
+	// A doc with no text fields at all.
+	docs = append(docs, `{"id":"notext","a":1,"s":1,"tags":["t1"]}`)
+	insertJSON(t, coll, docs...)
+	return fx, coll
+}
+
+// ftsProbePlans are the plans to force for every query: the driver, the pk
+// probe, and the two secondary-index probes. A hint that has no matching
+// candidate for a given query is a no-op — the comparison then just re-checks
+// the cheapest plan, which is harmless.
+var ftsProbePlans = []struct {
+	name string
+	hint []IndexHint
+}{
+	{"cbo", nil},
+	{"driver", []IndexHint{{IndexName: "ft", Boost: ftsProbeBoost}}},
+	{"probe-ids", []IndexHint{{IndexName: "id", Boost: ftsProbeBoost}}},
+	{"probe-a", []IndexHint{{IndexName: "a", Boost: ftsProbeBoost}}},
+	{"probe-tags", []IndexHint{{IndexName: "tags", Boost: ftsProbeBoost}}},
+}
+
+func ftsProbeQueries() []map[string]any {
+	text := func(kv ...any) map[string]any {
+		m := map[string]any{}
+		for i := 0; i < len(kv); i += 2 {
+			m[kv[i].(string)] = kv[i+1]
+		}
+		return m
+	}
+	searches := []map[string]any{
+		text("$search", "alpha"),
+		text("$search", "omega"),
+		text("$search", "uniq17"),
+		text("$search", "alpha beta gamma"),
+		text("$search", `"alpha beta"`),
+		text("$search", "prefix*"),
+		text("$search", "alpha", "$exclude", "beta"),
+		text("$search", "alpha", "$require", "gamma"),
+		text("$search", "alpha beta", "$defaultOperator", "and"),
+		text("$search", "alpha alpha beta"), // repeated term dedup
+		text("$search", "nosuchterm"),
+		text("$search", ""),
+	}
+	restrictions := []map[string]any{
+		nil,
+		{"id": map[string]any{"$in": []any{"d001", "d004", "d012", "tie3", "nope"}}},
+		{"id": map[string]any{"$in": manyIds(40)}},
+		{"id": map[string]any{"$gte": "d010", "$lt": "d060"}},
+		{"a": 3},
+		{"a": map[string]any{"$in": []any{1, 2}}},
+		{"tags": "t2"},
+		{"a": 3, "s": map[string]any{"$lt": 30}},
+	}
+	var out []map[string]any
+	for _, s := range searches {
+		for _, r := range restrictions {
+			q := map[string]any{"$text": s}
+			for k, v := range r {
+				q[k] = v
+			}
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+func manyIds(n int) []any {
+	out := make([]any, 0, n+2)
+	for i := 0; i < n; i++ {
+		out = append(out, fmt.Sprintf("d%03d", i*3))
+	}
+	out = append(out, "tie0", "tie5")
+	return out
+}
+
+// assertSamePlanResults runs the query under every forced plan and asserts
+// rows, order, and bit-exact scores match the driver plan.
+func assertSamePlanResults(t *testing.T, coll Collection, cond map[string]any, limit, offset uint, sort any) {
+	t.Helper()
+	var baseIds []string
+	var baseScores []float64
+	for _, p := range ftsProbePlans {
+		q := coll.Find(cond)
+		if len(p.hint) > 0 {
+			q = q.IndexHint(p.hint...)
+		}
+		if limit > 0 {
+			q = q.Limit(limit)
+		}
+		if offset > 0 {
+			q = q.Offset(offset)
+		}
+		if sort != nil {
+			q = q.Sort(sort)
+		}
+		ids, scores := collectIter(t, q)
+		if p.name == "cbo" {
+			baseIds, baseScores = ids, scores
+			continue
+		}
+		if !assert.Equal(t, baseIds, ids, "plan %s: rows/order diverged for %v limit=%d offset=%d sort=%v", p.name, cond, limit, offset, sort) {
+			ex, _ := coll.Find(cond).IndexHint(p.hint...).Explain(ctx)
+			t.Logf("diverging plan: %s", ex.Plan)
+			return
+		}
+		require.Equal(t, len(baseScores), len(scores))
+		for i := range scores {
+			assert.Equal(t, math.Float64bits(baseScores[i]), math.Float64bits(scores[i]),
+				"plan %s: score not bit-identical for %v row %d (%s): %v vs %v", p.name, cond, i, ids[i], baseScores[i], scores[i])
+		}
+
+		// Count must agree with the row count of the unwindowed query.
+		if limit == 0 && offset == 0 {
+			n, err := coll.Find(cond).IndexHint(p.hint...).Count(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, len(baseIds), n, "plan %s: count diverged for %v", p.name, cond)
+		}
+	}
+}
+
+func TestFtsProbe_DifferentialAllPlans(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	for _, cond := range ftsProbeQueries() {
+		assertSamePlanResults(t, coll, cond, 0, 0, nil)
+		assertSamePlanResults(t, coll, cond, 5, 0, nil)
+		assertSamePlanResults(t, coll, cond, 5, 3, nil)
+	}
+}
+
+func TestFtsProbe_DifferentialSorted(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	conds := []map[string]any{
+		{"$text": map[string]any{"$search": "alpha"}, "a": 3},
+		{"$text": map[string]any{"$search": "omega"}, "id": map[string]any{"$in": manyIds(30)}},
+		{"$text": map[string]any{"$search": "alpha beta"}},
+	}
+	for _, cond := range conds {
+		for _, sort := range []any{"s", "-s", "a"} {
+			assertSamePlanResults(t, coll, cond, 0, 0, sort)
+			assertSamePlanResults(t, coll, cond, 4, 0, sort)
+			assertSamePlanResults(t, coll, cond, 4, 2, sort)
+		}
+		// Explicit relevance sort maps to the intrinsic order.
+		assertSamePlanResults(t, coll, cond, 6, 0, `{"score":{"$meta":"textScore"}}`)
+	}
+}
+
+// Score ties must break by IntDocID (insertion order) under every plan — this
+// is what keeps bounded writes device-deterministic.
+func TestFtsProbe_TieBreakOrder(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	cond := map[string]any{
+		"$text": map[string]any{"$search": "omega omega gamma", "$defaultOperator": "and"},
+		"id":    map[string]any{"$in": []any{"tie7", "tie5", "tie3", "tie1", "tie0"}},
+	}
+	assertSamePlanResults(t, coll, cond, 3, 0, nil)
+	ids, _ := collectIter(t, coll.Find(cond).Limit(3))
+	assert.Equal(t, []string{"tie0", "tie1", "tie3"}, ids)
+}
+
+// A bounded write under $text must modify the same rows whichever plan runs.
+func TestFtsProbe_BoundedUpdateSameRows(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	cond := map[string]any{
+		"$text": map[string]any{"$search": "alpha"},
+		"id":    map[string]any{"$in": manyIds(40)},
+	}
+	expected, _ := collectIter(t, coll.Find(cond).Limit(3))
+	require.Len(t, expected, 3)
+
+	res, err := coll.Find(cond).IndexHint(IndexHint{IndexName: "id", Boost: ftsProbeBoost}).
+		Limit(3).Update(ctx, `{"$set":{"marked":1}}`)
+	require.NoError(t, err)
+	require.Equal(t, 3, res.Modified)
+
+	marked, _ := collectIter(t, coll.Find(`{"marked":1}`))
+	assert.ElementsMatch(t, expected, marked)
+}
+
+// The CBO must route the SYN-191 shapes to probe plans and broad queries to
+// the driver, and Count on a covered probe plan must fetch no documents.
+func TestFtsProbe_PlanChoice(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+
+	explain := func(cond map[string]any, limit uint) string {
+		q := coll.Find(cond)
+		if limit > 0 {
+			q = q.Limit(limit)
+		}
+		ex, err := q.Explain(ctx)
+		require.NoError(t, err)
+		return ex.Plan + " " + ex.Sql
+	}
+
+	selective := map[string]any{
+		"$text": map[string]any{"$search": "alpha"},
+		"id":    map[string]any{"$in": []any{"d000", "d004", "d008"}},
+	}
+	assert.Contains(t, explain(selective, 10), "FtsProbe", "3-id restriction must probe")
+
+	broad := map[string]any{"$text": map[string]any{"$search": "alpha"}}
+	assert.Contains(t, explain(broad, 10), "FtsSearch", "unrestricted must keep the driver")
+
+	eqA := map[string]any{"$text": map[string]any{"$search": "alpha"}, "a": 3}
+	assert.Contains(t, explain(eqA, 10), "FtsProbe", "selective index equality must probe")
+}
+
+// Logical-work guard: a Count whose residual is covered by the probe driver
+// must fetch zero documents — the structural fix for the Count sibling defect.
+func TestFtsProbe_CountFetchesNothing(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	cond := map[string]any{
+		"$text": map[string]any{"$search": "alpha"},
+		"id":    map[string]any{"$in": []any{"d000", "d004", "d008"}},
+	}
+	// Warm plan/visibility state outside the measured window.
+	_, err := coll.Find(cond).Count(ctx)
+	require.NoError(t, err)
+
+	qplannerEnableCounters(t)
+	n, err := coll.Find(cond).Count(ctx)
+	require.NoError(t, err)
+	require.Greater(t, n, 0)
+	pc := qplannerSnapshot()
+	assert.Zero(t, pc.FetchNextCalls, "covered probe Count must not fetch documents")
+	assert.Zero(t, pc.FilterNextCalls, "covered probe Count must not run the residual filter")
+}
+
+// The driver plan's primary-key gate: an id range restriction must not change
+// results, and stays on the driver when the range is broad.
+func TestFtsProbe_DriverIdGate(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	cond := map[string]any{
+		"$text": map[string]any{"$search": "alpha"},
+		"id":    map[string]any{"$gte": "d010", "$lt": "d040"},
+	}
+	ids, _ := collectIter(t, coll.Find(cond).IndexHint(IndexHint{IndexName: "ft", Boost: ftsProbeBoost}))
+	for _, id := range ids {
+		assert.GreaterOrEqual(t, id, "d010")
+		assert.Less(t, id, "d040")
+	}
+	require.NotEmpty(t, ids)
+}

--- a/fulltext_probe_test.go
+++ b/fulltext_probe_test.go
@@ -44,7 +44,9 @@ func ftsProbeColl(t *testing.T) (*fixture, Collection) {
 
 	vocab := []string{"alpha", "beta", "gamma", "delta", "omega", "prefixone", "prefixtwo", "prefixthree"}
 	var docs []string
-	for i := 0; i < 120; i++ {
+	// 300 docs: IntDocIDs span 3 postings chunks (chunk size 128), so the
+	// prober's single-chunk point-get is exercised against multi-chunk terms.
+	for i := 0; i < 300; i++ {
 		var words []string
 		for w, word := range vocab {
 			if i%(w+2) == 0 {
@@ -109,9 +111,14 @@ func ftsProbeQueries() []map[string]any {
 		text("$search", "uniq17"),
 		text("$search", "alpha beta gamma"),
 		text("$search", `"alpha beta"`),
+		text("$search", `"alpha"`), // quoted SINGLE token: driver routes to scanTerm
 		text("$search", "prefix*"),
+		text("$search", "alpha prefixon*"), // expansion overlapping a plain-term family
 		text("$search", "alpha", "$exclude", "beta"),
+		text("$search", "alpha", "$exclude", "prefix*"), // negated prefix
+		text("$search", "alpha", "$exclude", `"beta gamma"`),
 		text("$search", "alpha", "$require", "gamma"),
+		text("$search", "alpha", "$require", "nosuchterm"), // dead required clause: zero rows
 		text("$search", "alpha beta", "$defaultOperator", "and"),
 		text("$search", "alpha alpha beta"), // repeated term dedup
 		text("$search", "nosuchterm"),
@@ -284,6 +291,87 @@ func TestFtsProbe_PlanChoice(t *testing.T) {
 
 	eqA := map[string]any{"$text": map[string]any{"$search": "alpha"}, "a": 3}
 	assert.Contains(t, explain(eqA, 10), "FtsProbe", "selective index equality must probe")
+}
+
+// Weighted (BM25F) parity: per-field weights change the scored tf, a
+// zero-weight field contributes tf 0 yet still counts as presence for
+// matching, required bits, and exclusion — the prober must reproduce all of
+// it bit-exactly (a quoted single token routes through scanTerm, not the
+// phrase path). Non-default K1/B pin ftsResolveBM25 parity.
+func TestFtsProbe_WeightedDifferential(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish()
+	coll, err := fx.CreateCollection(ctx, "wprobe")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{
+		Name: "ft", Kind: IndexKindFulltext, Fields: []string{"title", "body"},
+		Fulltext: &FulltextParams{Weights: map[string]float64{"title": 3, "body": 0}, K1: 1.6, B: 0.6},
+	}))
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "a", Fields: []string{"a"}}))
+	var docs []string
+	for i := 0; i < 150; i++ {
+		title, body := "doc", "pad filler"
+		if i%2 == 0 {
+			title = "alpha common"
+		}
+		if i%3 == 0 {
+			body = "beta only in body" // zero-weight field: presence without score
+		}
+		if i%5 == 0 {
+			title = "alpha beta adjacent"
+		}
+		docs = append(docs, fmt.Sprintf(`{"id":"w%03d","a":%d,"title":%q,"body":%q}`, i, i%10, title, body))
+	}
+	insertJSON(t, coll, docs...)
+
+	conds := []map[string]any{
+		{"$text": map[string]any{"$search": "beta"}},
+		{"$text": map[string]any{"$search": `"alpha"`}},
+		{"$text": map[string]any{"$search": "alpha", "$exclude": "beta"}},
+		{"$text": map[string]any{"$search": "alpha", "$require": "beta"}},
+		{"$text": map[string]any{"$search": `"alpha beta"`}},
+		{"$text": map[string]any{"$search": "alpha beta", "$defaultOperator": "and"}},
+	}
+	restrictions := []map[string]any{
+		{"a": 3},
+		{"id": map[string]any{"$in": func() []any {
+			var out []any
+			for i := 0; i < 40; i++ {
+				out = append(out, fmt.Sprintf("w%03d", i*3))
+			}
+			return out
+		}()}},
+	}
+	for _, c := range conds {
+		for _, r := range restrictions {
+			cond := map[string]any{}
+			for k, v := range c {
+				cond[k] = v
+			}
+			for k, v := range r {
+				cond[k] = v
+			}
+			assertSamePlanResults(t, coll, cond, 0, 0, nil)
+			assertSamePlanResults(t, coll, cond, 5, 0, nil)
+		}
+	}
+}
+
+// >64 required clauses exhaust the 64-bit mask; the tail degrades to ungated
+// OR identically on both sides.
+func TestFtsProbe_RequiredBitExhaustion(t *testing.T) {
+	fx, coll := ftsProbeColl(t)
+	defer fx.finish()
+	req := make([]any, 0, 70)
+	req = append(req, "alpha", "gamma")
+	for i := 0; i < 68; i++ {
+		req = append(req, fmt.Sprintf("filler%d", i)) // df==0 fillers
+	}
+	cond := map[string]any{
+		"$text": map[string]any{"$search": "", "$require": req},
+		"id":    map[string]any{"$in": manyIds(40)},
+	}
+	assertSamePlanResults(t, coll, cond, 0, 0, nil)
 }
 
 // Logical-work guard: a Count whose residual is covered by the probe driver

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -930,15 +930,23 @@ func ftsGetUint(tx *btree.ReadTx, ns *btree.Namespace, key []byte) (uint64, erro
 
 // ftsGetUintOk is ftsGetUint reporting existence: an absent key is (0, false, nil).
 func ftsGetUintOk(tx *btree.ReadTx, ns *btree.Namespace, key []byte) (uint64, bool, error) {
-	v, err := tx.Get(ns, key)
+	n, ok, _, err := ftsGetUintOkBuf(tx, ns, key, nil)
+	return n, ok, err
+}
+
+// ftsGetUintOkBuf is ftsGetUintOk with a caller-owned value buffer — the
+// prober calls it once per candidate, and tx.Get's nil-buffer AppendValue
+// would allocate every time (same rationale as ftsDocLenBuf).
+func ftsGetUintOkBuf(tx *btree.ReadTx, ns *btree.Namespace, key, buf []byte) (uint64, bool, []byte, error) {
+	v, err := tx.AppendValue(ns, key, buf[:0])
 	if err != nil {
 		if errors.Is(err, btree.ErrKeyNotFound) {
-			return 0, false, nil
+			return 0, false, buf, nil
 		}
-		return 0, false, err
+		return 0, false, buf, err
 	}
 	n, _ := binary.Uvarint(v)
-	return n, true, nil
+	return n, true, v, nil
 }
 
 // ftsDocLenBuf returns the stored document length, using a caller-owned value buffer: the BM25

--- a/fulltext_search.go
+++ b/fulltext_search.go
@@ -255,22 +255,36 @@ func (e *ftsExec) analyze(raw string) []string {
 	return terms
 }
 
-// run compiles and executes the clauses. Positive clauses (should/must) are
-// scored first — plain terms in first-seen order, so a pure-OR query keeps the
-// exact v1 summation order — then phrases and prefixes; negated clauses run last
-// (tombstones only affect docs already scored).
-func (e *ftsExec) run(clauses []query.TextClause, defaultAnd bool) error {
-	// Ordered, deduped positive plain terms (preserves v1 scan order + parity).
-	var plainOrder []string
-	plainBit := map[string]uint64{}
-	type group struct {
-		terms  []string // >1 ⇒ phrase
-		stem   string   // prefix clause stem (Prefix only)
-		prefix bool
-		reqBit uint64
-	}
-	var posGroups, negGroups []group
+// ftsClauseGroup is one compiled non-plain clause: a phrase (len(terms) > 1),
+// or a prefix clause (prefix == true, stem set).
+type ftsClauseGroup struct {
+	terms  []string // >1 ⇒ phrase
+	stem   string   // prefix clause stem (Prefix only)
+	prefix bool
+	reqBit uint64
+}
 
+// ftsCompiledQuery is the compiled clause set of one $text predicate. It is
+// the SINGLE source of clause order and required-bit assignment for both
+// evaluation strategies — the driver scan (ftsExec.runCompiled) and the
+// per-document prober (ftsProber) — so their per-doc float summation order and
+// match semantics can never drift apart.
+type ftsCompiledQuery struct {
+	// plainOrder holds positive single-term clauses in first-seen order (v1
+	// scan-order parity); plainBit maps each to its OR-ed required bits.
+	plainOrder []string
+	plainBit   map[string]uint64
+	posGroups  []ftsClauseGroup
+	negGroups  []ftsClauseGroup
+	// requiredAll is the OR of every allocated required-clause bit.
+	requiredAll uint64
+}
+
+// compileClauses analyzes and classifies the clauses. Scoring order is fixed
+// here: plain positive terms first (first-seen order), then phrases/prefixes in
+// clause order, then negations.
+func (e *ftsExec) compileClauses(clauses []query.TextClause, defaultAnd bool) ftsCompiledQuery {
+	cq := ftsCompiledQuery{plainBit: map[string]uint64{}}
 	for _, c := range clauses {
 		terms := e.analyze(c.Raw)
 		if len(terms) == 0 {
@@ -281,19 +295,19 @@ func (e *ftsExec) run(clauses []query.TextClause, defaultAnd bool) error {
 
 		switch {
 		case c.Prefix && len(terms) == 1 && !c.Phrase:
-			g := group{stem: terms[0], prefix: true}
+			g := ftsClauseGroup{stem: terms[0], prefix: true}
 			if negated {
-				negGroups = append(negGroups, g)
+				cq.negGroups = append(cq.negGroups, g)
 			} else {
 				if required {
 					g.reqBit = e.allocReqBit()
 				}
-				posGroups = append(posGroups, g)
+				cq.posGroups = append(cq.posGroups, g)
 			}
 		case len(terms) == 1 && !c.Phrase:
 			term := terms[0]
 			if negated {
-				negGroups = append(negGroups, group{terms: terms})
+				cq.negGroups = append(cq.negGroups, ftsClauseGroup{terms: terms})
 				continue
 			}
 			var reqBit uint64
@@ -301,40 +315,50 @@ func (e *ftsExec) run(clauses []query.TextClause, defaultAnd bool) error {
 				reqBit = e.allocReqBit()
 			}
 			// Dedup a repeated positive term: score once, union its bits.
-			if _, seen := plainBit[term]; seen {
-				plainBit[term] |= reqBit
+			if _, seen := cq.plainBit[term]; seen {
+				cq.plainBit[term] |= reqBit
 			} else {
-				plainBit[term] = reqBit
-				plainOrder = append(plainOrder, term)
+				cq.plainBit[term] = reqBit
+				cq.plainOrder = append(cq.plainOrder, term)
 			}
 		default:
 			// Multi-token: explicit phrase, or an implicit phrase (CJK / joined word).
-			g := group{terms: terms}
+			g := ftsClauseGroup{terms: terms}
 			if negated {
-				negGroups = append(negGroups, g)
+				cq.negGroups = append(cq.negGroups, g)
 			} else {
 				if required {
 					g.reqBit = e.allocReqBit()
 				}
-				posGroups = append(posGroups, g)
+				cq.posGroups = append(cq.posGroups, g)
 			}
 		}
 	}
+	cq.requiredAll = e.requiredAll
+	return cq
+}
+
+// run compiles and executes the clauses. Positive clauses (should/must) are
+// scored first — plain terms in first-seen order, so a pure-OR query keeps the
+// exact v1 summation order — then phrases and prefixes; negated clauses run last
+// (tombstones only affect docs already scored).
+func (e *ftsExec) run(clauses []query.TextClause, defaultAnd bool) error {
+	cq := e.compileClauses(clauses, defaultAnd)
 
 	// 1) Plain positive terms, in first-seen order (v1 parity).
-	for _, term := range plainOrder {
-		if err := e.scanTerm(term, plainBit[term], false); err != nil {
+	for _, term := range cq.plainOrder {
+		if err := e.scanTerm(term, cq.plainBit[term], false); err != nil {
 			return err
 		}
 	}
 	// 2) Positive phrases and prefixes.
-	for _, g := range posGroups {
+	for _, g := range cq.posGroups {
 		if err := e.scoreGroup(g.terms, g.stem, g.prefix, g.reqBit, false); err != nil {
 			return err
 		}
 	}
 	// 3) Negated clauses (tombstone only docs already present).
-	for _, g := range negGroups {
+	for _, g := range cq.negGroups {
 		if err := e.scoreGroup(g.terms, g.stem, g.prefix, 0, true); err != nil {
 			return err
 		}
@@ -965,6 +989,19 @@ func (q *collQuery) detectFtsQuery() (*qplanner.FtsQuerySpec, query.Filter, erro
 				return nil, ErrNoFulltextIndex
 			}
 			return fx.searchCandidates(tx, text)
+		},
+		Probe: func(tx *btree.ReadTx) (qplanner.FtsProber, error) {
+			// Same visibility gate as Search.
+			if !fx.visibleTo(tx) {
+				return nil, ErrNoFulltextIndex
+			}
+			return fx.newFtsProber(tx, text)
+		},
+		StatsFn: func(tx *btree.ReadTx) (qplanner.FtsPlanStats, error) {
+			if !fx.visibleTo(tx) {
+				return qplanner.FtsPlanStats{}, ErrNoFulltextIndex
+			}
+			return fx.planStats(tx, text)
 		},
 	}
 	residual := ftsResidualFilter(q.cond)

--- a/internal/qplanner/README.md
+++ b/internal/qplanner/README.md
@@ -14,6 +14,9 @@ Query → BuildPlan (CBO) → Iterator Chain → Results
 2. **Plan Selection**: Generate three candidate plans (FullScan, IndexSeek, IndexScan) and pick the one with the lowest cost.
 3. **Execution**: The root iterator is called repeatedly via `Next()` to produce `(key, docId)` pairs.
 
+`$text` and `$knn` queries go through their own cost-based selection
+(`text_plan.go`, `knn_plan.go`) — see **Full-text and vector plans** below.
+
 ---
 
 ### Cost Model
@@ -154,6 +157,35 @@ This reduces the final sort from O(N log N) to O(K log K) and keeps the entries 
 `DedupIter` is one of `CanonicalKeyDedupIter` (single-field) or `SeenSetDedupIter` (compound); see the Multi-Key Index Deduplication section above.
 
 ---
+
+### Full-text and vector plans
+
+A `$text` predicate has two enforcement forms, chosen by cost (`text_plan.go`):
+
+| form | chain | cost shape |
+|---|---|---|
+| driver | `FtsIter → Fetch → Filter → …` | `Σ df × CostFtsPosting` + consumed fetches |
+| probe | `IdBounds/IndexIter → FtsProbeIter → Fetch → ScoreInject → Filter → …` | candidates × `(CostFtsProbeDoc + terms × CostFtsProbeTerm)` |
+
+The driver walks the posting lists (cost is exact: per-term document
+frequencies are read from the index at plan time) and additionally gates
+candidates against the query's primary-key bounds before the fetch. The probe
+verifies each candidate of another access path against the text index
+individually. Both produce bit-identical matches and scores; when relevance
+order is observable, `FtsProbeIter` runs in rank mode and re-emits matches in
+the driver's `(score desc, IntDocID asc)` order. A `Count` whose residual is
+covered by the probe's driver fetches no documents.
+
+A `$knn` clause means "the K nearest among filter-passing documents". The ANN
+driver (`VectorIter`) approximates this by post-filtering ef candidates; the
+probe form (`knn_plan.go`, `VectorScoreIter`) enumerates the filter candidates
+from a bounded access path, scores each stored vector directly, and keeps the
+exact K nearest survivors — under a selective filter it is both cheaper and
+more accurate, and the cost model switches automatically.
+
+Index hints force plans in both selectors: the fts/vector index name boosts
+the driver, the primary-key field name the pk probe, a secondary index name
+its probe.
 
 ### IndexSketch
 

--- a/internal/qplanner/cost.go
+++ b/internal/qplanner/cost.go
@@ -20,6 +20,29 @@ const (
 	// full-scan sort path.
 	CostMaterialize = 1.0
 
+	// Full-text cost weights — calibrated against the 50k-doc fts_restrict
+	// benchmarks (≈0.9 µs per cost unit, anchored by CostDocFetch ≈ 2.7 µs
+	// for a 4 KB fetch+parse).
+	//
+	// CostFtsPosting prices one posting visited by the driver scan: chunk
+	// decode + BM25 + amortized rank sort (~340 ns measured).
+	CostFtsPosting = 0.4
+	// CostFtsProbeTerm prices one per-term postings-chunk point-get during a
+	// document probe; CostFtsProbeDoc is the per-document overhead (docmap +
+	// docinfo point-gets). A full probe of one doc for a q-term query costs
+	// CostFtsProbeDoc + q×CostFtsProbeTerm (~1–3 µs measured for one term).
+	CostFtsProbeTerm = 1.5
+	CostFtsProbeDoc  = 1.0
+
+	// Vector cost weights. Exact per-candidate scoring reads the vector
+	// zero-copy from the already-parsed document, so it costs a dim-scaled
+	// SIMD kernel on top of the fetch (256d ≈ 0.2 units). The ANN driver's
+	// per-ef-candidate cost covers graph/list traversal + rerank, amortized;
+	// backends override it via VectorQuerySpec.SearchCostPerCand.
+	CostVecScoreBase     = 0.1
+	CostVecScoreDim      = 0.0005
+	CostKnnSearchPerCand = 4.0
+
 	// Fallback Heuristics
 	DefaultRangeSelectivity = 0.5 // Default assumption: a range predicate matches ~50% of the collection
 

--- a/internal/qplanner/cost.go
+++ b/internal/qplanner/cost.go
@@ -42,6 +42,10 @@ const (
 	CostVecScoreBase     = 0.1
 	CostVecScoreDim      = 0.0005
 	CostKnnSearchPerCand = 4.0
+	// CostKnnBruteDoc is the brute-force backend's per-document overhead on
+	// top of the sequential read: the raw-path vector decode (~0.7 µs
+	// measured on 20k docs / dim 64).
+	CostKnnBruteDoc = 0.8
 
 	// Fallback Heuristics
 	DefaultRangeSelectivity = 0.5 // Default assumption: a range predicate matches ~50% of the collection

--- a/internal/qplanner/fts_iter.go
+++ b/internal/qplanner/fts_iter.go
@@ -3,6 +3,7 @@ package qplanner
 import (
 	"github.com/anyproto/any-store/v2/anyenc"
 	"github.com/anyproto/any-store/v2/internal/btree"
+	"github.com/anyproto/any-store/v2/query"
 	"github.com/anyproto/any-store/v2/syncpool"
 )
 
@@ -37,11 +38,21 @@ type FtsCandidateStream interface {
 // VectorSearchFunc). A nil stream means no matches.
 type FtsSearchFunc func(tx *btree.ReadTx) (FtsCandidateStream, error)
 
-// FtsQuerySpec directs BuildPlan to build a full-text-search plan. When present
-// it is the SOLE source — all range-index/CBO selection is bypassed (a $text
-// predicate must drive the query).
+// FtsQuerySpec directs BuildPlan to build a full-text-search plan: the $text
+// predicate is enforced either by an FtsIter source (driver form) or by an
+// FtsProbeIter over another access path (probe form); buildTextPlan picks the
+// cheaper by cost.
 type FtsQuerySpec struct {
 	Search FtsSearchFunc
+	// Probe opens the per-document verifier for the probe form; nil means only
+	// the driver plan is legal.
+	Probe FtsProbeFunc
+	// StatsFn fills Stats on the plan's read tx (called once by the query
+	// compiler); a failure leaves Stats zero (Valid == false) and the plan
+	// degrades to driver-only rather than erroring.
+	StatsFn FtsStatsFunc
+	// Stats feed the driver/probe cost comparison (see FtsPlanStats.Valid).
+	Stats FtsPlanStats
 	// IndexName is the driving full-text index, reported by Explain.
 	IndexName string
 	// Ordered is true when Search streams candidates already sorted by score
@@ -67,9 +78,17 @@ type FtsIter struct {
 	Buf  *syncpool.DocBuffer
 	Plan *Plan
 
-	arena  anyenc.Arena
-	stream FtsCandidateStream
-	inited bool
+	// IDBounds, when set, gate each candidate's docId against the query's
+	// primary-key bounds BEFORE the document fetch: a candidate outside the
+	// bounds costs a byte comparison instead of a page read (+ parse). The
+	// bounds over-approximate the pk predicate by contract and the residual
+	// FilterIter still decides every row, so the gate only removes work.
+	IDBounds query.Bounds
+
+	arena    anyenc.Arena
+	stream   FtsCandidateStream
+	inited   bool
+	idSorted bool
 }
 
 func (it *FtsIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
@@ -82,6 +101,10 @@ func (it *FtsIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
 		if it.stream != nil && it.Plan != nil && it.Plan.Scores == nil && it.Spec.NeedScores {
 			it.Plan.Scores = &FloatSidecar{}
 		}
+		// One canonical-form check enables the binary-search gate; a
+		// non-canonical set (never produced by IndexBounds, but the contract
+		// is the caller's) falls back to the linear Contains.
+		it.idSorted = it.IDBounds.SortedDisjoint()
 	}
 	if it.stream == nil {
 		return nil, nil, false, nil
@@ -94,6 +117,17 @@ func (it *FtsIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
 		}
 		if !ok {
 			return nil, nil, false, nil
+		}
+
+		// Primary-key gate: reject out-of-bounds candidates before the fetch.
+		if len(it.IDBounds) > 0 {
+			if it.idSorted {
+				if !it.IDBounds.ContainsSorted(cDocId) {
+					continue
+				}
+			} else if !it.IDBounds.Contains(cDocId) {
+				continue
+			}
 		}
 
 		it.Buf.DocBuf, err = it.Data.AppendValue(cDocId, it.Buf.DocBuf[:0])

--- a/internal/qplanner/fts_probe_iter.go
+++ b/internal/qplanner/fts_probe_iter.go
@@ -75,14 +75,76 @@ type FtsProbeIter struct {
 	Tx     *btree.ReadTx
 	Plan   *Plan
 	Rank   bool
+	// TopK, when > 0, bounds the rank-mode materialization to the best K
+	// matches under the driver order (K = Limit + Offset, like SortIter's
+	// bounded heap); 0 keeps every match (no limit, or offset-only).
+	TopK int
 
 	prober FtsProber
 	inited bool
 
 	// rank state: docId bytes live in arena, entries reference spans.
-	entries []probeEntry
-	arena   []byte
-	idx     int
+	entries   []probeEntry
+	arena     []byte
+	keptBytes int
+	idx       int
+}
+
+// rankBetter is the driver's candidate order: score desc, IntDocID asc.
+func rankBetter(aScore float64, aInt uint64, bScore float64, bInt uint64) bool {
+	if aScore != bScore {
+		return aScore > bScore
+	}
+	return aInt < bInt
+}
+
+// worse reports that entries[i] is strictly worse than entries[j] under the
+// driver order. The bounded heap keeps its WORST entry at the root, so a new
+// candidate only needs one comparison against the root to be accepted.
+func (it *FtsProbeIter) worse(i, j int) bool {
+	return rankBetter(it.entries[j].score, it.entries[j].intId, it.entries[i].score, it.entries[i].intId)
+}
+
+func (it *FtsProbeIter) siftUp(i int) {
+	for i > 0 {
+		parent := (i - 1) / 2
+		if !it.worse(i, parent) {
+			return
+		}
+		it.entries[parent], it.entries[i] = it.entries[i], it.entries[parent]
+		i = parent
+	}
+}
+
+func (it *FtsProbeIter) siftDown(i int) {
+	n := len(it.entries)
+	for {
+		l, r := 2*i+1, 2*i+2
+		worst := i
+		if l < n && it.worse(l, worst) {
+			worst = l
+		}
+		if r < n && it.worse(r, worst) {
+			worst = r
+		}
+		if worst == i {
+			return
+		}
+		it.entries[i], it.entries[worst] = it.entries[worst], it.entries[i]
+		i = worst
+	}
+}
+
+// compact rewrites arena to hold only the kept entries' id bytes.
+func (it *FtsProbeIter) compact() {
+	fresh := make([]byte, 0, it.keptBytes)
+	for i := range it.entries {
+		e := &it.entries[i]
+		off := uint32(len(fresh))
+		fresh = append(fresh, it.arena[e.off:e.off+e.ln]...)
+		e.off = off
+	}
+	it.arena = fresh
 }
 
 type probeEntry struct {
@@ -110,6 +172,8 @@ func (it *FtsProbeIter) init() error {
 		return nil
 	}
 	// Rank mode: drain, probe distinct candidates, order like the driver.
+	// With a TopK bound only the best K matches are materialized (bounded
+	// worst-at-root heap, exactly like SortIter's TopK).
 	var dedup DocDedup
 	for {
 		_, docId, mk, serr := it.Source.Next()
@@ -129,9 +193,31 @@ func (it *FtsProbeIter) init() error {
 		if !ok {
 			continue
 		}
+		if it.TopK > 0 && len(it.entries) == it.TopK {
+			root := &it.entries[0]
+			if !rankBetter(score, intId, root.score, root.intId) {
+				continue
+			}
+			// Evictions strand the incumbent's id bytes; compact when the
+			// waste dominates.
+			if len(it.arena) > 1<<16 && len(it.arena) > 4*it.keptBytes {
+				it.compact()
+				root = &it.entries[0]
+			}
+			it.keptBytes += len(docId) - int(root.ln)
+			off := uint32(len(it.arena))
+			it.arena = append(it.arena, docId...)
+			it.entries[0] = probeEntry{off: off, ln: uint32(len(docId)), intId: intId, score: score}
+			it.siftDown(0)
+			continue
+		}
 		off := uint32(len(it.arena))
 		it.arena = append(it.arena, docId...)
+		it.keptBytes += len(docId)
 		it.entries = append(it.entries, probeEntry{off: off, ln: uint32(len(docId)), intId: intId, score: score})
+		if it.TopK > 0 {
+			it.siftUp(len(it.entries) - 1)
+		}
 	}
 	slices.SortFunc(it.entries, func(a, b probeEntry) int {
 		if a.score > b.score {

--- a/internal/qplanner/fts_probe_iter.go
+++ b/internal/qplanner/fts_probe_iter.go
@@ -1,0 +1,262 @@
+package qplanner
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/internal/btree"
+	"github.com/anyproto/any-store/v2/query"
+)
+
+// fts_probe_iter.go holds the probe form of a $text query: instead of the
+// posting lists driving the query (FtsIter), another access path — a
+// primary-key restriction or a secondary index — enumerates candidate docIds
+// and each candidate is verified against the text index individually. The
+// per-candidate cost is a few point-gets instead of a page fetch, and the
+// posting lists are never walked. Plan selection between the two forms is the
+// CBO's cost comparison in buildTextPlan.
+
+// FtsProber verifies the $text predicate for single documents. Implemented by
+// the anystore layer (it owns the fts namespaces); the contract mirrors
+// FtsSearchFunc. Probe must return the same verdict and a bit-identical score
+// to what the driver scan would produce for the same document on the same
+// snapshot — intId is the document's stable IntDocID, the driver's tie-break
+// key for equal scores.
+type FtsProber interface {
+	Probe(docId []byte) (score float64, intId uint64, ok bool, err error)
+	Close()
+}
+
+// FtsProbeFunc opens a prober on the given read tx. A nil FtsProbeFunc on the
+// spec means the probe form is unavailable and only the driver plan is legal.
+type FtsProbeFunc func(tx *btree.ReadTx) (FtsProber, error)
+
+// FtsStatsFunc computes the predicate's plan-time stats on the plan's read tx.
+type FtsStatsFunc func(tx *btree.ReadTx) (FtsPlanStats, error)
+
+// FtsPlanStats are the plan-time cost inputs of the $text predicate, filled by
+// the anystore layer from the index's exact per-term document frequencies.
+type FtsPlanStats struct {
+	// SumDF is the posting count the driver scan must accumulate.
+	SumDF float64
+	// ProbeTerms is the number of postings-chunk point-gets one probe costs.
+	ProbeTerms float64
+	// EstMatches estimates how many documents match the predicate.
+	EstMatches float64
+	// CorpusDocs is the fts corpus document count (meta N) — the TotalDocs
+	// fallback when no secondary-index sketch published one.
+	CorpusDocs float64
+	// Valid gates cost-based probe selection; false (unit tests, stats read
+	// failure) keeps the driver-only behavior.
+	Valid bool
+}
+
+// FtsProbeIter filters an upstream candidate stream through the $text
+// predicate.
+//
+// Two modes:
+//   - streaming (Rank == false): each upstream row is probed as it is pulled;
+//     misses are dropped, hits pass through unchanged (key and multiKey
+//     preserved, so downstream dedup stages keep working). Upstream order is
+//     preserved — used when a real-field sort (or no ordering need) makes the
+//     relevance order irrelevant.
+//   - rank (Rank == true): the upstream is drained (deduped by docId), every
+//     distinct candidate probed, and the matches re-emitted in the driver's
+//     exact order — (score desc, IntDocID asc) — so a relevance-ordered probe
+//     plan is row- and order-identical to the FtsIter plan.
+//
+// Matched scores are recorded in Plan.Scores keyed by docId; the sidecar is
+// created unconditionally for probe plans because the downstream
+// ScoreInjectIter reads it to decorate fetched documents with _score.
+type FtsProbeIter struct {
+	Spec   *FtsQuerySpec
+	Source Iterator
+	Tx     *btree.ReadTx
+	Plan   *Plan
+	Rank   bool
+
+	prober FtsProber
+	inited bool
+
+	// rank state: docId bytes live in arena, entries reference spans.
+	entries []probeEntry
+	arena   []byte
+	idx     int
+}
+
+type probeEntry struct {
+	off   uint32
+	ln    uint32
+	intId uint64
+	score float64
+}
+
+func (it *FtsProbeIter) init() error {
+	it.inited = true
+	prober, err := it.Spec.Probe(it.Tx)
+	if err != nil {
+		return err
+	}
+	it.prober = prober
+	if it.Plan != nil && it.Plan.Scores == nil {
+		it.Plan.Scores = &FloatSidecar{}
+	}
+	if !it.Rank {
+		return nil
+	}
+	// Rank mode: drain, probe distinct candidates, order like the driver.
+	var dedup DocDedup
+	for {
+		_, docId, mk, serr := it.Source.Next()
+		if serr != nil {
+			return serr
+		}
+		if docId == nil {
+			break
+		}
+		if !dedup.Accept(docId, mk) {
+			continue
+		}
+		score, intId, ok, perr := it.prober.Probe(docId)
+		if perr != nil {
+			return perr
+		}
+		if !ok {
+			continue
+		}
+		off := uint32(len(it.arena))
+		it.arena = append(it.arena, docId...)
+		it.entries = append(it.entries, probeEntry{off: off, ln: uint32(len(docId)), intId: intId, score: score})
+	}
+	slices.SortFunc(it.entries, func(a, b probeEntry) int {
+		if a.score > b.score {
+			return -1
+		}
+		if a.score < b.score {
+			return 1
+		}
+		if a.intId < b.intId {
+			return -1
+		}
+		if a.intId > b.intId {
+			return 1
+		}
+		return 0
+	})
+	return nil
+}
+
+func (it *FtsProbeIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
+	if !it.inited {
+		if err = it.init(); err != nil {
+			return nil, nil, false, err
+		}
+	}
+	if it.Rank {
+		if it.idx >= len(it.entries) {
+			return nil, nil, false, nil
+		}
+		e := it.entries[it.idx]
+		it.idx++
+		id := it.arena[e.off : e.off+e.ln]
+		if it.Plan != nil {
+			it.Plan.Scores.Set(id, e.score)
+		}
+		return id, id, false, nil
+	}
+	for {
+		key, docId, multiKey, err = it.Source.Next()
+		if err != nil || docId == nil {
+			return nil, nil, false, err
+		}
+		score, _, ok, perr := it.prober.Probe(docId)
+		if perr != nil {
+			return nil, nil, false, perr
+		}
+		if !ok {
+			continue
+		}
+		if it.Plan != nil {
+			it.Plan.Scores.Set(docId, score)
+		}
+		return key, docId, multiKey, nil
+	}
+}
+
+func (it *FtsProbeIter) Close() {
+	if it.prober != nil {
+		it.prober.Close()
+		it.prober = nil
+	}
+	if it.Source != nil {
+		it.Source.Close()
+	}
+}
+
+func (it *FtsProbeIter) String() string {
+	if it.Rank {
+		return fmt.Sprintf("%s -> FtsProbe(rank)", it.Source)
+	}
+	return fmt.Sprintf("%s -> FtsProbe", it.Source)
+}
+
+// ScoreInjectIter decorates fetched documents with the _score virtual field
+// from Plan.Scores, so the residual filter and Doc() see the same document
+// shape a driver (FtsIter) plan produces. Sits between FetchIter and
+// FilterIter in probe plans.
+type ScoreInjectIter struct {
+	Source Iterator
+	Plan   *Plan
+
+	arena anyenc.Arena
+}
+
+func (it *ScoreInjectIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
+	key, docId, multiKey, err = it.Source.Next()
+	if err != nil || docId == nil {
+		return nil, nil, false, err
+	}
+	if it.Plan != nil && it.Plan.DocParsed != nil && it.Plan.Scores != nil {
+		if s, ok := it.Plan.Scores.Get(docId); ok {
+			injectScore(&it.arena, it.Plan.DocParsed, s)
+		}
+	}
+	return key, docId, multiKey, nil
+}
+
+func (it *ScoreInjectIter) Close() {
+	if it.Source != nil {
+		it.Source.Close()
+	}
+}
+
+func (it *ScoreInjectIter) String() string {
+	return fmt.Sprintf("%s -> ScoreInject", it.Source)
+}
+
+// IdBoundsIter is the leaf of a primary-key probe plan: it emits the fixed
+// primary-key bounds as candidate docIds, in bound order, without touching any
+// namespace. The bounds over-approximate the pk predicate (SortAndMerge'd
+// point set), and non-existent ids cost the downstream probe a single failed
+// docmap point-get — the residual FilterIter still decides every row.
+// Requires AllBoundsFixed(Bounds).
+type IdBoundsIter struct {
+	Bounds query.Bounds
+	i      int
+}
+
+func (it *IdBoundsIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
+	if it.i >= len(it.Bounds) {
+		return nil, nil, false, nil
+	}
+	id := it.Bounds[it.i].Start
+	it.i++
+	return id, id, false, nil
+}
+
+func (it *IdBoundsIter) Close() {}
+
+func (it *IdBoundsIter) String() string {
+	return fmt.Sprintf("IdBounds(%d)", len(it.Bounds))
+}

--- a/internal/qplanner/fts_probe_iter.go
+++ b/internal/qplanner/fts_probe_iter.go
@@ -99,7 +99,11 @@ func (it *FtsProbeIter) init() error {
 		return err
 	}
 	it.prober = prober
-	if it.Plan != nil && it.Plan.Scores == nil {
+	// The sidecar is allocated only when scores are consumed — the public
+	// iterator's Score(), or a residual referencing _score (the query layer
+	// forces NeedScores on for that). Count/unbounded writes skip it, like
+	// the driver plan does; it would otherwise grow O(matched docs).
+	if it.Plan != nil && it.Plan.Scores == nil && it.Spec.NeedScores {
 		it.Plan.Scores = &FloatSidecar{}
 	}
 	if !it.Rank {
@@ -160,7 +164,7 @@ func (it *FtsProbeIter) Next() (key []byte, docId []byte, multiKey bool, err err
 		e := it.entries[it.idx]
 		it.idx++
 		id := it.arena[e.off : e.off+e.ln]
-		if it.Plan != nil {
+		if it.Plan != nil && it.Plan.Scores != nil {
 			it.Plan.Scores.Set(id, e.score)
 		}
 		return id, id, false, nil
@@ -177,7 +181,7 @@ func (it *FtsProbeIter) Next() (key []byte, docId []byte, multiKey bool, err err
 		if !ok {
 			continue
 		}
-		if it.Plan != nil {
+		if it.Plan != nil && it.Plan.Scores != nil {
 			it.Plan.Scores.Set(docId, score)
 		}
 		return key, docId, multiKey, nil

--- a/internal/qplanner/knn_plan.go
+++ b/internal/qplanner/knn_plan.go
@@ -73,18 +73,26 @@ func buildKnnPlan(params *PlanParams) *Plan {
 		if ef < 1 {
 			ef = 1
 		}
-		var searchCost float64
+		var searchCost, stream float64
 		if spec.BruteDriver {
-			searchCost = totalDocs * (CostSeqRead + scoreCost)
+			// Brute-force scans and scores the whole collection; with a
+			// residual it returns every doc ranked (topK=0) and the k-cut
+			// consumes candidates until K survivors, without one exactly K.
+			searchCost = totalDocs * (CostSeqRead + CostKnnBruteDoc + scoreCost)
+			stream = totalDocs
+			if !needFilter {
+				stream = float64(spec.K)
+			}
 		} else {
 			perCand := spec.SearchCostPerCand
 			if perCand <= 0 {
 				perCand = CostKnnSearchPerCand
 			}
 			searchCost = ef * perCand
+			stream = ef
 		}
 		// The k-cut stops consumption after K residual survivors.
-		consumed := ef
+		consumed := stream
 		if needFilter {
 			if need := float64(spec.K) / max(pResidual, 0.0001); need < consumed {
 				consumed = need
@@ -94,7 +102,7 @@ func buildKnnPlan(params *PlanParams) *Plan {
 		}
 		cands = append(cands, knnCandidate{
 			name: "KnnSearch", cost: searchCost + consumed*(CostDocFetch+CostFilter),
-			est: min(ef, float64(spec.K)), kind: knnPlanDriver,
+			est: min(consumed, float64(spec.K)), kind: knnPlanDriver,
 		})
 	}
 
@@ -212,8 +220,11 @@ func buildKnnProbePlan(params *PlanParams, cand *knnCandidate) *Plan {
 		if len(idx.Bounds) > 0 {
 			idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
 		}
-		finalizeIndexBounds(idx)
 		if idx.Info.Unique && idx.fullKeyPointBound() {
+			// CoverIter takes the UN-finalized bounds — it seeks the raw
+			// prefix itself; the reverse-tail pad would double-pad and
+			// MergeOverlappingBounds would collapse distinct point probes
+			// (see buildIndexSeekChain).
 			root = &CoverIter{
 				Source:  &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
 				IdxInfo: idx.Info,
@@ -223,6 +234,7 @@ func buildKnnProbePlan(params *PlanParams, cand *knnCandidate) *Plan {
 				root = &DocDedupIter{Source: root}
 			}
 		} else {
+			finalizeIndexBounds(idx)
 			root = &IndexIter{
 				Source:       &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
 				IdxInfo:      idx.Info,

--- a/internal/qplanner/knn_plan.go
+++ b/internal/qplanner/knn_plan.go
@@ -1,0 +1,450 @@
+package qplanner
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/query"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// knn_plan.go is the cost-based plan selection for $knn queries.
+//
+// The clause's semantics are "the K nearest documents among those passing the
+// residual filter". Two enforcement forms exist:
+//
+//   - DRIVER (approximate): the ANN index returns ef candidates in distance
+//     order, the residual filters them, and the k-cut keeps the first K
+//     survivors. Recall degrades as the residual gets more selective — the ef
+//     candidates may contain few (or none) of the true filtered neighbours.
+//   - PROBE (exact): a bounded access path (fixed pk bounds, a bounded
+//     secondary index) enumerates the filter candidates, each one's stored
+//     vector is scored directly (same kernel and vector source as the
+//     brute-force backend), and the true K nearest survivors are kept.
+//
+// The probe form is exact — under a selective filter it is both faster AND
+// more correct than post-filtering an ANN result, so the cost model prefers
+// it whenever the candidate count is small. The k-cut, user sort, and
+// pagination stack identically on both forms ("k selects, Sort orders, Limit
+// paginates").
+
+type knnCandidate struct {
+	name string
+	cost float64
+	est  float64
+	idx  *CBOIndex // nil for driver and pk-ids plans
+	kind knnPlanKind
+}
+
+type knnPlanKind int
+
+const (
+	knnPlanDriver knnPlanKind = iota
+	knnPlanProbeIds
+	knnPlanProbeSeek
+)
+
+// buildKnnPlan enumerates the legal $knn plans, costs them, and builds the
+// cheapest. Without a probe form (no DistFromDoc) or without any bounded
+// access path it degenerates to the ANN driver plan.
+func buildKnnPlan(params *PlanParams) *Plan {
+	spec := params.Vector
+	totalDocs := float64(params.TotalDocs)
+	if totalDocs < 1 {
+		totalDocs = 1
+	}
+	needFilter := params.Filter != nil && !isAllFilter(params.Filter)
+
+	pResidual := calculateSelectivity(params.Filter, params.Indexes, totalDocs, params.FieldBounds)
+	idFixed := len(params.IDBounds) > 0 && AllBoundsFixed(params.IDBounds)
+
+	// Per-candidate exact scoring: vector extraction is zero-copy from the
+	// already-parsed doc, so the kernel cost scales with the dimension.
+	scoreCost := CostVecScoreBase + float64(len(spec.Query))*CostVecScoreDim
+
+	var cands []knnCandidate
+
+	// ---- ANN driver (always legal) -------------------------------------
+	{
+		ef := float64(spec.Ef)
+		if ef < 1 {
+			ef = 1
+		}
+		var searchCost float64
+		if spec.BruteDriver {
+			searchCost = totalDocs * (CostSeqRead + scoreCost)
+		} else {
+			perCand := spec.SearchCostPerCand
+			if perCand <= 0 {
+				perCand = CostKnnSearchPerCand
+			}
+			searchCost = ef * perCand
+		}
+		// The k-cut stops consumption after K residual survivors.
+		consumed := ef
+		if needFilter {
+			if need := float64(spec.K) / max(pResidual, 0.0001); need < consumed {
+				consumed = need
+			}
+		} else if float64(spec.K) < consumed {
+			consumed = float64(spec.K)
+		}
+		cands = append(cands, knnCandidate{
+			name: "KnnSearch", cost: searchCost + consumed*(CostDocFetch+CostFilter),
+			est: min(ef, float64(spec.K)), kind: knnPlanDriver,
+		})
+	}
+
+	if spec.DistFromDoc != nil {
+		finish := func(e float64) float64 {
+			kept := min(e, float64(spec.K))
+			return e*(CostDocFetch+CostFilter+scoreCost) + sortCost(kept)
+		}
+		if idFixed {
+			e := float64(len(params.IDBounds))
+			cands = append(cands, knnCandidate{
+				name: "KnnProbeIds", cost: finish(e), est: min(e, float64(spec.K)),
+				kind: knnPlanProbeIds,
+			})
+		}
+		var fieldSelBuf [8]fieldSelEntry
+		fieldSel := collectFieldSelectivity(params, totalDocs, fieldSelBuf[:0])
+		for i := range params.Indexes {
+			idx := &params.Indexes[i]
+			if len(idx.Bounds) == 0 {
+				continue
+			}
+			if !sparseIndexComplete(idx, params.Filter) {
+				continue
+			}
+			e := estimateIndexDocsWithFieldSel(idx, totalDocs, fieldSel)
+			if e < 1 {
+				e = 1
+			}
+			nSeeks := float64(len(idx.Bounds))
+			if nSeeks < 1 {
+				nSeeks = 1
+			}
+			cands = append(cands, knnCandidate{
+				name: "KnnProbeSeek(" + idx.Info.Name + ")", idx: idx,
+				cost: nSeeks*CostIndexSeek + e*CostSeqRead + finish(e),
+				est:  min(e, float64(spec.K)), kind: knnPlanProbeSeek,
+			})
+		}
+	}
+
+	// Hint boosts: the vector index name boosts the driver, the pk field the
+	// pk probe, a secondary index name its probe.
+	if len(params.IndexHints) > 0 {
+		pk := params.PrimaryKey
+		if pk == "" {
+			pk = "id"
+		}
+		for ci := range cands {
+			c := &cands[ci]
+			hintName := spec.IndexName
+			switch {
+			case c.idx != nil:
+				hintName = c.idx.Info.Name
+			case c.kind == knnPlanProbeIds:
+				hintName = pk
+			}
+			for _, h := range params.IndexHints {
+				if h.IndexName == hintName {
+					c.cost -= float64(h.Boost)
+				}
+			}
+		}
+	}
+
+	best := &cands[0]
+	for ci := 1; ci < len(cands); ci++ {
+		if cands[ci].cost < best.cost {
+			best = &cands[ci]
+		}
+	}
+
+	var plan *Plan
+	if best.kind == knnPlanDriver {
+		plan = buildVectorPlan(params)
+	} else {
+		plan = buildKnnProbePlan(params, best)
+	}
+	plan.Cost = best.cost
+	if !params.CountOnly {
+		explainCands := make([]CandidatePlan, 0, len(cands))
+		for ci := range cands {
+			c := cands[ci]
+			explainCands = append(explainCands, CandidatePlan{Name: c.name, Cost: c.cost, EstRows: c.est})
+		}
+		slices.SortFunc(explainCands, func(a, b CandidatePlan) int {
+			return cmp.Compare(a.Cost, b.Cost)
+		})
+		plan.Explain = ExplainInfo{
+			TotalDocs:   int(totalDocs),
+			Selectivity: pResidual,
+			Candidates:  explainCands,
+			ChosenIndex: plan.IndexName,
+		}
+	}
+	return plan
+}
+
+// buildKnnProbePlan assembles the exact pre-filter chain:
+//
+//	driver -> [dedup] -> Fetch -> VectorScore(residual, k-cut) -> [Sort] -> [Limit]
+//
+// VectorScoreIter owns the residual (it must run over _distance-decorated
+// documents, exactly like the driver plan's FilterIter) and the k-cut.
+func buildKnnProbePlan(params *PlanParams, cand *knnCandidate) *Plan {
+	dataCS := &CursorSource{Tx: params.Tx, Ns: params.DataNs}
+	indexName := params.Vector.IndexName
+
+	var root Iterator
+	if cand.kind == knnPlanProbeIds {
+		root = &IdBoundsIter{Bounds: params.IDBounds}
+	} else {
+		idx := cand.idx
+		indexName = idx.Info.Name
+		if len(idx.Bounds) > 0 {
+			idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
+		}
+		finalizeIndexBounds(idx)
+		if idx.Info.Unique && idx.fullKeyPointBound() {
+			root = &CoverIter{
+				Source:  &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
+				IdxInfo: idx.Info,
+				Bounds:  idx.Bounds,
+			}
+			if len(idx.Bounds) > 1 {
+				root = &DocDedupIter{Source: root}
+			}
+		} else {
+			root = &IndexIter{
+				Source:       &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
+				IdxInfo:      idx.Info,
+				Bounds:       idx.Bounds,
+				PointLookup:  idx.PointLookup,
+				FullKeyBound: idx.fullKeyPointBound(),
+				ScalarProven: idx.ScalarProven,
+			}
+			if !idx.ScalarProven {
+				root = &DocDedupIter{Source: root}
+			}
+		}
+	}
+
+	root = &FetchIter{Source: root, Data: dataCS, Buf: params.Buf}
+	root = &VectorScoreIter{
+		Spec:   params.Vector,
+		Source: root,
+		Data:   dataCS,
+		Buf:    params.Buf,
+		Filter: params.Filter,
+	}
+	if params.Sorter != nil {
+		root = &SortIter{
+			Source: root,
+			Data:   dataCS,
+			Sorter: params.Sorter,
+			Buf:    params.Buf,
+			TopK:   sortTopK(params),
+		}
+	}
+	if params.Limit > 0 || params.Offset > 0 {
+		root = &LimitIter{Source: root, Limit: params.Limit, Offset: params.Offset}
+	}
+
+	plan := &Plan{Root: root, Name: cand.name, IndexName: indexName}
+	setPlanRef(root, plan)
+	return plan
+}
+
+// VectorScoreIter is the exact form of the $knn source: it drains an upstream
+// document stream (FetchIter beneath — Plan.DocParsed is the current doc),
+// scores each distinct document's stored vector against the query, evaluates
+// the residual filter over the _distance-decorated document, and keeps the K
+// nearest survivors — the clause's exact semantics. Emission is in the same
+// total (distance asc, docId asc) order the ANN backends guarantee, and each
+// emitted row's document is re-fetched and re-decorated so downstream stages
+// (a user SortIter reading _distance, Doc()) see the driver plan's shape.
+type VectorScoreIter struct {
+	Spec   *VectorQuerySpec
+	Source Iterator
+	Data   *CursorSource
+	Buf    *syncpool.DocBuffer
+	Filter query.Filter
+	Plan   *Plan
+
+	inited bool
+	kept   []scoredVecCand
+	arena  []byte
+	idx    int
+
+	injArena anyenc.Arena
+}
+
+type scoredVecCand struct {
+	off  uint32
+	ln   uint32
+	dist float32
+}
+
+func (it *VectorScoreIter) less(a, b scoredVecCand) bool {
+	if a.dist != b.dist {
+		return a.dist < b.dist
+	}
+	return bytes.Compare(it.arena[a.off:a.off+a.ln], it.arena[b.off:b.off+b.ln]) < 0
+}
+
+func (it *VectorScoreIter) init() error {
+	it.inited = true
+	if it.Spec.CheckTx != nil {
+		if err := it.Spec.CheckTx(it.Data.Tx); err != nil {
+			return err
+		}
+	}
+	k := it.Spec.K
+	var dedup DocDedup
+	for {
+		_, docId, mk, err := it.Source.Next()
+		if err != nil {
+			return err
+		}
+		if docId == nil {
+			break
+		}
+		if !dedup.Accept(docId, mk) {
+			continue
+		}
+		doc := docOf(it.Plan)
+		if doc == nil {
+			continue // defensive: the chain always has a FetchIter beneath
+		}
+		dist, ok := it.Spec.DistFromDoc(doc)
+		if !ok {
+			continue // no valid vector at the field — never an ANN candidate
+		}
+		// The residual runs over the decorated document, mirroring the driver
+		// chain's FilterIter position (before the k-cut).
+		injectDistance(&it.injArena, doc, dist)
+		if it.Filter != nil && !it.Filter.Ok(doc, it.Buf) {
+			continue
+		}
+		nc := scoredVecCand{off: uint32(len(it.arena)), ln: uint32(len(docId)), dist: dist}
+		if k > 0 && len(it.kept) == k {
+			// Max-heap replacement: on a tie the incumbent wins only when its
+			// docId is smaller — the total order decides, not arrival.
+			it.arena = append(it.arena, docId...)
+			if it.less(nc, it.kept[0]) {
+				it.kept[0] = nc
+				it.siftDown(0)
+			} else {
+				it.arena = it.arena[:nc.off] // rejected: reclaim the id bytes
+			}
+			continue
+		}
+		it.arena = append(it.arena, docId...)
+		it.kept = append(it.kept, nc)
+		if k > 0 {
+			it.siftUp(len(it.kept) - 1)
+		}
+	}
+	slices.SortFunc(it.kept, func(a, b scoredVecCand) int {
+		if it.less(a, b) {
+			return -1
+		}
+		if it.less(b, a) {
+			return 1
+		}
+		return 0
+	})
+	return nil
+}
+
+// siftUp/siftDown maintain a max-heap under less (root = worst kept).
+func (it *VectorScoreIter) siftUp(i int) {
+	for i > 0 {
+		parent := (i - 1) / 2
+		if !it.less(it.kept[parent], it.kept[i]) {
+			return
+		}
+		it.kept[parent], it.kept[i] = it.kept[i], it.kept[parent]
+		i = parent
+	}
+}
+
+func (it *VectorScoreIter) siftDown(i int) {
+	n := len(it.kept)
+	for {
+		l, r := 2*i+1, 2*i+2
+		worst := i
+		if l < n && it.less(it.kept[worst], it.kept[l]) {
+			worst = l
+		}
+		if r < n && it.less(it.kept[worst], it.kept[r]) {
+			worst = r
+		}
+		if worst == i {
+			return
+		}
+		it.kept[i], it.kept[worst] = it.kept[worst], it.kept[i]
+		i = worst
+	}
+}
+
+func docOf(plan *Plan) *anyenc.Value {
+	if plan == nil {
+		return nil
+	}
+	return plan.DocParsed
+}
+
+func (it *VectorScoreIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
+	if !it.inited {
+		if err = it.init(); err != nil {
+			return nil, nil, false, err
+		}
+	}
+	for it.idx < len(it.kept) {
+		c := it.kept[it.idx]
+		it.idx++
+		id := it.arena[c.off : c.off+c.ln]
+
+		// Re-fetch + re-decorate: downstream stages must see the same
+		// document shape the driver plan streams past its k-cut.
+		it.Buf.DocBuf, err = it.Data.AppendValue(id, it.Buf.DocBuf[:0])
+		if err != nil {
+			return nil, nil, false, err
+		}
+		doc, perr := it.Buf.Parser.ParseOwned(it.Buf.DocBuf)
+		if perr != nil {
+			return nil, nil, false, perr
+		}
+		if it.Plan != nil {
+			if it.Spec.NeedDistances {
+				if it.Plan.Distances == nil {
+					it.Plan.Distances = &FloatSidecar{}
+				}
+				it.Plan.Distances.Set(id, float64(c.dist))
+			}
+			injectDistance(&it.injArena, doc, c.dist)
+			it.Plan.DocParsed = doc
+		}
+		return id, id, false, nil
+	}
+	return nil, nil, false, nil
+}
+
+func (it *VectorScoreIter) Close() {
+	if it.Source != nil {
+		it.Source.Close()
+	}
+}
+
+func (it *VectorScoreIter) String() string {
+	return fmt.Sprintf("%s -> VectorScore(k=%d)", it.Source, it.Spec.K)
+}

--- a/internal/qplanner/knn_plan.go
+++ b/internal/qplanner/knn_plan.go
@@ -294,9 +294,24 @@ type VectorScoreIter struct {
 	inited bool
 	kept   []scoredVecCand
 	arena  []byte
-	idx    int
+	// keptBytes tracks the live id bytes in arena; evictions strand their
+	// incumbent's bytes until compact reclaims them.
+	keptBytes int
+	idx       int
 
 	injArena anyenc.Arena
+}
+
+// compact rewrites arena to hold only the kept entries' id bytes.
+func (it *VectorScoreIter) compact() {
+	fresh := make([]byte, 0, it.keptBytes)
+	for i := range it.kept {
+		e := &it.kept[i]
+		off := uint32(len(fresh))
+		fresh = append(fresh, it.arena[e.off:e.off+e.ln]...)
+		e.off = off
+	}
+	it.arena = fresh
 }
 
 type scoredVecCand struct {
@@ -346,20 +361,32 @@ func (it *VectorScoreIter) init() error {
 		if it.Filter != nil && !it.Filter.Ok(doc, it.Buf) {
 			continue
 		}
-		nc := scoredVecCand{off: uint32(len(it.arena)), ln: uint32(len(docId)), dist: dist}
 		if k > 0 && len(it.kept) == k {
-			// Max-heap replacement: on a tie the incumbent wins only when its
-			// docId is smaller — the total order decides, not arrival.
-			it.arena = append(it.arena, docId...)
-			if it.less(nc, it.kept[0]) {
-				it.kept[0] = nc
-				it.siftDown(0)
-			} else {
-				it.arena = it.arena[:nc.off] // rejected: reclaim the id bytes
+			// Compared against the worst kept BEFORE any arena append: on a
+			// tie the incumbent wins only when its docId is smaller — the
+			// total order decides, not arrival.
+			root := &it.kept[0]
+			if dist > root.dist ||
+				(dist == root.dist && bytes.Compare(docId, it.arena[root.off:root.off+root.ln]) >= 0) {
+				continue
 			}
+			// An eviction strands the incumbent's id bytes; compact when the
+			// waste dominates (an enumeration order correlated with distance
+			// would otherwise grow the arena with every candidate).
+			if len(it.arena) > 1<<16 && len(it.arena) > 4*it.keptBytes {
+				it.compact()
+				root = &it.kept[0]
+			}
+			it.keptBytes += len(docId) - int(root.ln)
+			nc := scoredVecCand{off: uint32(len(it.arena)), ln: uint32(len(docId)), dist: dist}
+			it.arena = append(it.arena, docId...)
+			it.kept[0] = nc
+			it.siftDown(0)
 			continue
 		}
+		nc := scoredVecCand{off: uint32(len(it.arena)), ln: uint32(len(docId)), dist: dist}
 		it.arena = append(it.arena, docId...)
+		it.keptBytes += len(docId)
 		it.kept = append(it.kept, nc)
 		if k > 0 {
 			it.siftUp(len(it.kept) - 1)

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -307,15 +307,17 @@ func (idx *CBOIndex) fullKeyPointBound() bool {
 // BuildPlan constructs an iterator chain using the Cost-Based Optimizer.
 // It evaluates full scan, index seek, and index scan plans, then picks the cheapest.
 func BuildPlan(params *PlanParams) *Plan {
-	// Vector query: the ANN search is the sole source. Bypass the CBO entirely —
-	// no range-index selection, no cost comparison, no full-scan fallback.
+	// Vector query: the $knn clause is enforced by the ANN driver (VectorIter)
+	// or the exact pre-filter probe (VectorScoreIter); buildKnnPlan costs both
+	// against the query's other access paths and picks the cheapest.
 	if params.Vector != nil {
-		return buildVectorPlan(params)
+		return buildKnnPlan(params)
 	}
-	// Full-text query: the $text search is the sole source. Same rationale — a
-	// $text predicate must drive, so there is no cost decision to make.
+	// Full-text query: the $text predicate is enforced by the driver (FtsIter)
+	// or the probe (FtsProbeIter) form; buildTextPlan costs both against the
+	// query's other access paths and picks the cheapest.
 	if params.Fts != nil {
-		return buildFtsPlan(params)
+		return buildTextPlan(params)
 	}
 
 	needSort := params.Sorter != nil
@@ -757,9 +759,10 @@ func buildVectorPlan(params *PlanParams) *Plan {
 func buildFtsPlan(params *PlanParams) *Plan {
 	dataCS := &CursorSource{Tx: params.Tx, Ns: params.DataNs}
 	source := &FtsIter{
-		Spec: params.Fts,
-		Data: dataCS,
-		Buf:  params.Buf,
+		Spec:     params.Fts,
+		Data:     dataCS,
+		Buf:      params.Buf,
+		IDBounds: params.IDBounds,
 	}
 	return buildSearchPlan(params, dataCS, source, 0, "FtsSearch", params.Fts.IndexName)
 }
@@ -1641,6 +1644,17 @@ func setPlanRef(it Iterator, plan *Plan) {
 	case *FtsIter:
 		v.Plan = plan
 		// leaf — no upstream source
+	case *FtsProbeIter:
+		v.Plan = plan
+		setPlanRef(v.Source, plan)
+	case *ScoreInjectIter:
+		v.Plan = plan
+		setPlanRef(v.Source, plan)
+	case *VectorScoreIter:
+		v.Plan = plan
+		setPlanRef(v.Source, plan)
+	case *VerifyIter:
+		setPlanRef(v.Source, plan)
 	}
 }
 

--- a/internal/qplanner/text_plan.go
+++ b/internal/qplanner/text_plan.go
@@ -372,10 +372,13 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 		if len(idx.Bounds) > 0 {
 			idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
 		}
-		dedupB := finalizeIndexBounds(idx)
 		reverse := shouldReverse(params.Sorter, idx)
 
 		if idx.Info.Unique && idx.fullKeyPointBound() {
+			// CoverIter must get the UN-finalized bounds: it seeks the raw
+			// prefix and applies HasExactFieldPrefix itself, so the reverse-
+			// tail pad would double-pad the seek, and MergeOverlappingBounds
+			// would collapse distinct point probes (see buildIndexSeekChain).
 			root = &CoverIter{
 				Source:  &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
 				IdxInfo: idx.Info,
@@ -385,6 +388,7 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 				root = &DocDedupIter{Source: root}
 			}
 		} else {
+			dedupB := finalizeIndexBounds(idx)
 			root = &IndexIter{
 				Source:       &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
 				IdxInfo:      idx.Info,
@@ -428,26 +432,30 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 
 	if params.CountOnly && countCovered {
 		// Count of the probed stream: distinct docIds, no fetches at all.
-		plan := &Plan{Root: root, Name: cand.name, IndexName: indexName}
-		setPlanRef(root, plan)
-		return plan
-	}
-
-	root = &FetchIter{Source: root, Data: dataCS, Buf: params.Buf}
-	root = &ScoreInjectIter{Source: root}
-	if needFilter {
-		root = &FilterIter{Source: root, Data: dataCS, Filter: params.Filter, Buf: params.Buf}
-	}
-	if canonicalWrap != nil {
-		root = canonicalWrap(root)
-	}
-	if needSort && (cand.idx == nil || !cand.idx.ExactSort) {
-		root = &SortIter{
-			Source: root,
-			Data:   dataCS,
-			Sorter: params.Sorter,
-			Buf:    params.Buf,
-			TopK:   sortTopK(params),
+		// The Limit/Offset wrap below still applies — countPlanRoot's
+		// LimitIter.CountDistinct is what windows the distinct count.
+	} else {
+		root = &FetchIter{Source: root, Data: dataCS, Buf: params.Buf}
+		// _score decoration is only needed when someone reads it: the public
+		// iterator (NeedScores) or a residual referencing the virtual field
+		// (the query layer forces NeedScores on for that).
+		if params.Fts.NeedScores {
+			root = &ScoreInjectIter{Source: root}
+		}
+		if needFilter {
+			root = &FilterIter{Source: root, Data: dataCS, Filter: params.Filter, Buf: params.Buf}
+		}
+		if canonicalWrap != nil {
+			root = canonicalWrap(root)
+		}
+		if needSort && (cand.idx == nil || !cand.idx.ExactSort) {
+			root = &SortIter{
+				Source: root,
+				Data:   dataCS,
+				Sorter: params.Sorter,
+				Buf:    params.Buf,
+				TopK:   sortTopK(params),
+			}
 		}
 	}
 	if params.Limit > 0 || params.Offset > 0 {

--- a/internal/qplanner/text_plan.go
+++ b/internal/qplanner/text_plan.go
@@ -428,6 +428,12 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 		Tx:     params.Tx,
 		Rank:   rankMode && !params.CountOnly,
 	}
+	// The rank materialization can be bounded by the result window (like
+	// SortIter's heap) ONLY when no downstream stage rejects rows — a
+	// residual filter after the probe would turn the bound into row loss.
+	if !needFilter {
+		probe.TopK = sortTopK(params)
+	}
 	root = probe
 
 	if params.CountOnly && countCovered {

--- a/internal/qplanner/text_plan.go
+++ b/internal/qplanner/text_plan.go
@@ -1,0 +1,475 @@
+package qplanner
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+)
+
+// text_plan.go is the cost-based plan selection for $text queries. The $text
+// predicate can be enforced two ways:
+//
+//   - DRIVER: FtsIter walks the posting lists and streams candidates in
+//     relevance order; everything else is a residual filter. Cost is O(Σ df) —
+//     the length of the involved posting lists — regardless of how selective
+//     the rest of the query is.
+//   - PROBE: another access path (fixed primary-key bounds, or a bounded /
+//     sort-covering secondary index) enumerates candidates and each one is
+//     verified against the text index individually (FtsProbeIter). Cost scales
+//     with the candidate count, not the posting lists.
+//
+// The two forms select exactly the same documents (the prober is
+// score-bit-identical to the driver by contract), so choosing between them is
+// a pure cost decision fed by exact per-term document frequencies
+// (FtsPlanStats) and the same sketch/interpolation estimates the ordinary CBO
+// uses. No shape rules: a query where the restriction is broad prices the
+// probe form out naturally.
+//
+// Ordering: when the query wants relevance order (no real-field sort) and the
+// order is observable (Iter, or a bounded write selecting rows by it), a probe
+// plan runs the FtsProbeIter in rank mode, reproducing the driver's exact
+// (score desc, IntDocID asc) order — bounded writes then modify identical rows
+// under either plan. When order is irrelevant (Count, unbounded writes) or an
+// explicit sort reorders anyway, the probe streams.
+
+// textCandidate is one enumerated $text plan alternative.
+type textCandidate struct {
+	name    string
+	cost    float64
+	estRows float64
+	idx     *CBOIndex // nil for driver and pk-ids plans
+	kind    textPlanKind
+}
+
+type textPlanKind int
+
+const (
+	textPlanDriver textPlanKind = iota
+	textPlanProbeIds
+	textPlanProbeSeek
+	textPlanProbeScan
+)
+
+// buildTextPlan enumerates the legal $text plans, costs them, and builds the
+// cheapest. With no usable probe form (no Probe func, no stats, no candidate
+// access paths) it degenerates to the driver plan — the pre-CBO behavior.
+func buildTextPlan(params *PlanParams) *Plan {
+	spec := params.Fts
+	totalDocs := float64(params.TotalDocs)
+	if spec.Stats.CorpusDocs > totalDocs {
+		totalDocs = spec.Stats.CorpusDocs
+	}
+	if totalDocs < 1 {
+		totalDocs = 1
+	}
+	needSort := params.Sorter != nil
+	needFilter := params.Filter != nil && !isAllFilter(params.Filter)
+
+	canProbe := spec.Probe != nil && spec.Stats.Valid
+	stats := spec.Stats
+
+	// selText: fraction of the collection matching the $text predicate.
+	selText := stats.EstMatches / totalDocs
+	if selText <= 0 {
+		selText = 0.0001
+	}
+	if selText > 1 {
+		selText = 1
+	}
+
+	// pResidual: combined selectivity of the residual (non-text) predicates,
+	// from the same estimator the ordinary CBO uses.
+	pResidual := calculateSelectivity(params.Filter, params.Indexes, totalDocs, params.FieldBounds)
+
+	// Fixed primary-key bounds bound both the driver's gate and the pk probe.
+	idFixed := len(params.IDBounds) > 0 && AllBoundsFixed(params.IDBounds)
+
+	// idScope: fraction of the collection the pk bounds admit (1 when
+	// unbounded or non-fixed — the gate still applies at runtime, but the
+	// cost model has no estimate for a pk range here).
+	idScope := 1.0
+	if idFixed {
+		idScope = float64(len(params.IDBounds)) / totalDocs
+		if idScope > 1 {
+			idScope = 1
+		}
+	}
+	// pOther: residual selectivity excluding the pk restriction (candidates
+	// that already satisfy the pk bounds still face the rest of the residual).
+	pOther := pResidual
+	if idScope > 0 && idScope < 1 {
+		pOther = pResidual / idScope
+	}
+	if pOther > 1 {
+		pOther = 1
+	}
+	if pOther <= 0 {
+		pOther = 0.0001
+	}
+
+	limitN := float64(params.Limit + params.Offset)
+
+	// Rank mode: relevance order must be reproduced by a probe plan — the
+	// order is observable (public iterator, or a bounded write selecting rows
+	// by it). Count and unbounded writes are set-invariant and stream.
+	rankMode := params.Sorter == nil && !params.CountOnly &&
+		(params.Limit > 0 || params.Offset > 0 || spec.NeedScores)
+
+	probeDocCost := CostFtsProbeDoc + stats.ProbeTerms*CostFtsProbeTerm
+
+	var cands []textCandidate
+
+	// ---- Driver plan (always legal) ------------------------------------
+	{
+		accCost := stats.SumDF * CostFtsPosting
+		gated := stats.EstMatches * idScope // candidates surviving the id gate
+		if gated < 1 {
+			gated = 1
+		}
+		consumed := gated
+		if params.Sorter == nil && !params.CountOnly && params.Limit > 0 {
+			// Relevance order streams; the limit cuts materialization.
+			if need := limitN / pOther; need < consumed {
+				consumed = need
+			}
+		}
+		cost := accCost + consumed*(CostDocFetch+CostFilter)
+		if needSort {
+			yield := gated * pOther
+			cost += sortCost(yield) + yield*CostMaterialize
+		}
+		cands = append(cands, textCandidate{
+			name: "FtsSearch", cost: cost, estRows: gated, kind: textPlanDriver,
+		})
+	}
+
+	if canProbe {
+		// probeCost returns the cost of probing e candidates and finishing
+		// the query from the survivors. fetchAll forces charging a fetch for
+		// every match (no limit cut available).
+		finishCost := func(e float64, orderedOut bool) float64 {
+			matches := e * selText
+			if matches < 1 {
+				matches = 1
+			}
+			fetchN := matches
+			if params.CountOnly && !needFilter {
+				fetchN = 0
+			} else if orderedOut && params.Limit > 0 {
+				// Output already in final order: the limit stops the fetches.
+				if need := limitN / pOther; need < fetchN {
+					fetchN = need
+				}
+			}
+			cost := e*probeDocCost + fetchN*(CostDocFetch+CostFilter)
+			if needSort {
+				cost += sortCost(matches*pOther) + matches*pOther*CostMaterialize
+			}
+			return cost
+		}
+
+		// ---- Probe from fixed pk bounds --------------------------------
+		if idFixed {
+			e := float64(len(params.IDBounds))
+			cands = append(cands, textCandidate{
+				name: "FtsProbeIds", cost: finishCost(e, rankMode), estRows: e * selText,
+				kind: textPlanProbeIds,
+			})
+		}
+
+		// ---- Probe from bounded secondary indexes ----------------------
+		var fieldSelBuf [8]fieldSelEntry
+		fieldSel := collectFieldSelectivity(params, totalDocs, fieldSelBuf[:0])
+		for i := range params.Indexes {
+			idx := &params.Indexes[i]
+			if len(idx.Bounds) == 0 {
+				continue
+			}
+			if !sparseIndexComplete(idx, params.Filter) {
+				continue
+			}
+			e := estimateIndexDocsWithFieldSel(idx, totalDocs, fieldSel)
+			if e < 1 {
+				e = 1
+			}
+			nSeeks := float64(len(idx.Bounds))
+			if nSeeks < 1 {
+				nSeeks = 1
+			}
+			access := nSeeks*CostIndexSeek + e*CostSeqRead
+			orderedOut := rankMode || (needSort && idx.ExactSort)
+			cands = append(cands, textCandidate{
+				name: "FtsProbeSeek(" + idx.Info.Name + ")", idx: idx,
+				cost:    access + finishCost(e, orderedOut),
+				estRows: e * selText, kind: textPlanProbeSeek,
+			})
+		}
+
+		// ---- Probe along a sort-covering index scan --------------------
+		// The scan streams in final order, so with a LIMIT only
+		// (L+O)/(pass rate) entries are visited and probed.
+		if needSort {
+			for i := range params.Indexes {
+				idx := &params.Indexes[i]
+				if !idx.ExactSort {
+					continue
+				}
+				if !sparseIndexComplete(idx, params.Filter) {
+					continue
+				}
+				idxSel := selectivityForIndex(idx, totalDocs)
+				scanSel := pResidual / idxSel
+				if scanSel > 1 {
+					scanSel = 1
+				}
+				if scanSel <= 0 {
+					scanSel = 0.0001
+				}
+				scanPop := totalDocs
+				if len(idx.Bounds) > 0 {
+					scanPop = totalDocs * idxSel
+					if scanPop < 1 {
+						scanPop = 1
+					}
+				}
+				s := scanPop
+				if params.Limit > 0 {
+					s = limitN / (scanSel * selText)
+					if s > scanPop {
+						s = scanPop
+					}
+					if s < 1 {
+						s = 1
+					}
+				}
+				cost := s*(CostIndexSeek+probeDocCost) + s*selText*(CostDocFetch+CostFilter)
+				cands = append(cands, textCandidate{
+					name: "FtsProbeScan(" + idx.Info.Name + ")", idx: idx,
+					cost: cost, estRows: s * selText * scanSel, kind: textPlanProbeScan,
+				})
+			}
+		}
+	}
+
+	// Hint boosts, by index name: the fts index name boosts the driver, a
+	// secondary index name its probe plans, and the primary-key field name
+	// the pk probe plan.
+	if len(params.IndexHints) > 0 {
+		pk := params.PrimaryKey
+		if pk == "" {
+			pk = "id"
+		}
+		for ci := range cands {
+			c := &cands[ci]
+			hintName := spec.IndexName
+			switch {
+			case c.idx != nil:
+				hintName = c.idx.Info.Name
+			case c.kind == textPlanProbeIds:
+				hintName = pk
+			}
+			for _, h := range params.IndexHints {
+				if h.IndexName == hintName {
+					c.cost -= float64(h.Boost)
+				}
+			}
+		}
+	}
+
+	best := &cands[0]
+	for ci := 1; ci < len(cands); ci++ {
+		if cands[ci].cost < best.cost {
+			best = &cands[ci]
+		}
+	}
+
+	// ---- Build the chosen chain ----------------------------------------
+	var plan *Plan
+	switch best.kind {
+	case textPlanDriver:
+		plan = buildFtsPlan(params)
+	default:
+		plan = buildTextProbePlan(params, best, rankMode)
+	}
+
+	plan.Cost = best.cost
+	if !params.CountOnly {
+		explainCands := make([]CandidatePlan, 0, len(cands))
+		for ci := range cands {
+			c := cands[ci]
+			explainCands = append(explainCands, CandidatePlan{
+				Name: c.name, Cost: c.cost, EstRows: c.estRows,
+			})
+		}
+		slices.SortFunc(explainCands, func(a, b CandidatePlan) int {
+			return cmp.Compare(a.Cost, b.Cost)
+		})
+		plan.Explain = ExplainInfo{
+			TotalDocs:   int(totalDocs),
+			Selectivity: selText * pResidual,
+			Candidates:  explainCands,
+			ChosenIndex: plan.IndexName,
+		}
+	}
+	return plan
+}
+
+// collectFieldSelectivity mirrors BuildPlan's per-field selectivity pass
+// (single-field point-lookup indexes with sketches).
+func collectFieldSelectivity(params *PlanParams, totalDocs float64, buf []fieldSelEntry) []fieldSelEntry {
+	for i := range params.Indexes {
+		idx := &params.Indexes[i]
+		if len(idx.Info.FieldNames) == 1 && idx.PointLookup && len(idx.Bounds) > 0 {
+			var est float64
+			if idx.Info.Unique && !idx.Info.Sparse {
+				est = float64(len(idx.Bounds))
+			} else if idx.Sketch != nil {
+				est = float64(idx.Sketch.Estimate(0, idx.Bounds[0].Start))
+			}
+			if est > 0 && len(buf) < cap(buf) {
+				buf = append(buf, fieldSelEntry{field: idx.Info.FieldNames[0], sel: est / totalDocs})
+			}
+		}
+	}
+	return buf
+}
+
+// buildTextProbePlan assembles the chosen probe chain:
+//
+//	rank:   driver -> FtsProbe(rank) -> Fetch -> ScoreInject -> [Filter] -> [Limit]
+//	stream: driver -> [dedup] -> FtsProbe -> Fetch -> ScoreInject -> [Filter]
+//	        -> [CanonicalDedup] -> [Sort] -> [Limit]
+//
+// CountOnly with a driver-covered residual skips everything after the probe
+// (no document is ever fetched).
+func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) *Plan {
+	needFilter := params.Filter != nil && !isAllFilter(params.Filter)
+	needSort := params.Sorter != nil
+	dataCS := &CursorSource{Tx: params.Tx, Ns: params.DataNs}
+
+	var root Iterator
+	var canonicalWrap func(Iterator) Iterator
+	indexName := params.Fts.IndexName
+
+	countCovered := false
+
+	switch cand.kind {
+	case textPlanProbeIds:
+		root = &IdBoundsIter{Bounds: params.IDBounds}
+		// The pk bounds exactly represent a single-predicate pk-only residual;
+		// then Count needs no fetch (mirrors indexCoversFilter's conditions).
+		pk := params.PrimaryKey
+		if pk == "" {
+			pk = "id"
+		}
+		hasFields := false
+		countCovered = !needFilter ||
+			(filterFieldsCoveredBy(params.Filter, []string{pk}, &hasFields) && hasFields &&
+				countFilterFieldPreds(params.Filter, pk) <= 1)
+	default:
+		idx := cand.idx
+		indexName = idx.Info.Name
+		if len(idx.Bounds) > 0 {
+			idx.Bounds = AdjustBoundsForNonUnique(idx.Bounds)
+		}
+		dedupB := finalizeIndexBounds(idx)
+		reverse := shouldReverse(params.Sorter, idx)
+
+		if idx.Info.Unique && idx.fullKeyPointBound() {
+			root = &CoverIter{
+				Source:  &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
+				IdxInfo: idx.Info,
+				Bounds:  idx.Bounds,
+			}
+			if len(idx.Bounds) > 1 {
+				root = &DocDedupIter{Source: root}
+			}
+		} else {
+			root = &IndexIter{
+				Source:       &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
+				IdxInfo:      idx.Info,
+				Bounds:       idx.Bounds,
+				Reverse:      reverse,
+				PointLookup:  idx.PointLookup,
+				FullKeyBound: idx.fullKeyPointBound(),
+				ScalarProven: idx.ScalarProven,
+			}
+			// Compound multikey dedup below the probe (same placement as the
+			// ordinary chains); single-field dups keep their canonical dedup
+			// above the filter in stream mode, and rank mode dedups
+			// internally.
+			if len(idx.Info.FieldPaths) > 1 && !idx.ScalarProven {
+				root = &DocDedupIter{Source: root}
+			}
+			if len(idx.Info.FieldPaths) == 1 && !rankMode {
+				fieldReverse := len(idx.Info.Reverse) > 0 && idx.Info.Reverse[0]
+				canonicalWrap = func(it Iterator) Iterator {
+					return &CanonicalKeyDedupIter{
+						Source:       it,
+						Bounds:       dedupB,
+						FieldPath:    idx.Info.FieldPaths[0],
+						Reverse:      reverse,
+						FieldReverse: fieldReverse,
+					}
+				}
+			}
+		}
+		countCovered = !needFilter ||
+			(idx.PointLookup && indexCoversFilter(idx, params.Filter))
+	}
+
+	probe := &FtsProbeIter{
+		Spec:   params.Fts,
+		Source: root,
+		Tx:     params.Tx,
+		Rank:   rankMode && !params.CountOnly,
+	}
+	root = probe
+
+	if params.CountOnly && countCovered {
+		// Count of the probed stream: distinct docIds, no fetches at all.
+		plan := &Plan{Root: root, Name: cand.name, IndexName: indexName}
+		setPlanRef(root, plan)
+		return plan
+	}
+
+	root = &FetchIter{Source: root, Data: dataCS, Buf: params.Buf}
+	root = &ScoreInjectIter{Source: root}
+	if needFilter {
+		root = &FilterIter{Source: root, Data: dataCS, Filter: params.Filter, Buf: params.Buf}
+	}
+	if canonicalWrap != nil {
+		root = canonicalWrap(root)
+	}
+	if needSort && (cand.idx == nil || !cand.idx.ExactSort) {
+		root = &SortIter{
+			Source: root,
+			Data:   dataCS,
+			Sorter: params.Sorter,
+			Buf:    params.Buf,
+			TopK:   sortTopK(params),
+		}
+	}
+	if params.Limit > 0 || params.Offset > 0 {
+		root = &LimitIter{Source: root, Limit: params.Limit, Offset: params.Offset}
+	}
+
+	plan := &Plan{Root: root, Name: cand.name, IndexName: indexName}
+	setPlanRef(root, plan)
+	return plan
+}
+
+// textPlanName is used by tests to assert plan choice via Plan.Name.
+func (k textPlanKind) String() string {
+	switch k {
+	case textPlanDriver:
+		return "FtsSearch"
+	case textPlanProbeIds:
+		return "FtsProbeIds"
+	case textPlanProbeSeek:
+		return "FtsProbeSeek"
+	case textPlanProbeScan:
+		return "FtsProbeScan"
+	}
+	return fmt.Sprintf("textPlanKind(%d)", int(k))
+}

--- a/internal/qplanner/vector_iter.go
+++ b/internal/qplanner/vector_iter.go
@@ -51,6 +51,21 @@ type VectorQuerySpec struct {
 	// slice this sequence, so an under-specified tie order would make different
 	// verbs page different documents.
 	TotallyOrdered bool
+
+	// ---- probe (pre-filter exact) form, filled by the anystore layer ----
+
+	// DistFromDoc computes the query↔document distance from a parsed document
+	// (the same vector source and kernel as the brute-force backend). nil
+	// means the probe form is unavailable and only the ANN driver is legal.
+	DistFromDoc func(doc *anyenc.Value) (float32, bool)
+	// CheckTx applies the index-visibility gate the driver's Search performs,
+	// so a probe plan errors exactly where the ANN search would.
+	CheckTx func(tx *btree.ReadTx) error
+	// SearchCostPerCand estimates the ANN search's own cost per ef candidate
+	// (graph/list traversal + rerank, amortized); BruteDriver marks the
+	// brute-force backend, whose driver cost is a full collection scan.
+	SearchCostPerCand float64
+	BruteDriver       bool
 }
 
 // VectorIter is the source iterator for a vector query. On first Next it runs

--- a/query.go
+++ b/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 
 	"github.com/anyproto/any-store/v2/internal/btree"
 	"github.com/anyproto/any-store/v2/internal/qplanner"
@@ -168,18 +169,6 @@ func visibleIndexes(btx *btree.ReadTx, idxs []*index) []*index {
 	return out
 }
 
-// reportCandidates builds the CBO candidate list for Explain's index report
-// on the fts/vector paths, where compilation never consults the CBO. Nil for
-// every other verb.
-func (q *collQuery) reportCandidates(btx *btree.ReadTx, opts planOpts) []qplanner.CBOIndex {
-	if !opts.wantCandidates {
-		return nil
-	}
-	idxs := visibleIndexes(btx, q.c.loadIndexes())
-	br := q.buildBoundsResult(idxs)
-	return q.buildCBOIndexesInto(nil, &br, idxs, btx, opts.countOnly)
-}
-
 // planOpts are the only per-verb compilation knobs. Everything else about
 // access-path selection is shared — a divergence here needs written rationale
 // (the SQLite shape: one WHERE/ORDER BY code generator, verb-specific only at
@@ -282,7 +271,10 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		if err = q.c.db.flushAmbientFtsPending(ctx); err != nil {
 			return nil, nil, err
 		}
-		ftsSpec.NeedScores = opts.needSidecars
+		// The score sidecar/decoration is needed by the public iterator, or by
+		// a residual that reads the _score virtual field on any verb.
+		ftsSpec.NeedScores = opts.needSidecars || filterRefsField(ftsResidual, qplanner.ScoreField) ||
+			sortRefsField(q.sort, qplanner.ScoreField)
 		// countOnly is sound without ordering: FtsIter emits one aggregate per
 		// doc (duplicate-free), and the distinct count is order-invariant.
 		sorter := ftsSorter(q.writeSorter(opts))
@@ -808,9 +800,12 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 		// paths so the index report never silently shrinks. Vector queries
 		// are honestly explained as their ANN plan now, exactly what Iter and
 		// the write verbs execute.
+		// needSidecars mirrors Iter so the described chain (rank vs stream
+		// probe form) is exactly the one Rows(Q) executes.
 		plan, cboIndexes, perr := q.compilePlan(ctx, tx, buf, qb.idBounds, planOpts{
 			exactTotalDocs: true,
 			wantCandidates: true,
+			needSidecars:   true,
 		})
 		if perr != nil {
 			return perr
@@ -825,8 +820,7 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 		// NOT CBO candidates though — the optimizer never costed them — so
 		// they carry a cost only when they actually drive the plan; a phantom
 		// plan.Cost on an unconsidered index would read as a costed candidate.
-		addIndex := func(name string, cost float64) {
-			used := name == plan.IndexName
+		addIndex := func(name string, cost float64, used bool) {
 			ie := IndexExplain{
 				Name: name,
 				Cost: cost,
@@ -839,7 +833,7 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 			}
 		}
 		for _, idx := range cboIndexes {
-			addIndex(idx.Info.Name, plan.Cost)
+			addIndex(idx.Info.Name, plan.Cost, idx.Info.Name == plan.IndexName)
 		}
 		sourceCost := func(name string) float64 {
 			if name == plan.IndexName {
@@ -855,18 +849,45 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 			if _, ferr := vi.forTx(tx); ferr != nil {
 				continue
 			}
-			addIndex(vi.info.Name, sourceCost(vi.info.Name))
+			// A probe plan enforces the $knn clause through this index's
+			// distance kernel even when a range index drives the enumeration.
+			used := vi.info.Name == plan.IndexName ||
+				(strings.HasPrefix(plan.Name, "Knn") && q.knnIndexName() == vi.info.Name)
+			addIndex(vi.info.Name, sourceCost(vi.info.Name), used)
 		}
 		for _, fx := range q.c.loadFtsIndexes() {
 			// Same gate the executed $text goes through.
 			if !fx.visibleTo(tx) {
 				continue
 			}
-			addIndex(fx.info.Name, sourceCost(fx.info.Name))
+			// Same rule: a $text probe plan verifies every row against this
+			// index even when it does not drive.
+			used := fx.info.Name == plan.IndexName ||
+				(strings.HasPrefix(plan.Name, "Fts") && q.ftsIndexName() == fx.info.Name)
+			addIndex(fx.info.Name, sourceCost(fx.info.Name), used)
 		}
 		return nil
 	})
 	return
+}
+
+// ftsIndexName returns the index a $text predicate resolves to (the first
+// visible full-text index — detectFtsQuery's rule), or "".
+func (q *collQuery) ftsIndexName() string {
+	if fxs := q.c.loadFtsIndexes(); len(fxs) > 0 {
+		return fxs[0].info.Name
+	}
+	return ""
+}
+
+// knnIndexName returns the vector index the query's $knn clause resolves to,
+// or "" for a non-$knn query.
+func (q *collQuery) knnIndexName() string {
+	spec, _, err := q.detectKnnQuery()
+	if err != nil || spec == nil {
+		return ""
+	}
+	return spec.IndexName
 }
 
 func (q *collQuery) makeQuery() (qb *queryBuilder, err error) {

--- a/query.go
+++ b/query.go
@@ -281,37 +281,35 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		// CBO inputs for the driver/probe cost decision: the residual's index
 		// candidates and the exact per-term stats of the $text predicate.
 		// Bounds are computed over q.cond — Text contributes none, so the
-		// residual predicates' bounds come out identical.
-		idxs := visibleIndexes(btx, q.c.loadIndexes())
-		br := q.buildBoundsResult(idxs)
-		cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, btx, opts.countOnly)
-		totalDocs := q.docCountForPlan(btx, idxs)
-		if ftsSpec.StatsFn != nil {
+		// residual predicates' bounds come out identical. A query that can
+		// have no probe candidate (no residual to bound an index, no fixed pk
+		// restriction) skips all of it — the unrestricted hot shape pays
+		// nothing over the pre-CBO driver path.
+		params := &qplanner.PlanParams{
+			Tx:         btx,
+			DataNs:     q.c.ns,
+			Filter:     ftsResidual,
+			Sorter:     sorter,
+			IDBounds:   idBounds,
+			PrimaryKey: q.c.primaryKey,
+			Limit:      int(q.limit),
+			Offset:     int(q.offset),
+			Buf:        buf,
+			IndexHints: q.buildIndexHints(),
+			CountOnly:  opts.countOnly,
+			Fts:        ftsSpec,
+		}
+		probePossible := q.fillProbeInputs(btx, ftsResidual, sorter != nil, opts, params)
+		if probePossible && ftsSpec.StatsFn != nil {
 			// A stats failure only disables the probe form (Valid stays
 			// false); the driver plan needs none of it.
 			if st, serr := ftsSpec.StatsFn(btx); serr == nil {
 				ftsSpec.Stats = st
 			}
 		}
-		plan = qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:          btx,
-			DataNs:      q.c.ns,
-			Filter:      ftsResidual,
-			Sorter:      sorter,
-			IDBounds:    idBounds,
-			PrimaryKey:  q.c.primaryKey,
-			Limit:       int(q.limit),
-			Offset:      int(q.offset),
-			Buf:         buf,
-			TotalDocs:   totalDocs,
-			Indexes:     cboIndexes,
-			IndexHints:  q.buildIndexHints(),
-			CountOnly:   opts.countOnly,
-			FieldBounds: &br,
-			Fts:         ftsSpec,
-		})
+		plan = qplanner.BuildPlan(params)
 		if opts.wantCandidates {
-			cbo = cboIndexes
+			cbo = params.Indexes
 		}
 		return plan, cbo, nil
 	}
@@ -329,30 +327,25 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 	if vspec != nil {
 		vspec.NeedDistances = opts.needSidecars
 		// CBO inputs for the ANN-driver / exact-probe cost decision — same
-		// assembly as the $text branch.
-		idxs := visibleIndexes(btx, q.c.loadIndexes())
-		br := q.buildBoundsResult(idxs)
-		cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, btx, opts.countOnly)
-		totalDocs := q.docCountForPlan(btx, idxs)
-		plan = qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:          btx,
-			DataNs:      q.c.ns,
-			Filter:      residual,
-			Sorter:      q.writeSorter(opts),
-			IDBounds:    idBounds,
-			PrimaryKey:  q.c.primaryKey,
-			Limit:       int(q.limit),
-			Offset:      int(q.offset),
-			Buf:         buf,
-			TotalDocs:   totalDocs,
-			Indexes:     cboIndexes,
-			IndexHints:  q.buildIndexHints(),
-			CountOnly:   opts.countOnly,
-			FieldBounds: &br,
-			Vector:      vspec,
-		})
+		// assembly and same no-candidate skip as the $text branch.
+		params := &qplanner.PlanParams{
+			Tx:         btx,
+			DataNs:     q.c.ns,
+			Filter:     residual,
+			Sorter:     q.writeSorter(opts),
+			IDBounds:   idBounds,
+			PrimaryKey: q.c.primaryKey,
+			Limit:      int(q.limit),
+			Offset:     int(q.offset),
+			Buf:        buf,
+			IndexHints: q.buildIndexHints(),
+			CountOnly:  opts.countOnly,
+			Vector:     vspec,
+		}
+		q.fillProbeInputs(btx, residual, false, opts, params)
+		plan = qplanner.BuildPlan(params)
 		if opts.wantCandidates {
-			cbo = cboIndexes
+			cbo = params.Indexes
 		}
 		return plan, cbo, nil
 	}
@@ -869,6 +862,36 @@ func (q *collQuery) Explain(ctx context.Context) (explain Explain, err error) {
 		return nil
 	})
 	return
+}
+
+// fillProbeInputs assembles the CBO inputs the $text/$knn driver-probe cost
+// decision needs — index candidates, per-field bounds, doc count — into
+// params, and reports whether ANY probe candidate can exist. A query with no
+// residual to bound an index, no fixed pk restriction, and no sort to cover
+// skips the whole assembly: the unrestricted hot shape pays nothing over the
+// pre-CBO driver path. Explain (wantCandidates) always assembles, for its
+// index report.
+func (q *collQuery) fillProbeInputs(btx *btree.ReadTx, residual query.Filter, needSort bool, opts planOpts, params *qplanner.PlanParams) (probePossible bool) {
+	idFixed := len(params.IDBounds) > 0 && qplanner.AllBoundsFixed(params.IDBounds)
+	hasResidual := residual != nil && !isAllQueryFilter(residual)
+	if !idFixed && !hasResidual && !needSort && !opts.wantCandidates {
+		return false
+	}
+	idxs := visibleIndexes(btx, q.c.loadIndexes())
+	probePossible = idFixed
+	if len(idxs) > 0 {
+		br := q.buildBoundsResult(idxs)
+		params.Indexes = q.buildCBOIndexesInto(nil, &br, idxs, btx, opts.countOnly)
+		params.FieldBounds = &br
+		for i := range params.Indexes {
+			if len(params.Indexes[i].Bounds) > 0 || (needSort && params.Indexes[i].ExactSort) {
+				probePossible = true
+				break
+			}
+		}
+	}
+	params.TotalDocs = q.docCountForPlan(btx, idxs)
+	return probePossible
 }
 
 // ftsIndexName returns the index a $text predicate resolves to (the first

--- a/query.go
+++ b/query.go
@@ -286,18 +286,42 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 		// countOnly is sound without ordering: FtsIter emits one aggregate per
 		// doc (duplicate-free), and the distinct count is order-invariant.
 		sorter := ftsSorter(q.writeSorter(opts))
+		// CBO inputs for the driver/probe cost decision: the residual's index
+		// candidates and the exact per-term stats of the $text predicate.
+		// Bounds are computed over q.cond — Text contributes none, so the
+		// residual predicates' bounds come out identical.
+		idxs := visibleIndexes(btx, q.c.loadIndexes())
+		br := q.buildBoundsResult(idxs)
+		cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, btx, opts.countOnly)
+		totalDocs := q.docCountForPlan(btx, idxs)
+		if ftsSpec.StatsFn != nil {
+			// A stats failure only disables the probe form (Valid stays
+			// false); the driver plan needs none of it.
+			if st, serr := ftsSpec.StatsFn(btx); serr == nil {
+				ftsSpec.Stats = st
+			}
+		}
 		plan = qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:        btx,
-			DataNs:    q.c.ns,
-			Filter:    ftsResidual,
-			Sorter:    sorter,
-			Limit:     int(q.limit),
-			Offset:    int(q.offset),
-			Buf:       buf,
-			CountOnly: opts.countOnly,
-			Fts:       ftsSpec,
+			Tx:          btx,
+			DataNs:      q.c.ns,
+			Filter:      ftsResidual,
+			Sorter:      sorter,
+			IDBounds:    idBounds,
+			PrimaryKey:  q.c.primaryKey,
+			Limit:       int(q.limit),
+			Offset:      int(q.offset),
+			Buf:         buf,
+			TotalDocs:   totalDocs,
+			Indexes:     cboIndexes,
+			IndexHints:  q.buildIndexHints(),
+			CountOnly:   opts.countOnly,
+			FieldBounds: &br,
+			Fts:         ftsSpec,
 		})
-		return plan, q.reportCandidates(btx, opts), nil
+		if opts.wantCandidates {
+			cbo = cboIndexes
+		}
+		return plan, cbo, nil
 	}
 
 	// $knn drives the query when present (CBO bypassed): the ANN search is the
@@ -312,18 +336,33 @@ func (q *collQuery) compilePlan(ctx context.Context, btx *btree.ReadTx, buf *syn
 	}
 	if vspec != nil {
 		vspec.NeedDistances = opts.needSidecars
+		// CBO inputs for the ANN-driver / exact-probe cost decision — same
+		// assembly as the $text branch.
+		idxs := visibleIndexes(btx, q.c.loadIndexes())
+		br := q.buildBoundsResult(idxs)
+		cboIndexes := q.buildCBOIndexesInto(nil, &br, idxs, btx, opts.countOnly)
+		totalDocs := q.docCountForPlan(btx, idxs)
 		plan = qplanner.BuildPlan(&qplanner.PlanParams{
-			Tx:        btx,
-			DataNs:    q.c.ns,
-			Filter:    residual,
-			Sorter:    q.writeSorter(opts),
-			Limit:     int(q.limit),
-			Offset:    int(q.offset),
-			Buf:       buf,
-			CountOnly: opts.countOnly,
-			Vector:    vspec,
+			Tx:          btx,
+			DataNs:      q.c.ns,
+			Filter:      residual,
+			Sorter:      q.writeSorter(opts),
+			IDBounds:    idBounds,
+			PrimaryKey:  q.c.primaryKey,
+			Limit:       int(q.limit),
+			Offset:      int(q.offset),
+			Buf:         buf,
+			TotalDocs:   totalDocs,
+			Indexes:     cboIndexes,
+			IndexHints:  q.buildIndexHints(),
+			CountOnly:   opts.countOnly,
+			FieldBounds: &br,
+			Vector:      vspec,
 		})
-		return plan, q.reportCandidates(btx, opts), nil
+		if opts.wantCandidates {
+			cbo = cboIndexes
+		}
+		return plan, cbo, nil
 	}
 
 	// CBO path. Bounds and candidates are built against btx: the

--- a/query/bound.go
+++ b/query/bound.go
@@ -230,6 +230,50 @@ func (b Bound) contains(val []byte) bool {
 	return true
 }
 
+// SortedDisjoint reports whether bs is in canonical form: sorted ascending by
+// Start with pairwise non-overlapping ranges — the precondition of
+// ContainsSorted. IndexBounds results are canonical (SortAndMerge), but a
+// caller holding bounds of unknown provenance must check before switching from
+// the linear Contains to the binary-search path.
+func (bs Bounds) SortedDisjoint() bool {
+	for i := 1; i < len(bs); i++ {
+		if bytes.Compare(bs[i-1].Start, bs[i].Start) > 0 {
+			return false
+		}
+		if isOverlap(bs[i-1], bs[i]) && isOverlap(bs[i], bs[i-1]) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsSorted reports whether val lies within any range of a CANONICAL
+// (sorted, disjoint — see SortedDisjoint) bound set, by binary search. On a
+// non-canonical set the answer is unsound BY DESIGN — the caller owns the
+// precondition; this is the hot-loop variant of Contains (which stays linear
+// and assumption-free).
+func (bs Bounds) ContainsSorted(val []byte) bool {
+	lo, hi := 0, len(bs)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		b := &bs[mid]
+		if len(b.Start) > 0 {
+			if c := bytes.Compare(val, b.Start); c < 0 || (c == 0 && !b.StartInclude) {
+				hi = mid
+				continue
+			}
+		}
+		if len(b.End) > 0 {
+			if c := bytes.Compare(val, b.End); c > 0 || (c == 0 && !b.EndInclude) {
+				lo = mid + 1
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // Intersect returns the lex-intersection of this bound set with other.
 // A bound set is a union of value ranges; the intersection is the set of
 // values present in BOTH unions. Used by TightIndexBounds to combine the

--- a/query/bound_test.go
+++ b/query/bound_test.go
@@ -313,3 +313,86 @@ func TestBounds_Intersect(t *testing.T) {
 	}
 }
 
+func TestBounds_SortedDisjoint(t *testing.T) {
+	mk := func(start, end string, si, ei bool) Bound {
+		return Bound{Start: []byte(start), End: []byte(end), StartInclude: si, EndInclude: ei}
+	}
+	assert.True(t, Bounds(nil).SortedDisjoint())
+	assert.True(t, Bounds{mk("a", "a", true, true)}.SortedDisjoint())
+	assert.True(t, Bounds{mk("a", "a", true, true), mk("c", "c", true, true)}.SortedDisjoint())
+	// Touching at a shared endpoint is treated as non-canonical either way —
+	// SortAndMerge coalesces adjacent bounds, so a canonical set never
+	// contains them, and rejecting them here only routes the caller to the
+	// assumption-free linear Contains.
+	assert.False(t, Bounds{mk("a", "b", true, true), mk("b", "c", true, true)}.SortedDisjoint())
+	assert.False(t, Bounds{mk("a", "b", true, false), mk("b", "c", true, true)}.SortedDisjoint())
+	// Out of order.
+	assert.False(t, Bounds{mk("c", "c", true, true), mk("a", "a", true, true)}.SortedDisjoint())
+	// Genuine overlap.
+	assert.False(t, Bounds{mk("a", "m", true, true), mk("d", "z", true, true)}.SortedDisjoint())
+	// Unbounded end overlaps everything after it.
+	assert.False(t, Bounds{{Start: []byte("a"), StartInclude: true}, mk("c", "d", true, true)}.SortedDisjoint())
+}
+
+// ContainsSorted must agree with the linear Contains on every canonical set —
+// its precondition (SortedDisjoint) is what the fuzz below relies on.
+func TestBounds_ContainsSorted(t *testing.T) {
+	mk := func(start, end string, si, ei bool) Bound {
+		return Bound{Start: []byte(start), End: []byte(end), StartInclude: si, EndInclude: ei}
+	}
+	sets := []Bounds{
+		nil,
+		{mk("a", "a", true, true)},
+		{mk("a", "a", true, true), mk("c", "c", true, true), mk("e", "e", true, true)},
+		{mk("a", "c", false, false), mk("e", "g", true, true)},
+		{{End: []byte("c"), EndInclude: false}, mk("e", "g", true, true), {Start: []byte("m"), StartInclude: false}},
+	}
+	vals := []string{"", "a", "a0", "b", "c", "d", "e", "f", "g", "h", "m", "n", "z"}
+	for si, bs := range sets {
+		if !bs.SortedDisjoint() {
+			t.Fatalf("set %d not canonical", si)
+		}
+		for _, v := range vals {
+			assert.Equal(t, bs.Contains([]byte(v)), bs.ContainsSorted([]byte(v)),
+				"set %d, val %q", si, v)
+		}
+	}
+}
+
+// Randomized agreement between Contains and ContainsSorted over canonical sets
+// built by SortAndMerge from arbitrary point/range bounds.
+func TestBounds_ContainsSorted_Randomized(t *testing.T) {
+	rnd := uint64(12345)
+	next := func(n int) int {
+		rnd = rnd*6364136223846793005 + 1442695040888963407
+		return int((rnd >> 33) % uint64(n))
+	}
+	letters := "abcdefghij"
+	for iter := 0; iter < 500; iter++ {
+		var bs Bounds
+		for i := 0; i < 1+next(5); i++ {
+			a := letters[next(len(letters))]
+			b := letters[next(len(letters))]
+			if a > b {
+				a, b = b, a
+			}
+			bs = append(bs, Bound{
+				Start: []byte{a}, End: []byte{b},
+				StartInclude: next(2) == 0 || a == b, EndInclude: next(2) == 0 || a == b,
+			})
+		}
+		bs = bs.SortAndMerge()
+		if !bs.SortedDisjoint() {
+			// SortAndMerge can leave touching-but-not-overlapping neighbors
+			// that SortedDisjoint accepts; a set it rejects must use the
+			// linear path — which is exactly what the runtime gate does.
+			continue
+		}
+		for c := byte('a'); c <= 'k'; c++ {
+			v := []byte{c}
+			if bs.Contains(v) != bs.ContainsSorted(v) {
+				t.Fatalf("iter %d: divergence on %q for %v", iter, v, bs)
+			}
+		}
+	}
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -1157,7 +1157,10 @@ func sortRefsField(s query.Sort, field string) bool {
 // a query executes single-threaded.
 func knnDistFromDoc(vi *vectorIndex, qv []float32) func(doc *anyenc.Value) (float32, bool) {
 	dist := vindex.DistanceFor(vi.info.Vector.Metric.toVindex())
-	buf := make([]float32, 0, vi.dim)
+	// Scratch for the numeric-array representation only, allocated lazily:
+	// packed TypeVectorF32 storage (the normal case) reads zero-copy, and
+	// detectKnnQuery builds one discarded spec per query (validateSources).
+	var buf []float32
 	return func(doc *anyenc.Value) (float32, bool) {
 		v := doc.Get(vi.fieldPath...)
 		if v == nil {
@@ -1174,6 +1177,9 @@ func knnDistFromDoc(vi *vectorIndex, qv []float32) func(doc *anyenc.Value) (floa
 			arr, err := v.Array()
 			if err != nil || len(arr) != vi.dim {
 				return 0, false
+			}
+			if buf == nil {
+				buf = make([]float32, 0, vi.dim)
 			}
 			buf = buf[:0]
 			for _, el := range arr {

--- a/vector_index.go
+++ b/vector_index.go
@@ -704,6 +704,9 @@ func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, e
 		// distance. ef is the re-rank depth / candidate count; nprobe is fixed
 		// in the index.
 		spec.Ef = knnEf(knn.Ef, captured.ivf.NProbe()*8, knn.K, hasResidual)
+		// ~2.2 cost units per ef candidate measured on the vector_restrict
+		// IVFSQ benchmark (cell scans + exact rerank, amortized).
+		spec.SearchCostPerCand = 2.5
 		spec.Search = func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
 			svi, err := captured.forTx(tx)
 			if err != nil {
@@ -737,7 +740,9 @@ func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, e
 			return q.c.bruteVectorCandidates(tx, svi, qv, topK)
 		}
 	default:
-		// HNSW: ef is the beam width.
+		// HNSW: ef is the beam width. Graph traversal touches ~M neighbours
+		// per accepted candidate, so it prices above IVF's linear cell scans.
+		spec.SearchCostPerCand = 4.0
 		spec.Ef = knnEf(knn.Ef, vi.ix.EfSearch(), knn.K, hasResidual)
 		spec.Search = func(tx *btree.ReadTx, qv []float32, ef int) ([]qplanner.VectorCandidate, error) {
 			svi, err := captured.forTx(tx)

--- a/vector_index.go
+++ b/vector_index.go
@@ -688,6 +688,15 @@ func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, e
 		K:              knn.K,
 		IndexName:      vi.info.Name,
 		TotallyOrdered: true, // all three backends return (distance, docId) ascending
+		// Probe (exact pre-filter) form: score a candidate's stored vector
+		// directly from the parsed document — the same vector source and
+		// distance kernel as the brute-force backend, so exact-mode distances
+		// are bit-identical to brute-driver distances.
+		DistFromDoc: knnDistFromDoc(vi, knn.Query),
+		CheckTx: func(tx *btree.ReadTx) error {
+			_, cerr := captured.forTx(tx)
+			return cerr
+		},
 	}
 	switch {
 	case vi.isIVF():
@@ -715,6 +724,7 @@ func (q *collQuery) detectKnnQuery() (*qplanner.VectorQuerySpec, query.Filter, e
 		// so it can rank and cut to k itself — but ONLY when no residual will
 		// discard candidates downstream (it is the one backend that can
 		// guarantee k post-residual survivors, by returning everything).
+		spec.BruteDriver = true
 		topK := 0
 		if !hasResidual {
 			topK = knn.K
@@ -1133,6 +1143,47 @@ func sortRefsField(s query.Sort, field string) bool {
 // the cursor key itself (the data namespace is keyed by encoded id). All
 // per-document state lives in reused buffers; the candidates' ids share one
 // arena.
+// knnDistFromDoc builds the probe-form distance closure: extract the field's
+// vector from a PARSED document (both representations — the packed
+// TypeVectorF32 blob and a plain numeric array, mirroring anyenc's
+// AppendFloat32s) and score it with the index's metric kernel. ok=false when
+// the field is absent, not a vector, or mis-dimensioned — exactly the
+// documents the ANN backends never index. The closure owns a scratch buffer;
+// a query executes single-threaded.
+func knnDistFromDoc(vi *vectorIndex, qv []float32) func(doc *anyenc.Value) (float32, bool) {
+	dist := vindex.DistanceFor(vi.info.Vector.Metric.toVindex())
+	buf := make([]float32, 0, vi.dim)
+	return func(doc *anyenc.Value) (float32, bool) {
+		v := doc.Get(vi.fieldPath...)
+		if v == nil {
+			return 0, false
+		}
+		switch v.Type() {
+		case anyenc.TypeVectorF32:
+			vec, err := v.VectorF32()
+			if err != nil || len(vec) != vi.dim {
+				return 0, false
+			}
+			return dist(qv, vec), true
+		case anyenc.TypeArray:
+			arr, err := v.Array()
+			if err != nil || len(arr) != vi.dim {
+				return 0, false
+			}
+			buf = buf[:0]
+			for _, el := range arr {
+				f, ferr := el.Float64()
+				if ferr != nil {
+					return 0, false
+				}
+				buf = append(buf, float32(f))
+			}
+			return dist(qv, buf), true
+		}
+		return 0, false
+	}
+}
+
 func (c *collection) bruteVectorCandidates(tx *btree.ReadTx, vi *vectorIndex, qv []float32, topK int) ([]qplanner.VectorCandidate, error) {
 	dist := vindex.DistanceFor(vi.info.Vector.Metric.toVindex())
 	cursor := tx.NewCursor(c.ns)

--- a/vector_index_test.go
+++ b/vector_index_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -419,5 +420,194 @@ func TestVectorIndex_Reopen(t *testing.T) {
 		for j := range post {
 			assert.Equal(t, pre[i][j].DocId, post[j].DocId, "result drift after reopen q%d", i)
 		}
+	}
+}
+
+// ---- $knn driver/probe plan duality ---------------------------------------
+
+// knnPlanHints force each $knn plan form: the vector index name forces the ANN
+// driver, the pk field the pk probe, a secondary index name its probe.
+var knnPlanHints = []struct {
+	name string
+	hint []IndexHint
+}{
+	{"cbo", nil},
+	{"driver", []IndexHint{{IndexName: "emb", Boost: 1 << 30}}},
+	{"probe-ids", []IndexHint{{IndexName: "id", Boost: 1 << 30}}},
+	{"probe-a", []IndexHint{{IndexName: "a", Boost: 1 << 30}}},
+}
+
+// knnProbeColl builds a brute-or-ANN collection with a secondary index on "a".
+func knnProbeColl(t *testing.T, mode VectorMode, n, dim int) (Collection, [][]float32) {
+	fx := newFixture(t)
+	t.Cleanup(fx.finish)
+	coll, err := fx.CreateCollection(ctx, "knnprobe")
+	require.NoError(t, err)
+	makeVectorIndex(t, coll, mode, dim)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "a", Fields: []string{"a"}}))
+	vecs := vrand(n, dim, 7)
+	for i, vc := range vecs {
+		doc := anyenc.MustParseJson(vecDocJSON(i, vc))
+		doc.Set("a", anyenc.MustParseJson(fmt.Sprintf("%d", i%10)))
+		require.NoError(t, coll.Insert(ctx, doc))
+	}
+	return coll, vecs
+}
+
+func collectKnn(t *testing.T, q Query) (ids []int, dists []float32) {
+	t.Helper()
+	iter, err := q.Iter(ctx)
+	require.NoError(t, err)
+	defer iter.Close()
+	for iter.Next() {
+		doc, derr := iter.Doc()
+		require.NoError(t, derr)
+		ids = append(ids, doc.Value().GetInt("id"))
+		dists = append(dists, iter.Distance())
+	}
+	require.NoError(t, iter.Err())
+	return ids, dists
+}
+
+// knnCond builds $knn + restriction conditions programmatically (the
+// production construction path).
+func knnCond(qv []float32, k int, extra query.Filter) query.Filter {
+	knn := vectorKnnFilter(qv, k)
+	if extra == nil {
+		return knn
+	}
+	return query.And{knn, extra}
+}
+
+func idInFilter(ids ...int) query.Filter {
+	vals := make([]*anyenc.Value, len(ids))
+	for i, id := range ids {
+		vals[i] = anyenc.MustParseJson(fmt.Sprintf("%d", id))
+	}
+	return query.Key{Path: []string{"id"}, Filter: query.NewInValue(vals...)}
+}
+
+// On the brute-force backend the driver is exact too, so every plan must
+// produce identical rows, order, and distances.
+func TestKnnProbe_BruteDifferential(t *testing.T) {
+	const dim, n, k = 12, 300, 8
+	coll, vecs := knnProbeColl(t, VectorModeBruteForce, n, dim)
+
+	conds := []query.Filter{
+		knnCond(vecs[5], k, idInFilter(3, 15, 27, 42, 55, 63, 78, 81, 99, 120, 150, 999)),
+		knnCond(vecs[5], k, query.MustParseCondition(`{"a":3}`)),
+		knnCond(vecs[9], k, nil),
+	}
+	for ci, cond := range conds {
+		var baseIds []int
+		var baseDists []float32
+		for _, p := range knnPlanHints {
+			q := coll.Find(cond)
+			if len(p.hint) > 0 {
+				q = q.IndexHint(p.hint...)
+			}
+			ids, dists := collectKnn(t, q)
+			if p.name == "cbo" {
+				baseIds, baseDists = ids, dists
+				continue
+			}
+			require.Equal(t, baseIds, ids, "cond %d plan %s: rows diverged", ci, p.name)
+			require.Equal(t, baseDists, dists, "cond %d plan %s: distances diverged", ci, p.name)
+		}
+	}
+}
+
+// Under a selective filter the exact probe must return the TRUE k nearest
+// filter survivors — computed here by a brute oracle — and the CBO must route
+// the restricted shapes to it. The ANN driver (post-filter) has no such
+// guarantee; this is the recall fix, not just the perf fix.
+func TestKnnProbe_ExactUnderFilter(t *testing.T) {
+	const dim, n, k = 12, 400, 10
+	coll, vecs := knnProbeColl(t, VectorModeBTree, n, dim)
+
+	// Oracle: true k nearest among docs with a == 3 (L2).
+	q := vecs[123]
+	type oc struct {
+		id int
+		d  float64
+	}
+	var all []oc
+	for i, vc := range vecs {
+		if i%10 != 3 {
+			continue
+		}
+		var sum float64
+		for d := 0; d < dim; d++ {
+			diff := float64(vc[d]) - float64(q[d])
+			sum += diff * diff
+		}
+		all = append(all, oc{i, sum})
+	}
+	slices.SortFunc(all, func(x, y oc) int {
+		if x.d != y.d {
+			return cmp.Compare(x.d, y.d)
+		}
+		return cmp.Compare(x.id, y.id)
+	})
+	want := make([]int, k)
+	for i := range want {
+		want[i] = all[i].id
+	}
+
+	cond := knnCond(q, k, query.MustParseCondition(`{"a":3}`))
+	ids, _ := collectKnn(t, coll.Find(cond).IndexHint(IndexHint{IndexName: "a", Boost: 1 << 30}))
+	assert.Equal(t, want, ids, "probe plan must return the exact filtered k-nearest")
+	assert.Len(t, ids, k, "probe plan must fill k when enough docs pass the filter")
+
+	ex, err := coll.Find(cond).Explain(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, ex.Plan+ex.Sql, "KnnProbe", "selective filter must route to the probe plan")
+
+	broad, err := coll.Find(knnCond(q, k, nil)).Explain(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, broad.Plan+broad.Sql, "KnnSearch", "unrestricted $knn must keep the ANN driver")
+}
+
+// A probe plan must honor _distance residual predicates and _distance sorts
+// exactly like the driver (brute backend: bit-exact).
+func TestKnnProbe_DistanceResidualAndSort(t *testing.T) {
+	const dim, n, k = 12, 200, 12
+	coll, vecs := knnProbeColl(t, VectorModeBruteForce, n, dim)
+
+	restriction := idInFilter(1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53)
+	base := knnCond(vecs[13], k, restriction)
+
+	var driverIds, probeIds []int
+	for _, p := range []string{"emb", "id"} {
+		q := coll.Find(base).IndexHint(IndexHint{IndexName: p, Boost: 1 << 30}).Sort("-_distance")
+		ids, dists := collectKnn(t, q)
+		for i := 1; i < len(dists); i++ {
+			assert.GreaterOrEqual(t, dists[i-1], dists[i], "descending distance order")
+		}
+		if p == "emb" {
+			driverIds = ids
+		} else {
+			probeIds = ids
+		}
+	}
+	assert.Equal(t, driverIds, probeIds, "sorted-by-distance rows must match across plans")
+}
+
+// Bounded writes select the same rows under either plan form.
+func TestKnnProbe_DeleteMatchesIterSelection(t *testing.T) {
+	const dim, n, k = 12, 200, 5
+	coll, vecs := knnProbeColl(t, VectorModeBruteForce, n, dim)
+
+	restriction := idInFilter(0, 10, 20, 30, 40, 50, 60, 70, 80, 90)
+	cond := knnCond(vecs[30], k, restriction)
+	expect, _ := collectKnn(t, coll.Find(cond))
+	require.Len(t, expect, k)
+
+	res, err := coll.Find(cond).IndexHint(IndexHint{IndexName: "id", Boost: 1 << 30}).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, k, res.Modified)
+	for _, id := range expect {
+		_, gerr := coll.FindId(ctx, id)
+		assert.ErrorIs(t, gerr, ErrDocNotFound, "doc %d must be deleted", id)
 	}
 }

--- a/vector_index_test.go
+++ b/vector_index_test.go
@@ -611,3 +611,33 @@ func TestKnnProbe_DeleteMatchesIterSelection(t *testing.T) {
 		assert.ErrorIs(t, gerr, ErrDocNotFound, "doc %d must be deleted", id)
 	}
 }
+
+// A REVERSE-declared unique index chosen as the $knn probe driver goes
+// through CoverIter, which must receive un-finalized bounds — the
+// reverse-tail pad would double-pad its seek and silently select nothing.
+func TestKnnProbe_ReverseUniqueCoverDriver(t *testing.T) {
+	const dim = 8
+	fx := newFixture(t)
+	t.Cleanup(fx.finish)
+	coll, err := fx.CreateCollection(ctx, "knnrev")
+	require.NoError(t, err)
+	makeVectorIndex(t, coll, VectorModeBruteForce, dim)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "u", Fields: []string{"-u"}, Unique: true}))
+	vecs := vrand(60, dim, 21)
+	for i, vc := range vecs {
+		doc := anyenc.MustParseJson(vecDocJSON(i, vc))
+		doc.Set("u", anyenc.MustParseJson(fmt.Sprintf("%d", i)))
+		require.NoError(t, coll.Insert(ctx, doc))
+	}
+	for _, extra := range []query.Filter{
+		query.MustParseCondition(`{"u":9}`),
+		query.MustParseCondition(`{"u":{"$in":[3,17,42,99]}}`),
+	} {
+		cond := knnCond(vecs[9], 3, extra)
+		driverIds, driverDists := collectKnn(t, coll.Find(cond).IndexHint(IndexHint{IndexName: "emb", Boost: 1 << 30}))
+		probeIds, probeDists := collectKnn(t, coll.Find(cond).IndexHint(IndexHint{IndexName: "u", Boost: 1 << 30}))
+		require.NotEmpty(t, driverIds)
+		assert.Equal(t, driverIds, probeIds, "reverse-unique cover probe lost rows")
+		assert.Equal(t, driverDists, probeDists)
+	}
+}


### PR DESCRIPTION
`$text` and `$knn` queries now go through cost-based plan selection instead of unconditionally driving from the posting lists / ANN search. Each predicate has two enforcement forms:

- **driver** (as before): `FtsIter` walks the posting lists / `VectorIter` runs the ANN search; the rest of the filter is residual. The FTS driver additionally gates candidates against the query's primary-key bounds before the document fetch.
- **probe** (new): a bounded access path — fixed primary-key bounds, a bounded or sort-covering secondary index — enumerates candidates, and each one is verified against the text index individually (`FtsProbeIter`: docmap + docinfo + one postings-chunk point-get per term), or scored exactly against the query vector (`VectorScoreIter`, same vector source and kernel as the brute-force backend).

The CBO picks the cheaper form using exact per-term document frequencies (FTS) and the same sketch/interpolation estimates the ordinary planner uses. A restricted query now costs the restriction, not the posting list.

### Correctness contracts

- The FTS prober is **bit-identical** to the driver scan — shared clause compilation, same per-doc float summation order, presence-gated like `scanTerm` (a zero-weight field's posting still matches; a single-token quoted clause is a `scanTerm`, not a phrase). A bounded write selects rows by `(score desc, IntDocID asc)`, so plan choice must never change the selected rows.
- Relevance order is reproduced by the probe's rank mode with the driver's exact comparator; explicit sorts get the deterministic docId tie-break either way.
- `$knn` + filter means "the K nearest among filter-passing documents": the probe form is exact, so under a selective filter it is both faster and strictly better recall than post-filtering ANN candidates. On the brute-force backend the two forms are bit-identical.
- A `Count` whose residual is covered by the probe's driver fetches no documents.

Differential tests force every plan via `IndexHint` (fts/vector index name → driver, pk field name → pk probe, secondary index name → its probe) and assert identical rows, order, windowed counts, and bit-exact scores across a matrix of clause kinds (phrases, prefixes, require/exclude, `$defaultOperator`, weighted BM25F with zero-weight fields, custom K1/B, >64 required clauses, multi-chunk corpora, reverse-declared unique indexes) × restrictions × windows × sorts; `$knn` probes are checked against a brute-force oracle.

### Benchmarks (50k docs; `fts_restrict` / `vector_restrict` groups in any-store-tests)

| shape | before | after |
|---|---|---|
| `$text` common term + `id $in [30]`, limit 30 | 132.8 ms | 130 µs |
| same, `Count()` | 124.7 ms | 91 µs |
| `$text` + indexed equality (1% selectivity) | 26.9 ms | 1.5 ms |
| `$text` + `.Sort(indexed).Limit(10)` | 131.2 ms | 65 µs |
| `$text` prefix / phrase + 30-id restriction | 116 / 7.9 ms | 124 / 113 µs |
| `$text` require + 100-id restriction (hybrid re-check shape) | 120 ms | 961 µs |
| `$knn` + `id $in [30]` (IVFSQ) | 1.68 ms | 180 µs |
| unrestricted `$text` / `$knn`, broad filters | unchanged | unchanged |

Unrestricted queries skip the CBO assembly entirely (no probe candidate can exist), so the hot driver-only shapes pay nothing.

Also adds `query.Bounds.SortedDisjoint`/`ContainsSorted` (binary-search membership for the driver's pk gate) and documents the plan selection in the qplanner README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F65kxscuPnaLWGvoFSApD4
