### PR TITLE
chore(cli): bump any-store to v2.0.1

### DIFF
--- a/cmd/any-store-cli2/go.mod
+++ b/cmd/any-store-cli2/go.mod
@@ -3,7 +3,7 @@ module github.com/anyproto/any-store/cmd/any-store-cli2/v2
 go 1.25.0
 
 require (
-	github.com/anyproto/any-store/v2 v2.0.0
+	github.com/anyproto/any-store/v2 v2.0.1
 	github.com/fatih/color v1.19.0
 	github.com/peterh/liner v1.2.2
 	github.com/robertkrimen/otto v0.5.1

--- a/cmd/any-store-cli2/go.sum
+++ b/cmd/any-store-cli2/go.sum
@@ -1,5 +1,5 @@
-github.com/anyproto/any-store/v2 v2.0.0 h1:AcJ7WRJqOiWFD0CKeo66hsQsMlJ+Wb+R2MsdthUe6E4=
-github.com/anyproto/any-store/v2 v2.0.0/go.mod h1:vVxA3PD7k2vAt07zk4n7Zdt6LANmSSIlSWMNuLOLAT0=
+github.com/anyproto/any-store/v2 v2.0.1 h1:9Of+i0wzRqZx31lw9NLn7Isb1Pi5qSZFjRaOxJKY0Ho=
+github.com/anyproto/any-store/v2 v2.0.1/go.mod h1:Mw/A48qIY3anKfv4jaiTEvv/JhuMpPEp6VuxHn6lAeM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=


### PR DESCRIPTION
Points the CLI at any-store v2.0.1 (cost-based $text/$knn driver-probe plan selection, $size/$strlen operators, dependency bumps). Tagging `cmd/any-store-cli2/v2.0.1` on the merge commit triggers the binary release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F65kxscuPnaLWGvoFSApD4