### PR TITLE
feat(query): dotted paths through arrays of objects, $elemMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ exp, _ := users.Find(`{"name": "Jane"}`).Explain(ctx)
 fmt.Println(exp.Plan) // chosen index, cost breakdown, rejected candidates
 ```
 
-Array fields index every element (multikey). The cost-based planner picks the cheapest index per query; `IndexHint` overrides it.
+Array fields index every element (multikey), and a dotted path through an array of objects (`"items.sku"` over `{"items":[{"sku":1},{"sku":2}]}`) indexes one entry per element — the same MongoDB field-path semantics filters and sorts use; `$elemMatch` binds several predicates to one element. The cost-based planner picks the cheapest index per query; `IndexHint` overrides it.
 
 ## Full-text search
 

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -333,7 +333,29 @@ func TestCollection_AggregateLookup(t *testing.T) {
 		anyenc.MustParseJson(`{"id":"t1","tags":["x","y"],"ref":"b"}`),
 		anyenc.MustParseJson(`{"id":0,"label":"zero"}`),
 		anyenc.MustParseJson(`{"id":"mix","refs":[7,"a",7,true]}`),
+		anyenc.MustParseJson(`{"id":"nest","items":[{"ref":"b"},{"x":1},{"ref":["c","b"]},{"ref":null}]}`),
+		anyenc.MustParseJson(`{"id":"pos","refs":[["b","c"],["a"]]}`),
 	))
+
+	t.Run("positional local path naming an array", func(t *testing.T) {
+		got := aggRows(t, coll, coll.Aggregate(`[
+			{"$match": {"id": "pos"}},
+			{"$lookup": {"localField": "refs.0", "as": "linked"}},
+			{"$project": {"id": 1, "ids": "$linked.id"}}
+		]`))
+		assert.Equal(t, expectJson(t, `{"id":"pos","ids":["b","c"]}`), got)
+	})
+
+	t.Run("local path through an array of objects", func(t *testing.T) {
+		// items.ref collects every element's ref (a leaf array one level
+		// deep); missing and null contribute nothing; dedup as for arrays.
+		got := aggRows(t, coll, coll.Aggregate(`[
+			{"$match": {"id": "nest"}},
+			{"$lookup": {"localField": "items.ref", "as": "linked"}},
+			{"$project": {"id": 1, "ids": "$linked.id"}}
+		]`))
+		assert.Equal(t, expectJson(t, `{"id":"nest","ids":["b","c"]}`), got)
+	})
 
 	t.Run("single id", func(t *testing.T) {
 		got := aggRows(t, coll, coll.Aggregate(`[

--- a/anyenc/leaves.go
+++ b/anyenc/leaves.go
@@ -1,0 +1,200 @@
+package anyenc
+
+import "math"
+
+// Leaf is one value a dotted path resolves to (see Value.AppendLeaves).
+type Leaf struct {
+	// Value is the resolved value; nil is a missing leaf.
+	Value *Value
+	// Positional is set when the last path segment is numeric and picked
+	// this leaf out of an array by position. MongoDB compares such a leaf
+	// whole: {"a.0":1} does not look inside a first element [1,2], while
+	// {"a.b":1} does look inside a leaf array under b. Consumers honour it
+	// the same way (filters skip element iteration, index keys and sort keys
+	// take the whole value).
+	Positional bool
+}
+
+// AppendLeaves appends to dst every value the dotted path resolves to under
+// MongoDB's query-matcher field-path semantics and returns the extended
+// slice. dst is reused across calls, so the walk allocates nothing once its
+// capacity is warm.
+//
+// Resolution per path segment:
+//   - object: descend by key; an absent key is a missing leaf.
+//   - array, numeric segment: the element at that index; out of range is a
+//     missing leaf. Engine extension over Mongo, which also treats the numeral
+//     as a key of object elements.
+//   - array, other segment: the remaining path (this segment included) is
+//     mapped over the elements. An object element continues the walk; an
+//     element that cannot carry the path (scalar, null, nested array) is a
+//     missing leaf; an empty array is one missing leaf.
+//   - scalar or null met before the last segment: a missing leaf.
+//
+// A leaf that is itself an array is appended whole — the caller decides
+// whether to look inside it (filters do, per element, unless the leaf is
+// Positional; sorts take the extremum). With no array on the path the result
+// is exactly one entry, equal to Get(path...).
+//
+// Missing leaves are deliberate: they carry the "no value here" fact that
+// the null-equality family, $exists and sort keys all need, and keep every
+// consumer (filter, sort, index key) on one definition. Mongo's matcher
+// skips non-object elements instead, which is why its {"a.b":null} does not
+// match {"a":[1]} while its sort and index keys do treat it as null.
+func (v *Value) AppendLeaves(dst []Leaf, path ...string) []Leaf {
+	walkLeaves(v, path, func(l Leaf) { dst = append(dst, l) })
+	return dst
+}
+
+// GetLeaf is the fast path of AppendLeaves: when the path crosses no array
+// by a non-numeric segment and does not end in an array index, the leaf set
+// has exactly one non-positional entry and GetLeaf returns it (nil for a
+// missing leaf) with single=true, at the cost of Get. single=false means
+// the caller must resolve the full leaf set.
+func (v *Value) GetLeaf(path ...string) (leaf *Value, single bool) {
+	for i, seg := range path {
+		if v == nil {
+			return nil, true
+		}
+		switch v.t {
+		case TypeObject:
+			v = v.o.Get(seg)
+		case TypeArray:
+			n, ok := ParseIndexSegment(seg)
+			if !ok {
+				return nil, false
+			}
+			if n < 0 || n >= len(v.a) {
+				return nil, true
+			}
+			if i == len(path)-1 {
+				return nil, false // positional leaf
+			}
+			v = v.a[n]
+		default:
+			return nil, true
+		}
+	}
+	return v, true
+}
+
+// WalkLeaves calls fn for every leaf of the path, in AppendLeaves order,
+// without materialising the leaf set. fn must not retain the Leaf's Value
+// past the walk of a pooled document.
+func (v *Value) WalkLeaves(path []string, fn func(Leaf)) {
+	walkLeaves(v, path, fn)
+}
+
+func walkLeaves(v *Value, path []string, fn func(Leaf)) {
+	for i, seg := range path {
+		if v == nil {
+			fn(Leaf{})
+			return
+		}
+		switch v.t {
+		case TypeObject:
+			v = v.o.Get(seg)
+		case TypeArray:
+			if n, ok := ParseIndexSegment(seg); ok {
+				if n < 0 || n >= len(v.a) {
+					fn(Leaf{})
+					return
+				}
+				v = v.a[n]
+				if i == len(path)-1 {
+					fn(Leaf{Value: v, Positional: true})
+					return
+				}
+				continue
+			}
+			if len(v.a) == 0 {
+				fn(Leaf{})
+				return
+			}
+			rest := path[i:]
+			for _, el := range v.a {
+				if el.t == TypeObject {
+					walkLeaves(el, rest, fn)
+				} else {
+					fn(Leaf{})
+				}
+			}
+			return
+		default:
+			fn(Leaf{})
+			return
+		}
+	}
+	fn(Leaf{Value: v})
+}
+
+// AppendIndexValues appends the values an index stores for a leaf set, in
+// key order: a missing leaf as nil (it encodes as null), a scalar leaf as
+// itself, and a non-empty array leaf as each element followed by the array
+// itself — unless the leaf is Positional, which stores the array whole
+// only. One definition for index maintenance, index-order dedup and the
+// planner's key reasoning; sort keys differ only in never taking the whole
+// array (Value.WalkLeaves feeds them directly).
+func AppendIndexValues(dst []*Value, leaves []Leaf) []*Value {
+	for _, l := range leaves {
+		if l.Value != nil && l.Value.t == TypeArray && !l.Positional {
+			dst = append(dst, l.Value.a...)
+		}
+		dst = append(dst, l.Value)
+	}
+	return dst
+}
+
+// AppendElementValues appends the candidates a sort key is chosen from: the
+// same as AppendIndexValues minus the whole-array entry of a non-empty
+// array leaf (an empty array keeps it — that is its only entry). An ordered
+// index scan's canonical entry for a document is elected among these, so
+// the whole-array entry, which the scan meets before or after the elements
+// depending on direction and element types, never decides the order.
+func AppendElementValues(dst []*Value, leaves []Leaf) []*Value {
+	for _, l := range leaves {
+		if l.Value != nil && l.Value.t == TypeArray && !l.Positional && len(l.Value.a) > 0 {
+			dst = append(dst, l.Value.a...)
+			continue
+		}
+		dst = append(dst, l.Value)
+	}
+	return dst
+}
+
+// ParseIndexSegment reports whether seg is a numeric path segment and the
+// array index it names. It accepts strconv.Atoi syntax (optional sign,
+// decimal digits) without Atoi's allocating error path; a numeric segment
+// that cannot index anything (negative, overflowing) is reported as ok with
+// n = -1, so callers turn it into "out of range" exactly as Atoi's error
+// would.
+func ParseIndexSegment(seg string) (n int, ok bool) {
+	i := 0
+	neg := false
+	if len(seg) > 0 && (seg[0] == '+' || seg[0] == '-') {
+		neg = seg[0] == '-'
+		i = 1
+	}
+	if i == len(seg) {
+		return 0, false
+	}
+	for ; i < len(seg); i++ {
+		c := seg[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		if n > (math.MaxInt32-9)/10 { // pre-multiply guard: no int wrap on 32-bit
+			for ; i < len(seg); i++ {
+				if seg[i] < '0' || seg[i] > '9' {
+					return 0, false // "1725580800000_x": a key, not an index
+				}
+			}
+			return -1, true
+		}
+		n = n*10 + int(c-'0')
+	}
+	if neg && n != 0 {
+		return -1, true
+	}
+	return n, true
+}

--- a/anyenc/leaves_test.go
+++ b/anyenc/leaves_test.go
@@ -1,0 +1,210 @@
+package anyenc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// leavesString renders leaves as " | "-joined JSON, "missing" for nil, with
+// a "@" suffix on positional leaves.
+func leavesString(leaves []Leaf) string {
+	parts := make([]string, len(leaves))
+	for i, l := range leaves {
+		if l.Value == nil {
+			parts[i] = "missing"
+		} else {
+			parts[i] = l.Value.String()
+		}
+		if l.Positional {
+			parts[i] += "@"
+		}
+	}
+	return strings.Join(parts, " | ")
+}
+
+func TestAppendLeaves(t *testing.T) {
+	cases := []struct {
+		doc, path, want string
+	}{
+		// no array on the path: exactly Get's answer
+		{`{"a":{"b":1}}`, "a.b", `1`},
+		{`{"a":{"b":[1,2]}}`, "a.b", `[1,2]`},
+		{`{"a":5}`, "a.b", `missing`},
+		{`{}`, "a.b", `missing`},
+		{`{"a":null}`, "a.b", `missing`},
+		{`{"a":{"c":1}}`, "a.b", `missing`},
+		{`{"a":[1,2]}`, "a", `[1,2]`},
+		// array of objects: one leaf per element, in order
+		{`{"a":[{"b":1},{"b":2}]}`, "a.b", `1 | 2`},
+		{`{"a":[{"b":[1,2]}]}`, "a.b", `[1,2]`},
+		{`{"a":[{"b":1},{"c":2}]}`, "a.b", `1 | missing`},
+		{`{"a":[{"b":1},5,"s",null,[{"b":1}]]}`, "a.b", `1 | missing | missing | missing | missing`},
+		{`{"a":[]}`, "a.b", `missing`},
+		{`{"a":[1,2]}`, "a.b", `missing | missing`},
+		// traversal repeats at every array level
+		{`{"a":[{"b":[{"c":1},{"c":2}]}]}`, "a.b.c", `1 | 2`},
+		{`{"a":[{"b":[{"c":[1,2]}]}]}`, "a.b.c", `[1,2]`},
+		{`{"a":[{"b":{"c":[1,2]}},{"b":{"c":3}}]}`, "a.b.c", `[1,2] | 3`},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.b.c", `missing | missing`},
+		{`{"a":[{"b":[1,2]}]}`, "a.b.c", `missing | missing`},
+		{`{"a":[{"b":[]}]}`, "a.b.c", `missing`},
+		// numeric segments index arrays and are keys on objects
+		{`{"a":[{"b":1},{"b":2}]}`, "a.0.b", `1`},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.1.b", `2`},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.2.b", `missing`},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.-1.b", `missing`},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.+1.b", `2`},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.01.b", `2`},
+		{`{"a":{"0":{"b":7}}}`, "a.0.b", `7`},
+		{`{"a":[{"0":{"b":7}}]}`, "a.0.b", `missing`},
+		{`{"a":[[1,2],[3]]}`, "a.0", `[1,2]@`},
+		{`{"a":[1,2]}`, "a.1", `2@`},
+		{`{"a":{"0":[1,2]}}`, "a.0", `[1,2]`},
+		{`{"a":[{"b":[[1,2]]},{"b":{"0":[3]}}]}`, "a.b.0", `[1,2]@ | [3]`},
+		{`{"a":[[{"b":1}]]}`, "a.0.b", `1`},
+		{`{"a":[]}`, "a.0", `missing`},
+		{`{"a":[[{"b":1}]]}`, "a.b", `missing`},
+	}
+	var buf []Leaf
+	for _, c := range cases {
+		v := MustParseJson(c.doc)
+		buf = v.AppendLeaves(buf[:0], strings.Split(c.path, ".")...)
+		assert.Equal(t, c.want, leavesString(buf), "%s %s", c.doc, c.path)
+	}
+}
+
+// With no array crossed by a non-numeric segment the single leaf is Get's answer.
+func TestAppendLeaves_GetParity(t *testing.T) {
+	for _, c := range []struct{ doc, path string }{
+		{`{"a":{"b":1}}`, "a.b"}, {`{"a":{"b":[1,2]}}`, "a.b"}, {`{"a":5}`, "a.b"},
+		{`{}`, "a.b"}, {`{"a":null}`, "a.b"}, {`{"a":[1,2]}`, "a"},
+		{`{"a":[{"b":1},{"b":2}]}`, "a.1.b"}, {`{"a":[{"b":1}]}`, "a.2.b"},
+		{`{"a":[[1,2],[3]]}`, "a.0"}, {`{"a":[]}`, "a.0"}, {`{"a":{"0":{"b":7}}}`, "a.0.b"},
+	} {
+		v := MustParseJson(c.doc)
+		path := strings.Split(c.path, ".")
+		leaves := v.AppendLeaves(nil, path...)
+		require.Len(t, leaves, 1, "%s %s", c.doc, c.path)
+		got := v.Get(path...)
+		if got == nil {
+			assert.Nil(t, leaves[0].Value, "%s %s", c.doc, c.path)
+		} else {
+			require.NotNil(t, leaves[0].Value, "%s %s", c.doc, c.path)
+			assert.Equal(t, got.String(), leaves[0].Value.String(), "%s %s", c.doc, c.path)
+		}
+	}
+}
+
+// GetLeaf answers exactly when AppendLeaves yields one non-positional leaf,
+// and then agrees with it.
+func TestGetLeaf_AgreesWithAppendLeaves(t *testing.T) {
+	docs := []string{
+		`{"a":{"b":1}}`, `{"a":5}`, `{}`, `{"a":[]}`, `{"a":[1,2]}`, `{"a":[[1,2]]}`,
+		`{"a":[{"b":1},{"b":2}]}`, `{"a":[{"b":[1]}]}`, `{"a":{"0":{"b":7}}}`, `{"a":{"b":[{"c":1}]}}`,
+	}
+	paths := [][]string{{"a"}, {"a", "b"}, {"a", "0"}, {"a", "0", "b"}, {"a", "1", "b"}, {"a", "b", "c"}, {"a", "b", "0"}}
+	for _, d := range docs {
+		v := MustParseJson(d)
+		for _, p := range paths {
+			leaves := v.AppendLeaves(nil, p...)
+			got, single := v.GetLeaf(p...)
+			if single {
+				require.Len(t, leaves, 1, "%s %v", d, p)
+				assert.False(t, leaves[0].Positional, "%s %v", d, p)
+				assert.Equal(t, leavesString(leaves), leavesString([]Leaf{{Value: got}}), "%s %v", d, p)
+			} else {
+				assert.True(t, len(leaves) > 1 || leaves[0].Positional || strings.Contains(d, "["), "%s %v", d, p)
+			}
+		}
+	}
+}
+
+func TestAppendLeaves_NilAndEmptyPath(t *testing.T) {
+	var nilV *Value
+	require.Equal(t, "missing", leavesString(nilV.AppendLeaves(nil, "a")))
+	v := MustParseJson(`{"a":1}`)
+	require.Equal(t, `{"a":1}`, leavesString(v.AppendLeaves(nil)))
+}
+
+func TestAppendLeaves_AllocFree(t *testing.T) {
+	v := MustParseJson(`{"a":[{"b":[{"c":1},{"c":2}]},{"b":[{"c":3}]},{"x":1},5]}`)
+	path := []string{"a", "b", "c"}
+	buf := v.AppendLeaves(nil, path...)
+	allocs := testing.AllocsPerRun(100, func() {
+		buf = v.AppendLeaves(buf[:0], path...)
+	})
+	assert.Zero(t, allocs)
+	assert.Equal(t, "1 | 2 | 3 | missing | missing", leavesString(buf))
+}
+
+func valuesString(vals []*Value) string {
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		if v == nil {
+			parts[i] = "null"
+		} else {
+			parts[i] = v.String()
+		}
+	}
+	return strings.Join(parts, " | ")
+}
+
+func TestAppendIndexAndElementValues(t *testing.T) {
+	cases := []struct{ doc, path, index, elements string }{
+		{`{"a":1}`, "a", `1`, `1`},
+		{`{}`, "a", `null`, `null`},
+		{`{"a":[]}`, "a", `[]`, `[]`},
+		{`{"a":[1,2]}`, "a", `1 | 2 | [1,2]`, `1 | 2`},
+		{`{"a":[[1],2]}`, "a", `[1] | 2 | [[1],2]`, `[1] | 2`},
+		{`{"a":[[1,2],[3]]}`, "a.0", `[1,2]`, `[1,2]`}, // positional: whole only
+		{`{"a":[{"b":1},{"b":[2,3]},{"c":1},{"b":[]}]}`, "a.b", `1 | 2 | 3 | [2,3] | null | []`, `1 | 2 | 3 | null | []`},
+	}
+	var leaves []Leaf
+	var vals []*Value
+	for _, c := range cases {
+		v := MustParseJson(c.doc)
+		leaves = v.AppendLeaves(leaves[:0], strings.Split(c.path, ".")...)
+		vals = AppendIndexValues(vals[:0], leaves)
+		assert.Equal(t, c.index, valuesString(vals), "index %s %s", c.doc, c.path)
+		vals = AppendElementValues(vals[:0], leaves)
+		assert.Equal(t, c.elements, valuesString(vals), "elements %s %s", c.doc, c.path)
+	}
+}
+
+func TestWalkLeaves_MatchesAppendLeaves_AllocFree(t *testing.T) {
+	v := MustParseJson(`{"a":[{"b":[{"c":1},{"c":2}]},{"b":[{"c":3}]},{"x":1},5,{"b":{"c":[4]}}]}`)
+	path := []string{"a", "b", "c"}
+	want := v.AppendLeaves(nil, path...)
+	var got []Leaf
+	v.WalkLeaves(path, func(l Leaf) { got = append(got, l) })
+	assert.Equal(t, leavesString(want), leavesString(got))
+	n := 0
+	allocs := testing.AllocsPerRun(100, func() {
+		v.WalkLeaves(path, func(l Leaf) { n++ })
+	})
+	assert.Zero(t, allocs)
+}
+
+func TestParseIndexSegment(t *testing.T) {
+	cases := []struct {
+		seg string
+		n   int
+		ok  bool
+	}{
+		{"0", 0, true}, {"7", 7, true}, {"+3", 3, true}, {"01", 1, true},
+		{"-1", -1, true}, {"-0", 0, true}, {"99999999999999999999", -1, true},
+		{"1725580800000_x", 0, false}, {"99999999999999999999x", 0, false},
+		{"", 0, false}, {"+", 0, false}, {"-", 0, false}, {"a", 0, false},
+		{"1a", 0, false}, {" 1", 0, false}, {"1 ", 0, false}, {"1.0", 0, false},
+	}
+	for _, c := range cases {
+		n, ok := ParseIndexSegment(c.seg)
+		assert.Equal(t, c.ok, ok, c.seg)
+		if ok {
+			assert.Equal(t, c.n, n, c.seg)
+		}
+	}
+}

--- a/anyenc/value.go
+++ b/anyenc/value.go
@@ -93,8 +93,8 @@ func (v *Value) Get(keys ...string) *Value {
 				return nil
 			}
 		} else if v.t == TypeArray {
-			n, err := strconv.Atoi(key)
-			if err != nil || n < 0 || n >= len(v.a) {
+			n, ok := ParseIndexSegment(key)
+			if !ok || n < 0 || n >= len(v.a) {
 				return nil
 			}
 			v = v.a[n]

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -253,6 +253,10 @@ resolves the value(s) as primary keys of the **same collection**, and sets
 to the array of matched full documents — always an array (Mongo semantics),
 empty when nothing matches.
 
+- `localField` resolves with field-path semantics: a path through an array
+  of objects (`"items.ref"`) collects every element's value, and a leaf
+  array contributes its elements one level deep; null, missing and array
+  values match nothing.
 - Omitting `from` is the canonical form — the stage is self-join-only, so
   the source collection is implied. When present, `from` must equal the
   aggregated collection's name; anything else fails `Iter`/`Count`/`Explain`

--- a/docs/query-filter-contract.md
+++ b/docs/query-filter-contract.md
@@ -191,3 +191,81 @@ build per query and carry no such guarantee.
     Pinned by `TestComp_TypeBracketing`, `TestCompOkScalar_MatchesMarshalReference`
     (the oracle carries the rule) and `TestGuaranteesPresence` (`$lt`/`$lte`
     with a non-null operand guarantee presence: they reject null and missing).
+
+14. **Dotted paths traverse arrays of objects (MongoDB field-path
+    semantics).** A path resolves to a LEAF SET (`anyenc.Value.AppendLeaves`):
+    an object descends by key; an array met by a non-numeric segment maps the
+    rest of the path over its elements — an object element continues, an
+    element that cannot carry the path (scalar, null, nested array, object
+    lacking the key) is a MISSING leaf, and an empty array is one missing
+    leaf; a scalar met mid-path is a missing leaf. `{"a.b":1}` matches
+    `{"a":[{"b":1},{"b":2}]}`; traversal repeats at every array level. A leaf
+    that is itself an array keeps the element-wise rules of item 13 (whole
+    array for an array operand, per element otherwise).
+    Quantification is per operator, as in Mongo: a positive predicate
+    (`$eq`, ranges, `$in`, `$regex`, `$exists`, `$type`, `$size`) matches when
+    ANY leaf satisfies it; a negation (`$ne`, `$nin`, `$not`, `$nor`) when NO
+    leaf satisfies the negated predicate; sibling operators on one path pick
+    their witnesses independently — `{"a.b":{"$gt":1,"$lt":3}}` matches
+    `[{"b":1},{"b":5}]`. `$elemMatch` (item 15) binds them.
+    A NUMERIC segment indexes an array (`"a.0"`, engine extension over
+    Mongo's positional-or-key ambiguity) and the leaf it picks is POSITIONAL:
+    compared whole even when it is an array (`{"a.0":1}` does not match
+    `{"a":[[1,2]]}`; `{"a.0":[1,2]}` does), stored whole by an index, and its
+    whole value is its sort key. Traversal resumes on later segments.
+    One definition feeds every consumer: `Key.Ok` (`LeafFilter`), index
+    entries (one per `anyenc.AppendIndexValues` value, fanning out like a
+    leaf array — the multikey flag, per-doc dedup and sparse handling follow;
+    a sparse index holds a document only when every field has a present,
+    non-null value somewhere in it, and then writes every key that has at
+    least one present field — `{"a":[{"b":1},{"c":2}]}` under a sparse
+    `(a.b, a.c)` has keys `(1, null)` and `(null, 2)`; fields of a COMPOUND
+    index that run
+    through the same array iterate it together, one entry per element, as
+    Mongo generates them — never a cross product — so the planner compounds
+    bounds and entry-level cover filters across such fields only on a
+    scalar-proven index and seeks the first of them otherwise), sort keys
+    (min/max over
+    `anyenc.AppendElementValues`, item 10) and `CanonicalKeyDedupIter`. The
+    raw fast paths (`OkRaw`, `AppendKeyRaw`) decline at an array container
+    and fall back to the parsed document. `$type` matches an array whose
+    ELEMENT has the type as well as the array itself (`"array"`), and
+    accepts Mongo's `"bool"` alias.
+    Deliberate divergences from Mongo, pinned by the MongoDB-fixture replay
+    `TestMongoArraySemantics` in the `any-store-tests` repository: (a) the null-equality
+    family (`$eq null`, `$in [null]`, and their negations) matches a missing
+    leaf produced by an element that cannot carry the path or by an empty
+    array — Mongo's matcher skips those elements, though its sort and index
+    keys treat them as null; any-store keeps filter, sort and index on one
+    answer; (b) numeric segments never match an object element keyed by the
+    numeral; (c) an empty leaf array sorts by its whole-array key (item 10)
+    and cross-type order is anyenc tag order (item 13) — Mongo sorts `[]`
+    before null and orders objects type-first, then by field name.
+    Pinned by `TestKey_PathThroughArrays`, `TestKey_PathThroughArrays_AllocFree`
+    (item 2 holds for traversal), `anyenc.TestAppendLeaves` and
+    `TestIndex_ArrayNested_NestedField_IntermediateArray_Traversed`.
+
+15. **`$elemMatch` binds predicates to one element.** `{"a":{"$elemMatch":
+    C}}` matches when `a` is an array with an element satisfying `C` as a
+    whole. The operand's first key decides the form (Mongo's rule): a
+    field-level operator (`$gt`, `$in`, `$not`, `$elemMatch`, …) makes the
+    VALUE form — `C` is an operator set applied to each element as ONE value
+    (`ElemFilter`: an element that is itself an array is compared whole, as a
+    positional leaf is); anything else (a field name, `{}`, `$or`/`$and`/
+    `$nor`) makes the OBJECT form — `C` is a document condition applied to
+    each OBJECT element (Mongo also admits array elements, viewed as objects
+    keyed by position; here they never match). `$all` accepts a list made
+    only of `{"$elemMatch": …}` objects (a conjunction of element matches;
+    mixing with values is a `ParseError`). `$text` and `$knn` are rejected
+    inside either form. Through a dotted path it applies to every leaf array,
+    positional leaves included.
+    Bounds: the value form contributes `C`'s own bounds on the field (an
+    element's value is one of the field's entries) unless the path is
+    positional; the object form re-keys `C` under the sub-fields —
+    `{"a":{"$elemMatch":{"b":{"$gt":1}}}}` bounds `a.b` as `{"a.b":{"$gt":1}}`
+    would. Both are supersets, never the exact value image (a scalar or an
+    object with that value sits in the bounds without matching), so a `Key`
+    holding a `$elemMatch` always keeps its residual filter: the planner's
+    covering-count, verify-chain and residual-elision paths treat it as
+    uncovered (`keyBoundsExact`). Pinned by `TestElemMatch_Parse`,
+    `TestElemMatch_Ok` and `TestElemMatch_IndexBoundsAndString`.

--- a/fulltext_query_ops_test.go
+++ b/fulltext_query_ops_test.go
@@ -242,7 +242,6 @@ func TestFtsCount_MatchesIterAcrossWindows(t *testing.T) {
 	}
 }
 
-
 // $text inside an open write tx must see the tx's own uncommitted full-text
 // writes — the same view on every verb — and a rollback must discard them.
 // Previously Count/Iter matched against stale committed postings while
@@ -283,4 +282,38 @@ func TestFtsReadYourWrites_InsideWriteTx(t *testing.T) {
 	count, err = coll.Find(q).Count(ctx)
 	require.NoError(t, err)
 	assert.Zero(t, count)
+}
+
+// A $text plan driven by a sparse index over a path through an array of
+// objects: the index-order dedup must elect among the entries the sparse
+// index wrote, never a null/missing leaf.
+func TestFtsOps_SparseTraversedIndexKeepsDocs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		sparse bool
+	}{{"sparse", true}, {"dense", false}} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newFixture(t)
+			coll, err := fx.CreateCollection(ctx, "ops")
+			require.NoError(t, err)
+			require.NoError(t, coll.EnsureIndex(ctx,
+				IndexInfo{Kind: IndexKindFulltext, Fields: []string{"text"}},
+				IndexInfo{Name: "a.b", Fields: []string{"a.b"}, Sparse: tc.sparse},
+			))
+			insertJSON(t, coll,
+				`{"id":"d1","text":"alpha","a":[{"c":1},{"b":[1,2]}]}`,
+				`{"id":"d2","text":"alpha","a":[{"b":[3,4]},{"c":2}]}`,
+				`{"id":"d3","text":"alpha","a":[{"b":[5,6]},{"b":[7,8]}]}`,
+			)
+			filter := `{"$text":{"$search":"alpha"},"a.b":{"$size":2}}`
+			hint := IndexHint{IndexName: "a.b", Boost: 1_000_000}
+			for _, sort := range []string{"a.b", "-a.b"} {
+				q := coll.Find(filter).IndexHint(hint).Sort(sort)
+				assert.Equal(t, []string{"d1", "d2", "d3"}, sortedIDs(collectIdsString(t, q)), sort)
+			}
+			n, err := coll.Find(filter).IndexHint(hint).Count(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, 3, n)
+		})
+	}
 }

--- a/index.go
+++ b/index.go
@@ -232,6 +232,13 @@ type IndexInfo struct {
 	// consistent with query matching, where {field: null} matches both a null
 	// and a missing field.
 	//
+	// Over a path through an array of objects the rule is per document: each
+	// indexed field must hold a present value in SOME element. Every key is
+	// then written unless all of its fields are null or missing in that
+	// element — {"a":[{"b":1},{"c":2}]} under (a.b, a.c) has keys (1, null)
+	// and (null, 2) — so a document that matches through different elements
+	// is still reachable by the seek on the leading field.
+	//
 	// As a consequence, the planner only uses a sparse index for a query that
 	// guarantees every indexed field is present and non-null; otherwise it would
 	// silently drop matching documents the index never stored. In particular a
@@ -371,15 +378,17 @@ type index struct {
 	// in keysBuf[k] just past field L's encoding, so keysBuf[k][:keyBoundsBuf[k][L]]
 	// is the level-L prefix fed to the multi-level sketch.
 	keyBoundsBuf [][]int
-	// curBounds is scratch (len == number of index fields) holding the field-end
-	// offsets of the key currently being built by writeValues; copied into
-	// keyBoundsBuf at each leaf.
-	curBounds   []int
-	uniqBuf     [][]anyenc.Tuple
-	fullKeyBuf  anyenc.Tuple // reusable buffer for full keys (key+docId)
-	seekBuf     anyenc.Tuple // reusable buffer for unique constraint seek results
-	uniqSeekBuf anyenc.Tuple // reusable buffer for the padded unique-probe seek key
-	mkBuf       []byte       // reusable buffer for the multikey-flag check-and-put read
+	// fields is writeValues' per-field scratch, indexed by field position and
+	// reset once per document (resetFields).
+	fields      []fieldScratch
+	rebinds     []rebind        // stack of rebound fields across nested fan-outs
+	shared      int             // later fields currently rebound: level dedup is off
+	rebound     bool            // some field was rebound for this document: keys dedup whole
+	valBuf      []*anyenc.Value // stack of a leaf array's index values
+	fullKeyBuf  anyenc.Tuple    // reusable buffer for full keys (key+docId)
+	seekBuf     anyenc.Tuple    // reusable buffer for unique constraint seek results
+	uniqSeekBuf anyenc.Tuple    // reusable buffer for the padded unique-probe seek key
+	mkBuf       []byte          // reusable buffer for the multikey-flag check-and-put read
 }
 
 // loadPubSketch returns the published reader snapshot. Lock-free; the returned
@@ -441,11 +450,8 @@ func (idx *index) cloneWithNs(ns *btree.Namespace, nsName string, catalogKey []b
 		reverse:        idx.reverse,
 		sketch:         idx.sketch,
 		sketchModified: idx.sketchModified,
-		// uniqBuf and curBounds are indexed by field position, not appended —
-		// they must be pre-sized like init does.
-		uniqBuf:   make([][]anyenc.Tuple, len(idx.fieldPaths)),
-		curBounds: make([]int, len(idx.fieldPaths)),
 	}
+	n.initScratch()
 	// cboInfo embeds the namespace handle — rebuild it around the new one.
 	cbo := *idx.cboInfo
 	cbo.Ns = ns
@@ -484,10 +490,18 @@ func (idx *index) init() (err error) {
 		idx.fieldPaths = append(idx.fieldPaths, fields)
 		idx.reverse = append(idx.reverse, reverse)
 	}
-	idx.uniqBuf = make([][]anyenc.Tuple, len(idx.fieldPaths))
-	idx.curBounds = make([]int, len(idx.fieldPaths))
+	idx.initScratch()
 
 	// Build cached CBO index info once (avoids per-query allocation)
+	sharedFrom := len(idx.fieldPaths)
+	for j := 1; j < len(idx.fieldPaths) && sharedFrom == len(idx.fieldPaths); j++ {
+		for i := 0; i < j; i++ {
+			if idx.fieldPaths[i][0] == idx.fieldPaths[j][0] {
+				sharedFrom = j
+				break
+			}
+		}
+	}
 	idx.cboInfo = &qplanner.IndexInfo{
 		Name:       idx.info.Name,
 		FieldNames: idx.fieldNames,
@@ -496,6 +510,7 @@ func (idx *index) init() (err error) {
 		Unique:     idx.info.Unique,
 		Sparse:     idx.info.Sparse,
 		Ns:         idx.ns,
+		SharedFrom: sharedFrom,
 	}
 	return nil
 }
@@ -672,22 +687,194 @@ func (idx *index) applySketch(ki, prevKi int, inc bool) {
 	}
 }
 
-func (idx *index) writeKey() {
+// writeKey appends the key being built and reports whether it was written:
+// a sparse index skips a key whose fields are all null or missing.
+func (idx *index) writeKey() bool {
+	if idx.info.Sparse {
+		any := false
+		for i := range idx.fields {
+			if idx.fields[i].present {
+				any = true
+				idx.fields[i].seen = true
+			}
+		}
+		if !any {
+			return false
+		}
+	}
+	if idx.rebound {
+		for _, k := range idx.keysBuf {
+			if bytes.Equal(k, idx.keyBuf) {
+				return true
+			}
+		}
+	}
 	nl := len(idx.keysBuf) + 1
 	idx.keysBuf = slices.Grow(idx.keysBuf, nl)[:nl]
 	idx.keysBuf[nl-1] = append(idx.keysBuf[nl-1][:0], idx.keyBuf...)
 	idx.keyBoundsBuf = slices.Grow(idx.keyBoundsBuf, nl)[:nl]
-	idx.keyBoundsBuf[nl-1] = append(idx.keyBoundsBuf[nl-1][:0], idx.curBounds...)
+	bounds := idx.keyBoundsBuf[nl-1][:0]
+	for i := range idx.fields {
+		bounds = append(bounds, idx.fields[i].curBound)
+	}
+	idx.keyBoundsBuf[nl-1] = bounds
+	return true
 }
 
-func (idx *index) writeValues(d *anyenc.Value, i int) bool {
+// writeValues appends, for field i, one key per value the field stores for
+// this document, each continued into field i+1 depth-first, and reports
+// whether any full key was written. A sparse index skips a key whose fields
+// are all null or missing, and drops the document when some field is null
+// or missing in every key (fillKeysBuf).
+//
+// Field i resolves from fields[i].root at segment .consumed (the whole document
+// at segment 0 unless an earlier field rebound it — see resolveField): a
+// path through an array of objects fans out one entry per element, like a
+// leaf array does, and fields that run through the SAME array iterate it
+// together, one key per element, never as a cross product.
+func (idx *index) writeValues(i int) bool {
 	if i == len(idx.fieldPaths) {
-		idx.writeKey()
-		return true
+		return idx.writeKey()
 	}
-	v := d.Get(idx.fieldPaths[i]...)
-	if idx.info.Sparse && (v == nil || v.Type() == anyenc.TypeNull) {
+	idx.fields[i].keyPrefix = len(idx.keyBuf)
+	root, seg := idx.fields[i].root, idx.fields[i].consumed
+	// One scalar leaf — the common field — needs no fan-out bookkeeping.
+	if leaf, single := root.GetLeaf(idx.fieldPaths[i][seg:]...); single && (leaf == nil || leaf.Type() != anyenc.TypeArray) {
+		idx.fields[i].dedup = false
+		return idx.emitLeaf(i, anyenc.Leaf{Value: leaf})
+	}
+	// Several values under one prefix (an array, or fan-out) may repeat —
+	// {"a":[{"b":1},{"b":1}]} — and must yield one entry.
+	idx.fields[i].dedup = true
+	idx.fields[i].uniq = idx.fields[i].uniq[:0]
+	return idx.resolveField(i, root, seg)
+}
+
+// resolveField walks field i's path from segment seg at v and emits every
+// leaf (anyenc.Value.AppendLeaves semantics). At an array met by a
+// non-numeric segment, every later field whose path reaches this same array
+// is rebound to the element being visited, so its own walk continues inside
+// that element — MongoDB's key generation for fields sharing an array.
+func (idx *index) resolveField(i int, v *anyenc.Value, seg int) bool {
+	path := idx.fieldPaths[i]
+	for ; seg < len(path); seg++ {
+		if v == nil {
+			return idx.emitLeaf(i, anyenc.Leaf{})
+		}
+		switch v.Type() {
+		case anyenc.TypeObject:
+			v = v.Get(path[seg])
+		case anyenc.TypeArray:
+			arr, _ := v.Array()
+			if n, ok := anyenc.ParseIndexSegment(path[seg]); ok {
+				if n < 0 || n >= len(arr) {
+					return idx.emitLeaf(i, anyenc.Leaf{})
+				}
+				v = arr[n]
+				if seg == len(path)-1 {
+					return idx.emitLeaf(i, anyenc.Leaf{Value: v, Positional: true})
+				}
+				continue
+			}
+			if len(arr) == 0 {
+				return idx.emitLeaf(i, anyenc.Leaf{})
+			}
+			mark := len(idx.rebinds)
+			shared := 0
+			for j := i + 1; j < len(idx.fieldPaths); j++ {
+				if idx.sharesArray(j, i, seg) {
+					idx.rebinds = append(idx.rebinds, rebind{j, idx.fields[j].root, idx.fields[j].consumed})
+					shared++
+				}
+			}
+			// Field i's own context moves into the element too, so a deeper
+			// fan-out compares later fields against where this walk stands.
+			idx.rebinds = append(idx.rebinds, rebind{i, idx.fields[i].root, idx.fields[i].consumed})
+			idx.shared += shared
+			if shared > 0 {
+				idx.rebound = true
+			}
+			wrote := false
+			for _, el := range arr {
+				for _, rb := range idx.rebinds[mark:] {
+					idx.fields[rb.field].root, idx.fields[rb.field].consumed = el, seg
+				}
+				var ok bool
+				if el.Type() == anyenc.TypeObject {
+					ok = idx.resolveField(i, el, seg)
+				} else {
+					ok = idx.emitLeaf(i, anyenc.Leaf{})
+				}
+				wrote = wrote || ok
+			}
+			for _, rb := range idx.rebinds[mark:] {
+				idx.fields[rb.field].root, idx.fields[rb.field].consumed = rb.root, rb.consumed
+			}
+			clear(idx.rebinds[mark:])
+			idx.rebinds = idx.rebinds[:mark]
+			idx.shared -= shared
+			return wrote
+		default:
+			return idx.emitLeaf(i, anyenc.Leaf{})
+		}
+	}
+	return idx.emitLeaf(i, anyenc.Leaf{Value: v})
+}
+
+// fieldScratch is one index field's state while writeValues builds a
+// document's keys. Laid out widest first — pointer, slice header, ints, then
+// the bools — so it packs into 64 bytes with no interior padding.
+type fieldScratch struct {
+	root      *anyenc.Value  // value the field resolves from (rebound inside a shared array)
+	uniq      []anyenc.Tuple // values already written under the current prefix
+	consumed  int            // path segments already resolved by root
+	keyPrefix int            // len(keyBuf) at this field's level
+	curBound  int            // len(keyBuf) past this field's value in the key being built
+	dedup     bool           // the values under one prefix may repeat
+	present   bool           // the value in the key being built is non-null
+	seen      bool           // some key of this document had the field present
+}
+
+// rebind records a later field's root before an array fan-out rebinds it to
+// the element under visit.
+type rebind struct {
+	field    int
+	root     *anyenc.Value
+	consumed int
+}
+
+// sharesArray reports whether field j, resolved from the same root and
+// segment as field i, reaches the array field i fans out on at segment seg
+// and continues into its elements (a numeric segment there would index the
+// array instead, and a path ending at the array names the array itself).
+func (idx *index) sharesArray(j, i, seg int) bool {
+	pj, pi := idx.fieldPaths[j], idx.fieldPaths[i]
+	if len(pj) <= seg || idx.fields[j].root != idx.fields[i].root || idx.fields[j].consumed != idx.fields[i].consumed {
 		return false
+	}
+	for k := idx.fields[i].consumed; k < seg; k++ {
+		if pj[k] != pi[k] {
+			return false
+		}
+	}
+	_, numeric := anyenc.ParseIndexSegment(pj[seg])
+	return !numeric
+}
+
+// emitLeaf writes field i's index values for one leaf — the value, or each
+// element followed by the array itself for a non-positional array leaf
+// (anyenc.AppendIndexValues) — each continued into field i+1.
+func (idx *index) emitLeaf(i int, l anyenc.Leaf) bool {
+	var one [1]*anyenc.Value
+	vals := one[:]
+	one[0] = l.Value
+	vb := len(idx.valBuf)
+	if l.Value != nil && l.Value.Type() == anyenc.TypeArray && !l.Positional {
+		if arr, _ := l.Value.Array(); len(arr) > 0 {
+			idx.valBuf = append(idx.valBuf, arr...)
+			idx.valBuf = append(idx.valBuf, l.Value)
+			vals = idx.valBuf[vb:]
+		}
 	}
 
 	// Reverse-flagged fields are stored bitwise-inverted so a single forward
@@ -697,63 +884,89 @@ func (idx *index) writeValues(d *anyenc.Value, i int) bool {
 	// value flag are NEVER inverted. Inversion is a bijection, so the unique
 	// dedup (isUnique) and unique-constraint seek still compare correctly.
 	reverse := i < len(idx.reverse) && idx.reverse[i]
-
-	k := idx.keyBuf
-	if v != nil && v.Type() == anyenc.TypeArray {
-		arr, _ := v.Array()
-		if len(arr) != 0 {
-			idx.uniqBuf[i] = idx.uniqBuf[i][:0]
-			for _, av := range arr {
-				if reverse {
-					idx.keyBuf = anyenc.Tuple(k).AppendInverted(av)
-				} else {
-					idx.keyBuf = av.MarshalTo(k)
-				}
-				if idx.isUnique(i, idx.keyBuf) {
-					idx.curBounds[i] = len(idx.keyBuf)
-					if !idx.writeValues(d, i+1) {
-						return false
-					}
-				}
-			}
+	k := idx.keyBuf[:idx.fields[i].keyPrefix]
+	wrote := false
+	for _, v := range vals {
+		if reverse {
+			idx.keyBuf = anyenc.Tuple(k).AppendInverted(v)
+		} else {
+			idx.keyBuf = v.MarshalTo(k)
+		}
+		// A value's subtree is fixed by the value alone only while no later
+		// field is rebound (it then resolves from its own root either way);
+		// under a rebind two equal values can head different keys, and
+		// writeKey dedups the whole key instead.
+		if idx.fields[i].dedup && idx.shared == 0 && !idx.isUnique(i, idx.keyBuf) {
+			continue
+		}
+		// Presence is the leaf's: a null element of a present array leaf is
+		// still one of its entries.
+		idx.fields[i].present = l.Value != nil && l.Value.Type() != anyenc.TypeNull
+		idx.fields[i].curBound = len(idx.keyBuf)
+		if idx.writeValues(i + 1) {
+			wrote = true
 		}
 	}
-
-	if reverse {
-		idx.keyBuf = anyenc.Tuple(k).AppendInverted(v)
-	} else {
-		idx.keyBuf = v.MarshalTo(k)
-	}
-	idx.curBounds[i] = len(idx.keyBuf)
-	return idx.writeValues(d, i+1)
+	// Clear the frame before cutting it: the buffer outlives the document.
+	clear(idx.valBuf[vb:])
+	idx.valBuf = idx.valBuf[:vb]
+	return wrote
 }
 
+// keysBufKeep bounds the entry buffers kept between documents: a document
+// that fans out into more entries than this hands its buffers back.
+const keysBufKeep = 4096
+
 func (idx *index) fillKeysBuf(it item) {
+	if cap(idx.keysBuf) > keysBufKeep {
+		idx.keysBuf, idx.keyBoundsBuf = nil, nil
+	}
 	idx.keysBuf = idx.keysBuf[:0]
 	idx.keyBoundsBuf = idx.keyBoundsBuf[:0]
 	idx.keyBuf = idx.keyBuf[:0]
-	idx.resetUnique()
-	if !idx.writeValues(it.Value(), 0) {
+	doc := it.Value()
+	idx.rebound = false
+	idx.resetFields(doc)
+	wrote := idx.writeValues(0)
+	if wrote && idx.info.Sparse {
+		// A sparse index holds a document only when every field is present
+		// and non-null somewhere in it.
+		for i := range idx.fields {
+			wrote = wrote && idx.fields[i].seen
+		}
+	}
+	if !wrote {
 		idx.keysBuf = idx.keysBuf[:0]
 		idx.keyBoundsBuf = idx.keyBoundsBuf[:0]
 	}
+	idx.resetFields(nil)
 }
 
-func (idx *index) resetUnique() {
-	for i := range idx.uniqBuf {
-		idx.uniqBuf[i] = idx.uniqBuf[i][:0]
+// initScratch sizes the per-field scratch (indexed by field position, never
+// appended).
+func (idx *index) initScratch() {
+	idx.fields = make([]fieldScratch, len(idx.fieldPaths))
+}
+
+// resetFields starts every field at doc, segment 0, with nothing seen and
+// no dedup set; the dedup buffers keep their capacity.
+func (idx *index) resetFields(doc *anyenc.Value) {
+	for i := range idx.fields {
+		f := &idx.fields[i]
+		*f = fieldScratch{root: doc, uniq: f.uniq[:0]}
 	}
 }
 
 func (idx *index) isUnique(i int, k anyenc.Tuple) bool {
-	for _, ek := range idx.uniqBuf[i] {
+	f := &idx.fields[i]
+	for _, ek := range f.uniq {
 		if bytes.Equal(k, ek) {
 			return false
 		}
 	}
-	nl := len(idx.uniqBuf[i]) + 1
-	idx.uniqBuf[i] = slices.Grow(idx.uniqBuf[i], nl)[:nl]
-	idx.uniqBuf[i][nl-1] = append(idx.uniqBuf[i][nl-1][:0], k...)
+	nl := len(f.uniq) + 1
+	f.uniq = slices.Grow(f.uniq, nl)[:nl]
+	f.uniq[nl-1] = append(f.uniq[nl-1][:0], k...)
 	return true
 }
 

--- a/index_corruption_test.go
+++ b/index_corruption_test.go
@@ -1940,8 +1940,7 @@ func TestAudit14_LegacyNilValue_AllNilSimulatesPreUpgrade(t *testing.T) {
 	// keys PLUS the canonical whole-array key, all with nil value bytes.
 	// writeValues has emitted the canonical (0x06-prefixed) whole-array key
 	// since before the value byte existed, so real legacy multi-key data
-	// always carries it; the count path's canonical-key probe detects it by
-	// key prefix regardless of the (nil) value byte.
+	// always carries it.
 	for _, kv := range []struct {
 		key string
 		doc string
@@ -1968,6 +1967,12 @@ func TestAudit14_LegacyNilValue_AllNilSimulatesPreUpgrade(t *testing.T) {
 		injectRawIndexEntry(t, c, idx, canonical, nil)
 	}
 
+	// A pre-flag writer never wrote the scalar-proven marker either: drop
+	// the one EnsureIndex wrote so the index reads as legacy (unproven).
+	require.NoError(t, c.db.doWriteTx(ctx, func(tx *btree.WriteTx) error {
+		return tx.Delete(c.db.systemNS, multikeyKey(idx.ns.Name()))
+	}))
+
 	post := readRawIndexEntries(t, fx.DB, "audit14_allnil", "tags")
 	require.Equal(t, preLen+6, len(post),
 		"expected %d (pre) + 4 per-element + 2 canonical entries, got %d", preLen, len(post))
@@ -1977,9 +1982,9 @@ func TestAudit14_LegacyNilValue_AllNilSimulatesPreUpgrade(t *testing.T) {
 	}
 
 	// Multi-bound $in over [a,b,c]: d1 matches "a" and "b" (2 hits), d2
-	// matches "b" and "c" (2 hits). Without dedup, count = 4. The canonical
-	// 0x06 keys make the count path's probe report multi-key, routing to the
-	// sort-dedup count, so the distinct-doc count is 2.
+	// matches "b" and "c" (2 hits). Without dedup, count = 4. The missing
+	// scalar-proven marker routes the count path to the dedup walk, so the
+	// distinct-doc count is 2.
 	n, err := coll.Find(`{"tags":{"$in":["a","b","c"]}}`).Count(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 2, n,

--- a/index_query_test.go
+++ b/index_query_test.go
@@ -2352,7 +2352,6 @@ All helpers used here (newFixture, collectField, collectIdsString, assertIndexLe
 are defined elsewhere in the package test suite and reused as-is.
 */
 
-
 // act-01
 func TestIndex_Single_Ne_TwoBoundSeek_IncludesNullAndMissing(t *testing.T) {
 	// Builds a collection; when withIndex is true a non-sparse index {a} is added.
@@ -2866,7 +2865,7 @@ func TestIndex_ArrayNested_NeOverMultiKey_DedupAndAgreement(t *testing.T) {
 // array; the non-numeric "name" fails -> nil -> one 'null' entry (non-sparse).
 // Positional access (items.0.name) resolves via the numeric index but is a
 // different, unindexed path.
-func TestIndex_ArrayNested_NestedField_IntermediateArray_NotTraversed(t *testing.T) {
+func TestIndex_ArrayNested_NestedField_IntermediateArray_Traversed(t *testing.T) {
 	fx := newFixture(t)
 	coll, err := fx.CreateCollection(ctx, "test")
 	require.NoError(t, err)
@@ -2875,29 +2874,34 @@ func TestIndex_ArrayNested_NestedField_IntermediateArray_NotTraversed(t *testing
 	require.NoError(t, coll.Insert(ctx,
 		anyenc.MustParseJson(`{"id":1,"items":[{"name":"a"},{"name":"b"}]}`),
 		anyenc.MustParseJson(`{"id":2,"items":[{"name":"c"}]}`),
+		anyenc.MustParseJson(`{"id":3,"items":[{"name":"a"},{"other":1}]}`),
+		anyenc.MustParseJson(`{"id":4,"items":[]}`),
 	))
 
-	// Each doc contributes exactly one 'null' entry: the array intermediate
-	// stops traversal so the indexed value is null for both docs.
+	// The path maps over the array's objects: one entry per element value
+	// ("a","b" | "c" | "a",null | null) — the doc fans out like a leaf array.
 	idx := coll.GetIndexes()[0]
-	assertIndexLen(t, idx, 2)
+	assertIndexLen(t, idx, 6)
 
-	// No implicit array traversal: items.name="a" finds nothing. This query
-	// still IndexScans the items.name index (which holds only null entries).
-	cnt, err := coll.Find(`{"items.name":"a"}`).Count(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 0, cnt)
-
-	// Positional access works (resolves via the numeric index). This is a
-	// different, unindexed path -> FullScan; do not assert IndexScan.
-	posCnt, err := coll.Find(`{"items.0.name":"a"}`).Count(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 1, posCnt)
-
-	// Both docs are findable via the shared 'null' entry.
-	nullCnt, err := coll.Find(`{"items.name":null}`).Count(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 2, nullCnt)
+	for _, tc := range []struct {
+		filter string
+		want   []int
+	}{
+		{`{"items.name":"a"}`, []int{1, 3}},
+		{`{"items.name":{"$in":["b","c"]}}`, []int{1, 2}},
+		{`{"items.name":{"$ne":"a"}}`, []int{2, 4}},
+		{`{"items.0.name":"a"}`, []int{1, 3}},
+		{`{"items.1.name":"a"}`, nil},
+		// missing on an element that lacks the field, or on an empty array
+		{`{"items.name":null}`, []int{3, 4}},
+		{`{"items.name":{"$exists":false}}`, []int{4}},
+	} {
+		q := coll.Find(tc.filter)
+		assert.ElementsMatch(t, tc.want, collectIntField(t, q, "id"), tc.filter)
+		cnt, err := q.Count(ctx)
+		require.NoError(t, err, tc.filter)
+		assert.Equal(t, len(tc.want), cnt, tc.filter)
+	}
 }
 
 // act-30: Querying by a whole NON-empty array value uses the post-loop
@@ -3745,4 +3749,284 @@ func TestIndex_ArraySortOrderProvidingGate(t *testing.T) {
 		assert.NotContains(t, ex.Sql, "Sort", "no bounds on the sort run: index order == min-element order: %s", ex.Sql)
 		assert.NotContains(t, ex.Sql, "TopK")
 	})
+}
+
+// A sparse index writes no entry for a null/missing leaf; the index-order
+// dedup must elect the canonical entry among the entries that exist.
+func TestIndex_ArrayNested_SparseDedupKeepsDoc(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ab", Fields: []string{"a.b"}, Sparse: true}))
+	require.NoError(t, coll.Insert(ctx,
+		anyenc.MustParseJson(`{"id":1,"a":[{"b":"abc"},{"c":2}]}`),
+		anyenc.MustParseJson(`{"id":2,"a":[{"b":"xbz"},{"b":null}]}`),
+		anyenc.MustParseJson(`{"id":3,"a":[{"c":1}]}`),
+	))
+	assertIndexLen(t, coll.GetIndexes()[0], 2)
+	for _, sort := range []string{"a.b", "-a.b"} {
+		q := coll.Find(`{"a.b":{"$regex":"b"}}`).Sort(sort)
+		assert.Equal(t, 2, len(collectIntField(t, q, "id")), sort)
+		cnt, err := coll.Find(`{"a.b":{"$regex":"b"}}`).Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, cnt)
+	}
+}
+
+// Several whole-array entries per doc (one per array leaf) must not emit
+// the doc once per entry.
+func TestIndex_ArrayNested_MultipleWholeArrayEntries(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ab", Fields: []string{"a.b"}}))
+	require.NoError(t, coll.Insert(ctx,
+		anyenc.MustParseJson(`{"id":1,"a":[{"b":[1,2]},{"b":[3]}]}`),
+		anyenc.MustParseJson(`{"id":2,"a":[{"b":[4]}]}`),
+		anyenc.MustParseJson(`{"id":3,"a":[{"b":5}]}`),
+	))
+	// entries for doc 1: 1, 2, [1,2], 3, [3]
+	assertIndexLen(t, coll.GetIndexes()[0], 5+2+1)
+	for _, tc := range []struct {
+		filter string
+		want   []int
+	}{
+		{`{"a.b":{"$type":"array"}}`, []int{1, 2}},
+		{`{"a.b":{"$in":[[1,2],[3]]}}`, []int{1}},
+		{`{"$or":[{"a.b":[1,2]},{"a.b":[3]}]}`, []int{1}},
+		{`{"a.b":{"$in":[2,[3]]}}`, []int{1}},
+	} {
+		for _, sort := range []string{"", "a.b", "-a.b"} {
+			q := coll.Find(tc.filter)
+			if sort != "" {
+				q = q.Sort(sort)
+			}
+			assert.ElementsMatch(t, tc.want, collectIntField(t, q, "id"), "%s sort %q", tc.filter, sort)
+		}
+		cnt, err := coll.Find(tc.filter).Count(ctx)
+		require.NoError(t, err, tc.filter)
+		assert.Equal(t, len(tc.want), cnt, tc.filter)
+	}
+}
+
+// Fan-out through an array of objects writes scalar entries with no
+// whole-array key: multi-bound counts must still dedup per document.
+func TestIndex_ArrayNested_CountFanoutWithoutArrayKey(t *testing.T) {
+	fx := newFixture(t)
+	for _, unique := range []bool{false, true} {
+		coll, err := fx.CreateCollection(ctx, fmt.Sprintf("test_%v", unique))
+		require.NoError(t, err)
+		require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ab", Fields: []string{"a.b"}, Unique: unique}))
+		require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(`{"id":1,"a":[{"b":1},{"b":2}]}`)))
+		for i := 2; i < 12; i++ {
+			require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(fmt.Sprintf(`{"id":%d,"a":[{"b":%d}]}`, i, i+10))))
+		}
+		filter := `{"a.b":{"$in":[1,2,12,13]}}`
+		cnt, err := coll.Find(filter).Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 3, cnt, "unique=%v", unique)
+		assert.ElementsMatch(t, []int{1, 2, 3}, collectIntField(t, coll.Find(filter), "id"), "unique=%v", unique)
+		assert.Equal(t, 2, len(collectIntField(t, coll.Find(filter).Offset(1), "id")), "unique=%v", unique)
+	}
+}
+
+// Fields of a compound index that run through the same array of objects
+// iterate it together: one entry per element, never a cross product.
+func TestIndex_ArrayNested_CompoundSharedArray(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "bc", Fields: []string{"a.b", "a.c"}}))
+
+	var elems []string
+	for i := 0; i < 50; i++ {
+		elems = append(elems, fmt.Sprintf(`{"b":%d,"c":%d}`, i, 100+i))
+	}
+	require.NoError(t, coll.Insert(ctx,
+		anyenc.MustParseJson(`{"id":1,"a":[`+strings.Join(elems, ",")+`]}`),
+		anyenc.MustParseJson(`{"id":2,"a":[{"b":1,"c":2},{"b":3,"c":4},{"c":5},7]}`),
+		anyenc.MustParseJson(`{"id":3,"a":{"b":1,"c":4}}`),
+	))
+	// doc1: 50 element pairs; doc2: (1,2),(3,4),(null,5),(null,null); doc3: (1,4)
+	assertIndexLen(t, coll.GetIndexes()[0], 50+4+1)
+
+	for _, tc := range []struct {
+		filter string
+		want   []int
+	}{
+		{`{"a.b":1,"a.c":2}`, []int{2}},
+		{`{"a.b":1,"a.c":4}`, []int{2, 3}}, // the unbound form matches across elements (doc2) and the plain object (doc3)
+		{`{"a":{"$elemMatch":{"b":1,"c":2}}}`, []int{2}},
+		{`{"a":{"$elemMatch":{"b":1,"c":4}}}`, nil}, // doc3's a is an object, doc2 pairs (1,2),(3,4)
+		{`{"a.b":3,"a.c":4}`, []int{2}},
+		{`{"a.b":null,"a.c":5}`, []int{2}},
+		{`{"a.b":7,"a.c":107}`, []int{1}},
+	} {
+		q := coll.Find(tc.filter)
+		assert.ElementsMatch(t, tc.want, collectIntField(t, q, "id"), tc.filter)
+		cnt, err := q.Count(ctx)
+		require.NoError(t, err, tc.filter)
+		assert.Equal(t, len(tc.want), cnt, tc.filter)
+	}
+
+	// Two arrays (or an array and a scalar path) stay independent.
+	coll2, err := fx.CreateCollection(ctx, "test2")
+	require.NoError(t, err)
+	require.NoError(t, coll2.EnsureIndex(ctx, IndexInfo{Name: "bx", Fields: []string{"a.b", "x.y"}}))
+	require.NoError(t, coll2.Insert(ctx, anyenc.MustParseJson(`{"id":1,"a":[{"b":1},{"b":2}],"x":[{"y":1},{"y":2}]}`)))
+	assertIndexLen(t, coll2.GetIndexes()[0], 4)
+
+	// The array itself next to a path through it: the whole-array field fans
+	// out into elements plus the array, the path into the elements' values.
+	coll3, err := fx.CreateCollection(ctx, "test3")
+	require.NoError(t, err)
+	require.NoError(t, coll3.EnsureIndex(ctx, IndexInfo{Name: "ab", Fields: []string{"a", "a.b"}}))
+	require.NoError(t, coll3.Insert(ctx, anyenc.MustParseJson(`{"id":1,"a":[{"b":1},{"b":2}]}`)))
+	assertIndexLen(t, coll3.GetIndexes()[0], 3*2)
+
+	// Nested arrays share at every level: (a.b.c, a.b.d) over two levels.
+	coll4, err := fx.CreateCollection(ctx, "test4")
+	require.NoError(t, err)
+	require.NoError(t, coll4.EnsureIndex(ctx, IndexInfo{Name: "cd", Fields: []string{"a.b.c", "a.b.d"}}))
+	require.NoError(t, coll4.Insert(ctx, anyenc.MustParseJson(`{"id":1,"a":[{"b":[{"c":1,"d":1},{"c":2,"d":2}]},{"b":[{"c":3,"d":3}]}]}`)))
+	assertIndexLen(t, coll4.GetIndexes()[0], 3)
+	assert.ElementsMatch(t, []int{1}, collectIntField(t, coll4.Find(`{"a.b.c":2,"a.b.d":2}`), "id"))
+	assert.Empty(t, collectIntField(t, coll4.Find(`{"a":{"$elemMatch":{"b":{"$elemMatch":{"c":1,"d":2}}}}}`), "id"))
+}
+
+// A unique compound index over one array of objects constrains element pairs,
+// not cross-product pairs.
+func TestIndex_ArrayNested_UniqueCompoundSharedArray(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "bc", Fields: []string{"a.b", "a.c"}, Unique: true}))
+	require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(`{"id":1,"a":[{"b":1,"c":2},{"b":3,"c":4}]}`)))
+	require.NoError(t, coll.Insert(ctx, anyenc.MustParseJson(`{"id":2,"a":{"b":1,"c":4}}`)))
+	err = coll.Insert(ctx, anyenc.MustParseJson(`{"id":3,"a":[{"b":3,"c":4}]}`))
+	assert.ErrorIs(t, err, ErrUniqueConstraint)
+}
+
+// A sparse index over a path through an array of objects never provides the
+// sort order: a document with a missing leaf sorts by null (its least leaf)
+// while the index holds only its non-null leaves.
+func TestIndex_ArrayNested_SparseIndexOrderDemoted(t *testing.T) {
+	fx := newFixture(t)
+	mk := func(name string, sparse bool) Collection {
+		coll, err := fx.CreateCollection(ctx, name)
+		require.NoError(t, err)
+		if name != "plain" {
+			require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ab", Fields: []string{"a.b"}, Sparse: sparse}))
+		}
+		require.NoError(t, coll.Insert(ctx,
+			anyenc.MustParseJson(`{"id":1,"a":[{"b":2},{"c":1}]}`), // leaves 2, missing → key null
+			anyenc.MustParseJson(`{"id":2,"a":[{"b":1}]}`),
+			anyenc.MustParseJson(`{"id":3,"a":[{"b":3},{"b":0}]}`),
+		))
+		return coll
+	}
+	plain, sparse, dense := mk("plain", false), mk("sparse", true), mk("dense", false)
+	hint := IndexHint{IndexName: "ab", Boost: 1 << 30}
+	for _, sort := range []string{"a.b", "-a.b"} {
+		want := collectIntField(t, plain.Find(nil).Sort(sort), "id")
+		for name, coll := range map[string]Collection{"sparse": sparse, "dense": dense} {
+			assert.Equal(t, want, collectIntField(t, coll.Find(nil).IndexHint(hint).Sort(sort), "id"), "%s %s", name, sort)
+			assert.Equal(t, want[:1], collectIntField(t, coll.Find(nil).IndexHint(hint).Sort(sort).Limit(1), "id"), "%s %s limit", name, sort)
+		}
+	}
+}
+
+// A digit run that overflows an int but ends in other characters is a key,
+// not an array index: the path fans out and the index re-keys under it.
+func TestIndex_ArrayNested_DigitPrefixedKey(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	const key = "1725580800000_x"
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "ak", Fields: []string{"a." + key}}))
+	require.NoError(t, coll.Insert(ctx,
+		anyenc.MustParseJson(`{"id":1,"a":[{"`+key+`":7}]}`),
+		anyenc.MustParseJson(`{"id":2,"a":[{"`+key+`":8},{"`+key+`":7}]}`),
+		anyenc.MustParseJson(`{"id":3,"a":[{"other":7}]}`),
+	))
+	assertIndexLen(t, coll.GetIndexes()[0], 4)
+	for _, filter := range []string{`{"a.` + key + `":7}`, `{"a":{"$elemMatch":{"` + key + `":7}}}`} {
+		q := coll.Find(filter)
+		assert.ElementsMatch(t, []int{1, 2}, collectIntField(t, q, "id"), filter)
+		cnt, err := q.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, cnt, filter)
+	}
+}
+
+// $elemMatch's condition names object keys inside the element; an index on a
+// positional path stores the element whole, so no bound is re-keyed there.
+func TestIndex_ArrayNested_ElemMatchPositionalIndex(t *testing.T) {
+	fx := newFixture(t)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(t, err)
+	require.NoError(t, coll.EnsureIndex(ctx, IndexInfo{Name: "a0", Fields: []string{"a.0"}}))
+	require.NoError(t, coll.Insert(ctx,
+		anyenc.MustParseJson(`{"id":1,"a":[{"0":5}]}`),
+		anyenc.MustParseJson(`{"id":2,"a":[{"0":6},{"0":5}]}`),
+		anyenc.MustParseJson(`{"id":3,"a":[5]}`),
+	))
+	filter := `{"a":{"$elemMatch":{"0":5}}}`
+	assert.Empty(t, query.MustParseCondition(filter).IndexBounds("a.0", nil))
+	q := coll.Find(filter).IndexHint(IndexHint{IndexName: "a0", Boost: 1 << 30})
+	assert.ElementsMatch(t, []int{1, 2}, collectIntField(t, q, "id"))
+	cnt, err := q.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, cnt)
+	res, err := coll.Find(filter).Delete(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Modified)
+}
+
+// A sparse compound index over one array of objects: a key is written when
+// any of its fields is present in that element, the document when every
+// field is present in some element — so a document matching through
+// different elements stays reachable by the seek on the leading field.
+func TestIndex_ArrayNested_SparseCompoundSharedArray(t *testing.T) {
+	fx := newFixture(t)
+	docs := []string{
+		`{"id":1,"a":[{"b":1,"c":2},{"b":3,"c":4}]}`,
+		`{"id":4,"a":[{"b":1},{"c":2}]}`,
+		`{"id":5,"a":[{"b":1,"c":2}]}`,
+		`{"id":6,"a":[{"b":1,"c":2},{"b":9}]}`,
+		`{"id":7,"a":{"b":1}}`,            // c never present: not indexed
+		`{"id":8,"a":[{"b":null,"c":3}]}`, // b never non-null: not indexed
+	}
+	plain, err := fx.CreateCollection(ctx, "plain")
+	require.NoError(t, err)
+	sparse, err := fx.CreateCollection(ctx, "sparse")
+	require.NoError(t, err)
+	require.NoError(t, sparse.EnsureIndex(ctx, IndexInfo{Name: "bc", Fields: []string{"a.b", "a.c"}, Sparse: true}))
+	for _, d := range docs {
+		require.NoError(t, plain.Insert(ctx, anyenc.MustParseJson(d)))
+		require.NoError(t, sparse.Insert(ctx, anyenc.MustParseJson(d)))
+	}
+	// doc1: (1,2),(3,4); doc4: (1,null),(null,2); doc5: (1,2); doc6: (1,2),(9,null)
+	assertIndexLen(t, sparse.GetIndexes()[0], 2+2+1+2)
+
+	hint := IndexHint{IndexName: "bc", Boost: 1 << 30}
+	for _, filter := range []string{
+		`{"a.b":1,"a.c":2}`,
+		`{"a.b":9,"a.c":{"$gt":0}}`,
+		`{"a.b":{"$gte":1},"a.c":{"$lte":2}}`,
+	} {
+		want := collectIntField(t, plain.Find(filter), "id")
+		q := sparse.Find(filter).IndexHint(hint)
+		ex, err := q.Explain(ctx)
+		require.NoError(t, err)
+		used := false
+		for _, ix := range ex.Indexes {
+			used = used || ix.Used
+		}
+		require.True(t, used, "%s must plan on the sparse index: %s", filter, ex.Sql)
+		assert.ElementsMatch(t, want, collectIntField(t, q, "id"), filter)
+		cnt, err := q.Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, len(want), cnt, filter)
+	}
 }

--- a/index_test.go
+++ b/index_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -656,5 +657,43 @@ func TestAudit01_ValueByte_MultiElementArray(t *testing.T) {
 		require.NotEmptyf(t, e.Value, "entry %d: value must not be empty", i)
 		assert.NotZerof(t, e.Value[0]&qplanner.IndexEntryFlagMultiKey,
 			"entry %d: multi-key flag bit must be set", i)
+	}
+}
+
+// fieldScratch is laid out widest first so the per-field scratch stays at
+// one cache line per field.
+func TestFieldScratchLayout(t *testing.T) {
+	assert.Equal(t, uintptr(64), unsafe.Sizeof(fieldScratch{}))
+}
+
+// BenchmarkIndex_fillKeysBuf measures key generation alone, per document
+// shape: the scalar compound field, a leaf array, and a compound index over
+// one array of objects (fields iterated together).
+func BenchmarkIndex_fillKeysBuf(b *testing.B) {
+	fx := newFixture(b)
+	coll, err := fx.CreateCollection(ctx, "test")
+	require.NoError(b, err)
+	cases := []struct {
+		name   string
+		fields []string
+		doc    string
+	}{
+		{"scalar_compound", []string{"a", "b", "c"}, `{"id":1,"a":1,"b":"x","c":2.5}`},
+		{"leaf_array", []string{"tags"}, `{"id":1,"tags":["a","b","c","d"]}`},
+		{"shared_array_compound", []string{"a.b", "a.c"}, `{"id":1,"a":[{"b":1,"c":2},{"b":3,"c":4},{"b":5},{"c":6}]}`},
+		{"shared_array_sparse", []string{"a.b", "a.c"}, `{"id":1,"a":[{"b":1,"c":2},{"b":3,"c":4},{"b":5},{"c":6}]}`},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			info := IndexInfo{Name: c.name, Fields: c.fields, Sparse: strings.HasSuffix(c.name, "_sparse")}
+			idx := &index{info: info, c: coll.(*collection)}
+			require.NoError(b, idx.init())
+			it := mustParseItem(b, c.doc)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				idx.fillKeysBuf(it)
+			}
+		})
 	}
 }

--- a/internal/aggregate/expr.go
+++ b/internal/aggregate/expr.go
@@ -2,7 +2,6 @@ package aggregate
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 
@@ -70,7 +69,7 @@ func resolveFieldPath(a *anyenc.Arena, v *anyenc.Value, path []string) *anyenc.V
 			}
 			continue
 		}
-		if n, numeric := parseIndexSegment(seg); numeric {
+		if n, numeric := anyenc.ParseIndexSegment(seg); numeric {
 			arr, _ := v.Array()
 			if n < 0 || n >= len(arr) {
 				return nil
@@ -93,38 +92,6 @@ func resolveFieldPath(a *anyenc.Arena, v *anyenc.Value, path []string) *anyenc.V
 		return out
 	}
 	return v
-}
-
-// parseIndexSegment reports whether seg is a numeric path segment and its
-// array index. It accepts strconv.Atoi syntax without its allocating error
-// path (Atoi builds a *NumError per miss, and non-numeric segments are the
-// common case): numeric-but-unusable segments (negative, overflowing) return
-// -1, which indexing turns into missing — the same outcome anyenc.Value.Get
-// gives them.
-func parseIndexSegment(seg string) (n int, numeric bool) {
-	i := 0
-	neg := false
-	if len(seg) > 0 && (seg[0] == '+' || seg[0] == '-') {
-		neg = seg[0] == '-'
-		i = 1
-	}
-	if i == len(seg) {
-		return 0, false
-	}
-	for ; i < len(seg); i++ {
-		c := seg[i]
-		if c < '0' || c > '9' {
-			return 0, false
-		}
-		if n > (math.MaxInt32-9)/10 { // pre-multiply guard: no int wrap on 32-bit
-			return -1, true
-		}
-		n = n*10 + int(c-'0')
-	}
-	if neg {
-		return -1, true
-	}
-	return n, true
 }
 
 func (e *FieldRefExpr) String() string { return "$" + e.Field }

--- a/internal/aggregate/stage_lookup.go
+++ b/internal/aggregate/stage_lookup.go
@@ -52,8 +52,10 @@ type LookupStage struct {
 	bufs []*syncpool.DocBuffer // one per matched doc of the current row
 
 	keyScratch []byte
-	keys       []byte // marshaled ids seen in the current row's array
-	keyOffs    []int  // start offsets into keys
+	keys       []byte          // marshaled ids seen in the current row's array
+	keyOffs    []int           // start offsets into keys
+	leaves     []anyenc.Leaf   // scratch: the local path's leaf set
+	vals       []*anyenc.Value // scratch: its lookup values
 
 	prev    *anyenc.Value // previous overlaid row, nil when nothing to undo
 	prevVal *anyenc.Value // its original "as" value (nil = was missing)
@@ -72,33 +74,22 @@ func (s *LookupStage) Next(ctx *Ctx) (*anyenc.Value, error) {
 	}
 	out := ctx.RowArena.NewArray()
 	n := 0
-	lv := v.Get(s.Spec.LocalPath...)
-	if lv != nil {
-		switch lv.Type() {
-		case anyenc.TypeNull:
-			// The pk is never null: no match, empty result.
-		case anyenc.TypeArray:
-			s.keys, s.keyOffs = s.keys[:0], s.keyOffs[:0]
-			for _, el := range lv.GetArray() {
-				if el.Type() == anyenc.TypeNull {
-					continue
-				}
-				s.keyScratch = el.MarshalTo(s.keyScratch[:0])
-				if s.seen(s.keyScratch) {
-					continue // set membership: first occurrence wins
-				}
-				s.keyOffs = append(s.keyOffs, len(s.keys))
-				s.keys = append(s.keys, s.keyScratch...)
-				doc, lerr := s.fetch(n)
-				if lerr != nil {
-					return nil, lerr
-				}
-				if doc != nil {
-					out.SetArrayItem(n, doc)
-					n++
-				}
-			}
-		default:
+	// The local path resolves with field-path semantics (a path through an
+	// array of objects collects every element's value, as Mongo's localField
+	// does) and a leaf array — positional or not — contributes its elements,
+	// one level deep. Null, missing and array values never name a pk: skipped.
+	s.leaves = v.AppendLeaves(s.leaves[:0], s.Spec.LocalPath...)
+	s.vals = s.vals[:0]
+	for _, l := range s.leaves {
+		if l.Value != nil && l.Value.Type() == anyenc.TypeArray {
+			arr, _ := l.Value.Array()
+			s.vals = append(s.vals, arr...)
+			continue
+		}
+		s.vals = append(s.vals, l.Value)
+	}
+	if len(s.vals) == 1 {
+		if lv := s.vals[0]; lv != nil && lv.Type() != anyenc.TypeNull && lv.Type() != anyenc.TypeArray {
 			s.keyScratch = lv.MarshalTo(s.keyScratch[:0])
 			doc, lerr := s.fetch(0)
 			if lerr != nil {
@@ -106,6 +97,27 @@ func (s *LookupStage) Next(ctx *Ctx) (*anyenc.Value, error) {
 			}
 			if doc != nil {
 				out.SetArrayItem(0, doc)
+			}
+		}
+	} else {
+		s.keys, s.keyOffs = s.keys[:0], s.keyOffs[:0]
+		for _, el := range s.vals {
+			if el == nil || el.Type() == anyenc.TypeNull || el.Type() == anyenc.TypeArray {
+				continue
+			}
+			s.keyScratch = el.MarshalTo(s.keyScratch[:0])
+			if s.seen(s.keyScratch) {
+				continue // set membership: first occurrence wins
+			}
+			s.keyOffs = append(s.keyOffs, len(s.keys))
+			s.keys = append(s.keys, s.keyScratch...)
+			doc, lerr := s.fetch(n)
+			if lerr != nil {
+				return nil, lerr
+			}
+			if doc != nil {
+				out.SetArrayItem(n, doc)
+				n++
 			}
 		}
 	}

--- a/internal/qplanner/cover_iter.go
+++ b/internal/qplanner/cover_iter.go
@@ -12,6 +12,8 @@ type CoverIter struct {
 	Source  *CursorSource
 	IdxInfo *IndexInfo
 	Bounds  query.Bounds
+	// ScalarProven mirrors CBOIndex.ScalarProven (see IndexIter).
+	ScalarProven bool
 
 	idx     int
 	keyBuf  []byte // reusable buffer for SeekKey results
@@ -40,11 +42,10 @@ func (it *CoverIter) Next() (key []byte, docId []byte, multiKey bool, err error)
 			// for the (already rare) multi-bound unique compound lookup.
 			it.hasMultiKey = true
 		} else {
-			fieldReverse := len(it.IdxInfo.Reverse) > 0 && it.IdxInfo.Reverse[0]
-			it.hasMultiKey, err = indexProbeAnyMultiKey(it.Source, fieldReverse)
-			if err != nil {
-				return nil, nil, false, err
-			}
+			// A fan-out through an array of objects writes scalar entries
+			// with no whole-array key, so only the sticky scalar-proven flag
+			// can rule multikey out.
+			it.hasMultiKey = !it.ScalarProven
 		}
 		it.multiKeyProbed = true
 	}

--- a/internal/qplanner/cover_iter_test.go
+++ b/internal/qplanner/cover_iter_test.go
@@ -138,10 +138,16 @@ func TestCoverIter_MultiBound_MultiKey_SetsMultiKeyFlag(t *testing.T) {
 		rtx, err := db.BeginRead()
 		require.NoError(t, err)
 		defer func() { _ = rtx.Rollback() }()
-		it := &CoverIter{Source: &CursorSource{Tx: rtx, Ns: ns}, IdxInfo: info, Bounds: twoBounds}
+		it := &CoverIter{Source: &CursorSource{Tx: rtx, Ns: ns}, IdxInfo: info, Bounds: twoBounds, ScalarProven: true}
 		_, docID, multiKey, err := it.Next()
 		require.NoError(t, err)
 		require.NotNil(t, docID)
-		assert.False(t, multiKey, "pure-scalar index → probe false → multiKey=false")
+		assert.False(t, multiKey, "scalar-proven index → multiKey=false")
+
+		unproven := &CoverIter{Source: &CursorSource{Tx: rtx, Ns: ns}, IdxInfo: info, Bounds: twoBounds}
+		_, docID, multiKey, err = unproven.Next()
+		require.NoError(t, err)
+		require.NotNil(t, docID)
+		assert.True(t, multiKey, "unproven index (legacy marker, or fan-out without a whole-array key) → multiKey=true")
 	})
 }

--- a/internal/qplanner/dedup_iter.go
+++ b/internal/qplanner/dedup_iter.go
@@ -48,6 +48,10 @@ type CanonicalKeyDedupIter struct {
 	// canonical-element selection happens in the same space the cursor walks.
 	FieldReverse bool
 
+	// Sparse mirrors the index's Sparse flag: a null or missing leaf then has
+	// no entry and must not be elected canonical.
+	Sparse bool
+
 	// Bounds are the SCAN bounds — padded for full keys exactly as IndexIter
 	// walks them — and an element is tested as the least key it can have,
 	// enc(elem)‖0x01 (every real suffix starts with a type tag or docId byte
@@ -59,8 +63,11 @@ type CanonicalKeyDedupIter struct {
 	// padded scan skips, so the doc was elected on an entry never seen and
 	// dropped — or, with the continuation on the other side, emitted twice.
 
-	keyBuf []byte // reusable encode buffer for min/max comparison
-	best   []byte // reusable buffer for the canonical element
+	keyBuf []byte          // reusable encode buffer for min/max comparison
+	best   []byte          // reusable buffer for the canonical element
+	leaves []anyenc.Leaf   // scratch: the field path's leaf set
+	vals   []*anyenc.Value // scratch: the election candidates (elements)
+	wholes []*anyenc.Value // scratch: the doc's whole-array entries
 }
 
 func (it *CanonicalKeyDedupIter) Next() (key []byte, docId []byte, multiKey bool, err error) {
@@ -84,27 +91,69 @@ func (it *CanonicalKeyDedupIter) Next() (key []byte, docId []byte, multiKey bool
 		if it.Plan == nil || it.Plan.DocParsed == nil {
 			return key, docId, false, nil // no doc available; can't dedup — pass through
 		}
-		v := it.Plan.DocParsed.Get(it.FieldPath...)
-		if v == nil || v.Type() != anyenc.TypeArray {
-			// Scalar field — only one entry per doc, no dedup needed.
+		doc := it.Plan.DocParsed
+		if leaf, single := doc.GetLeaf(it.FieldPath...); single && (leaf == nil || leaf.Type() != anyenc.TypeArray) {
+			// One entry per doc — the common scalar row: pass through.
+			return key, docId, false, nil
+		}
+		// The doc's entries for this field are what index maintenance wrote
+		// (writeValues): none for a null/missing leaf of a sparse index, one
+		// per element plus one for the array itself for a non-positional
+		// array leaf. The canonical entry is elected among the elements —
+		// the sort-key candidates, so an index-order scan yields the min/max
+		// ELEMENT's entry — and only when no element is in bounds does a
+		// whole-array entry stand in, so a doc with several whole-array
+		// entries is still emitted once.
+		it.leaves = doc.AppendLeaves(it.leaves[:0], it.FieldPath...)
+		if it.Sparse {
+			kept := it.leaves[:0]
+			for _, l := range it.leaves {
+				if l.Value != nil && l.Value.Type() != anyenc.TypeNull {
+					kept = append(kept, l)
+				}
+			}
+			it.leaves = kept
+		}
+		it.vals = anyenc.AppendElementValues(it.vals[:0], it.leaves)
+		it.wholes = it.wholes[:0]
+		for _, l := range it.leaves {
+			if l.Value != nil && l.Value.Type() == anyenc.TypeArray && !l.Positional {
+				if arr, _ := l.Value.Array(); len(arr) > 0 {
+					it.wholes = append(it.wholes, l.Value)
+				}
+			}
+		}
+		if len(it.vals)+len(it.wholes) <= 1 {
 			return key, docId, false, nil
 		}
 
-		if it.isCanonical(v, fieldVal) {
+		if it.isCanonical(fieldVal) {
 			return key, docId, false, nil
 		}
 		// Not the canonical hit — skip.
 	}
 }
 
-// isCanonical elects the array's canonical in-bounds element and reports
-// whether fieldVal is it. Kept out of Next so the scalar pass-through — every
-// row of a single-field index scan — stays a short loop.
-func (it *CanonicalKeyDedupIter) isCanonical(v *anyenc.Value, fieldVal []byte) bool {
-	items, _ := v.Array()
+// isCanonical elects the doc's canonical in-bounds entry — among the
+// elements first, the whole-array entries otherwise — and reports whether
+// fieldVal is it. Kept out of Next so the scalar pass-through — every row of
+// a single-field index scan — stays a short loop.
+func (it *CanonicalKeyDedupIter) isCanonical(fieldVal []byte) bool {
+	it.elect(it.vals)
+	if len(it.best) == 0 {
+		it.elect(it.wholes)
+	}
+	// Nothing hits the bounds — upstream shouldn't have emitted this doc,
+	// but pass through conservatively.
+	return len(it.best) == 0 || bytes.Equal(fieldVal, it.best)
+}
+
+// elect leaves the min (forward) / max (reverse) in-bounds candidate's key
+// in it.best, empty when none is in bounds.
+func (it *CanonicalKeyDedupIter) elect(cands []*anyenc.Value) {
 	it.best = it.best[:0]
 	noBounds := len(it.Bounds) == 0
-	for _, item := range items {
+	for _, item := range cands {
 		// Encode in the same byte space as fieldVal and Bounds: inverted
 		// (stored) for a reverse field, plain ascending otherwise.
 		if it.FieldReverse {
@@ -129,9 +178,6 @@ func (it *CanonicalKeyDedupIter) isCanonical(v *anyenc.Value, fieldVal []byte) b
 			it.best = append(it.best[:0], it.keyBuf...)
 		}
 	}
-	// No array element hits the bounds — upstream shouldn't have emitted
-	// this doc, but pass through conservatively.
-	return len(it.best) == 0 || bytes.Equal(fieldVal, it.best)
 }
 
 // skipOffset delegates a cursor-level offset skip to the source. This is

--- a/internal/qplanner/index_iter.go
+++ b/internal/qplanner/index_iter.go
@@ -314,56 +314,6 @@ func (it *IndexIter) skipOffset(n int) (remaining int, err error) {
 	return n - skipped, nil
 }
 
-// arrayPrefix is the anyenc type tag for array-typed values. writeValues
-// emits a key with this leading byte exactly when a doc has an array-typed
-// value for an indexed field (the per-element keys of a nested array, and the
-// whole-value-as-tuple key of any multi-key doc). So a key with this prefix
-// exists in a single-field index iff that index has ever held a multi-key
-// (array) entry.
-var arrayPrefix = []byte{byte(anyenc.TypeArray)}
-
-// arrayPrefixInverted is the array tag for a REVERSE-flagged single-field index.
-// Such an index stores the whole-array key bitwise-inverted (index.go
-// writeValues), so its leading byte is ^TypeArray (0xF9) instead of 0x06.
-var arrayPrefixInverted = []byte{^byte(anyenc.TypeArray)}
-
-// arrayProbePrefix returns the leading byte the probe must seek to detect a
-// multi-key (array) entry: the inverted array tag for a reverse single-field
-// index, the plain array tag otherwise.
-func arrayProbePrefix(reverse bool) []byte {
-	if reverse {
-		return arrayPrefixInverted
-	}
-	return arrayPrefix
-}
-
-// indexProbeAnyMultiKey reports whether the index namespace has any entry whose
-// key begins with the array type tag — i.e. whether any indexed doc had an
-// array-typed value. It is a single btree Seek, snapshot-consistent with the
-// caller's read tx. fieldReverse selects the inverted array tag for a reverse
-// single-field index.
-//
-// PRECONDITION: only valid for single-field indexes. For a compound index the
-// array field's value is not at byte position 0 of the key, so its array tag
-// sits mid-key and the Seek would miss it (false negative). Callers must route
-// compound/non-PointLookup shapes elsewhere before probing.
-func indexProbeAnyMultiKey(cs *CursorSource, fieldReverse bool) (bool, error) {
-	c := cs.NewCursor()
-	defer c.Close()
-	prefix := arrayProbePrefix(fieldReverse)
-	if err := c.Seek(prefix); err != nil {
-		return false, err
-	}
-	if !c.Valid() {
-		return false, nil
-	}
-	k, err := c.Key()
-	if err != nil {
-		return false, err
-	}
-	return len(k) > 0 && k[0] == prefix[0], nil
-}
-
 // CountEntries counts distinct documents matching this index iterator's
 // bounds via a 4-branch dispatch:
 //
@@ -413,7 +363,7 @@ func (it *IndexIter) CountEntries() (int, error) {
 		return it.countEntriesViaSeenSet(true)
 	}
 
-	// Branches 3 & 4: single-field PointLookup — the probe decides.
+	// Branches 3 & 4: single-field PointLookup — the scalar-proven flag decides.
 	hasMultiKey, err := it.probeMultiKey()
 	if err != nil {
 		return 0, err
@@ -424,27 +374,16 @@ func (it *IndexIter) CountEntries() (int, error) {
 	return it.countEntriesViaSeenSet(false) // Branch 4: blind dedup
 }
 
-// probeMultiKey runs the canonical-key probe lazily and caches the result for
-// this iterator. True iff the index holds a multi-key entry — a doc with an
-// array-typed value writes a canonical 0x06 whole-array key (writeValues has
-// done this since before the value-byte feature, so legacy multi-key data is
-// detected too). The caller must have established that this is a single-field
-// index (see indexProbeAnyMultiKey's precondition); CountEntries enforces that
-// by routing compound/non-PointLookup to the seen-set path (Branch 2) first.
+// probeMultiKey reports whether the index may hold several entries for one
+// document. Only the sticky scalar-proven flag can rule that out: a fan-out
+// through an array of objects writes scalar entries with no whole-array key,
+// so no key-shape probe of the namespace could detect it. False means the
+// index is proven scalar for this snapshot (Branch 3); anything else — a
+// multikey index or a legacy index without the marker — dedups (Branch 4).
 func (it *IndexIter) probeMultiKey() (bool, error) {
-	if it.indexHasMultiKeyProbed {
-		return it.indexHasMultiKey, nil
-	}
-	// CountEntries only reaches here for single-field indexes (it gates on
-	// len(FieldNames)==1), so Reverse[0] is the array field's direction.
-	fieldReverse := len(it.IdxInfo.Reverse) > 0 && it.IdxInfo.Reverse[0]
-	has, err := indexProbeAnyMultiKey(it.Source, fieldReverse)
-	if err != nil {
-		return false, err
-	}
-	it.indexHasMultiKey = has
+	it.indexHasMultiKey = !it.ScalarProven
 	it.indexHasMultiKeyProbed = true
-	return has, nil
+	return it.indexHasMultiKey, nil
 }
 
 // countEntriesBatch is the original page-batch fast path, used for

--- a/internal/qplanner/index_iter_test.go
+++ b/internal/qplanner/index_iter_test.go
@@ -591,10 +591,9 @@ type rawEntry struct {
 }
 
 // rawKeyBtree opens an in-memory btree namespace and writes entries with
-// caller-supplied raw key bytes. Used to exercise indexProbeAnyMultiKey with
-// array (0x06) and object (0x07) leading bytes that anyenc.AppendAnyValue
-// (scalars only) cannot produce — array/object keys are built via
-// anyenc.MustParseJson(...).MarshalTo to avoid hand-coded byte drift.
+// caller-supplied raw key bytes, so array/object keys (built via
+// anyenc.MustParseJson(...).MarshalTo) sit next to the scalars
+// anyenc.AppendAnyValue produces.
 func rawKeyBtree(t *testing.T, entries []rawEntry) (*btree.DB, *btree.Namespace) {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "ix.db")
@@ -611,67 +610,6 @@ func rawKeyBtree(t *testing.T, entries []rawEntry) (*btree.DB, *btree.Namespace)
 	}
 	require.NoError(t, wtx.Commit())
 	return db, ns
-}
-
-// TestIndexProbeAnyMultiKey pins the canonical-key probe: it returns true iff
-// the namespace contains an entry whose key starts with the array type tag
-// (0x06), which writeValues emits exactly for array-valued (multi-key) docs.
-func TestIndexProbeAnyMultiKey(t *testing.T) {
-	scalarStr := func(s, docId string) []byte {
-		return append(anyenc.AppendAnyValue(nil, s), []byte(docId)...)
-	}
-	scalarNum := func(n int, docId string) []byte {
-		return append(anyenc.AppendAnyValue(nil, n), []byte(docId)...)
-	}
-	jsonKey := func(json, docId string) []byte {
-		return append(anyenc.MustParseJson(json).MarshalTo(nil), []byte(docId)...)
-	}
-
-	// Sanity: the encodings carry the leading type tags the probe relies on.
-	require.Equal(t, byte(anyenc.TypeArray), jsonKey(`["a","b"]`, "d")[0])
-	require.Equal(t, byte(anyenc.TypeObject), jsonKey(`{"k":"v"}`, "d")[0])
-
-	cases := []struct {
-		name    string
-		entries []rawEntry
-		want    bool
-	}{
-		{"pure-scalar string (0x03)", []rawEntry{
-			{scalarStr("a", "d1"), IndexValueScalar},
-			{scalarStr("b", "d2"), IndexValueScalar},
-		}, false},
-		{"pure-scalar number (0x02)", []rawEntry{
-			{scalarNum(5, "d1"), IndexValueScalar},
-			{scalarNum(10, "d2"), IndexValueScalar},
-		}, false},
-		{"array entries (0x06)", []rawEntry{
-			{jsonKey(`["a","b"]`, "d1"), IndexValueMultiKey},
-		}, true},
-		{"mixed scalar + array", []rawEntry{
-			{scalarStr("a", "d1"), IndexValueScalar},
-			{jsonKey(`["a","b"]`, "d2"), IndexValueMultiKey},
-		}, true},
-		{"empty namespace", nil, false},
-		{"object-only (0x07, cursor lands past 0x06)", []rawEntry{
-			{jsonKey(`{"k":"v"}`, "d1"), IndexValueScalar},
-		}, false},
-		{"legacy nil-value array (probe reads key, not value)", []rawEntry{
-			{jsonKey(`["a","b"]`, "d1"), nil},
-		}, true},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			db, ns := rawKeyBtree(t, tc.entries)
-			rtx, err := db.BeginRead()
-			require.NoError(t, err)
-			defer func() { _ = rtx.Rollback() }()
-
-			got, err := indexProbeAnyMultiKey(&CursorSource{Tx: rtx, Ns: ns}, false)
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, got)
-		})
-	}
 }
 
 // boundForValue builds the adjusted point bound the planner hands to the count
@@ -890,17 +828,16 @@ func TestCountEntries_Dispatch(t *testing.T) {
 		defer func() { _ = rtx.Rollback() }()
 
 		it := &IndexIter{
-			Source:      &CursorSource{Tx: rtx, Ns: ns},
-			IdxInfo:     &IndexInfo{Name: "ix", FieldNames: []string{"f"}},
-			Bounds:      query.Bounds{boundForValue("a"), boundForValue("b")},
-			PointLookup: true,
+			Source:       &CursorSource{Tx: rtx, Ns: ns},
+			IdxInfo:      &IndexInfo{Name: "ix", FieldNames: []string{"f"}},
+			Bounds:       query.Bounds{boundForValue("a"), boundForValue("b")},
+			PointLookup:  true,
+			ScalarProven: true,
 		}
 		defer it.Close()
 		n, err := it.CountEntries()
 		require.NoError(t, err)
 		assert.Equal(t, 2, n)
-		assert.True(t, it.indexHasMultiKeyProbed, "single-field PointLookup must run the probe")
-		assert.False(t, it.indexHasMultiKey, "pure-scalar → probe false → Branch 3 batch")
 	})
 
 	t.Run("Branch4_MultiKey_PointLookup_SortDedup", func(t *testing.T) {
@@ -926,8 +863,6 @@ func TestCountEntries_Dispatch(t *testing.T) {
 		n, err := it.CountEntries()
 		require.NoError(t, err)
 		assert.Equal(t, 3, n, "d1, d2 scalar + d3 array straddling both bounds, deduped to one")
-		assert.True(t, it.indexHasMultiKeyProbed)
-		assert.True(t, it.indexHasMultiKey, "array entry present → probe true → Branch 4 sort-dedup")
 	})
 
 	t.Run("Branch2_Compound_SortDedup_NoProbe", func(t *testing.T) {
@@ -961,7 +896,6 @@ func TestCountEntries_Dispatch(t *testing.T) {
 		n, err := it.CountEntries()
 		require.NoError(t, err)
 		assert.Equal(t, 1, n, "compound array doc straddling both bounds counted once")
-		assert.False(t, it.indexHasMultiKeyProbed, "compound index must NOT run the probe (Branch 2)")
 	})
 
 	t.Run("Branch4_LegacyNilValue_PointLookup_SortDedup", func(t *testing.T) {
@@ -993,8 +927,6 @@ func TestCountEntries_Dispatch(t *testing.T) {
 		n, err := it.CountEntries()
 		require.NoError(t, err)
 		assert.Equal(t, 2, n, "legacy multi-key with canonical 0x06 keys dedups: d1{a,b}, d2{b,c}")
-		assert.True(t, it.indexHasMultiKeyProbed)
-		assert.True(t, it.indexHasMultiKey, "canonical 0x06 key (even nil-valued) → probe true → dedup")
 	})
 }
 

--- a/internal/qplanner/iterator.go
+++ b/internal/qplanner/iterator.go
@@ -171,6 +171,13 @@ type IndexInfo struct {
 	Unique     bool
 	Sparse     bool
 	Ns         *btree.Namespace
+	// SharedFrom is the first field position whose path shares a leading
+	// segment with an earlier field's (len(FieldNames) when none). Fields
+	// that run through the same array of objects iterate it together, one
+	// entry per element, so a bound on such a field pairs with the earlier
+	// fields' bounds only within one element: over data that may fan out,
+	// the planner compounds bounds and cover filters up to this position.
+	SharedFrom int
 }
 
 // AppendIndexKey appends the value for field at position i to the tuple.

--- a/internal/qplanner/knn_plan.go
+++ b/internal/qplanner/knn_plan.go
@@ -226,9 +226,10 @@ func buildKnnProbePlan(params *PlanParams, cand *knnCandidate) *Plan {
 			// MergeOverlappingBounds would collapse distinct point probes
 			// (see buildIndexSeekChain).
 			root = &CoverIter{
-				Source:  &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
-				IdxInfo: idx.Info,
-				Bounds:  idx.Bounds,
+				Source:       &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
+				IdxInfo:      idx.Info,
+				Bounds:       idx.Bounds,
+				ScalarProven: idx.ScalarProven,
 			}
 			if len(idx.Bounds) > 1 {
 				root = &DocDedupIter{Source: root}

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -1844,11 +1844,24 @@ func countInnerPreds(f query.Filter) int {
 	}
 }
 
+// keyBoundsExact reports whether a Key's index bounds are the exact value
+// image of its predicate — the premise of every FilterIter-skipping path. A
+// $elemMatch breaks it: its bounds are element-level (value form) or
+// re-keyed sub-field bounds (object form), and a scalar or an object with
+// that value sits in the same bounds without matching. Such a Key always
+// keeps its residual filter.
+func keyBoundsExact(k query.Key) bool {
+	return !query.ContainsElemMatch(k.Filter)
+}
+
 // filterFieldsCoveredBy walks the filter tree and checks that every referenced
 // field name is present in idxFields. Zero-allocation.
 func filterFieldsCoveredBy(f query.Filter, idxFields []string, hasFields *bool) bool {
 	switch ft := f.(type) {
 	case query.Key:
+		if !keyBoundsExact(ft) {
+			return false
+		}
 		name := strings.Join(ft.Path, ".")
 		if slices.Contains(idxFields, name) {
 			*hasFields = true
@@ -1884,6 +1897,9 @@ func filterFieldsCoveredBy(f query.Filter, idxFields []string, hasFields *bool) 
 func collectUncoveredFilterFields(f query.Filter, coveredFields []string) []string {
 	switch ft := f.(type) {
 	case query.Key:
+		if !keyBoundsExact(ft) {
+			return nil
+		}
 		name := strings.Join(ft.Path, ".")
 		if slices.Contains(coveredFields, name) {
 			return []string{} // covered
@@ -2466,6 +2482,8 @@ func ComputeIndexBounds(idx *IndexInfo, br *BoundsResult) (query.Bounds, int) {
 func ComputeIndexBoundsTight(idx *IndexInfo, br *BoundsResult) (query.Bounds, int) {
 	return computeIndexBounds(idx, br.LookupTight)
 }
+
+
 
 // ComputeSingleFieldBounds is the single-field chain for explicit logical
 // bounds: the stored-space transform when the field is reverse-declared, the

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -244,6 +244,12 @@ type CBOIndex struct {
 	// Sketch estimates are only valid when BoundFields == len(Info.FieldNames).
 	BoundFields int
 
+	// UsableFields is how many leading index fields the bound chain and the
+	// entry-level cover filters may use — len(Info.FieldNames), or
+	// Info.SharedFrom when the index may hold correlated fan-out entries
+	// (0 in hand-built candidates means no cap).
+	UsableFields int
+
 	// PointLookup is true when ALL original bounds are equality (Start == End),
 	// before AdjustBoundsForNonUnique modifies End. This allows correct sketch estimation.
 	PointLookup bool
@@ -1318,8 +1324,9 @@ func buildIndexSeekChain(params *PlanParams, idx *CBOIndex, needFilter, needSort
 				Tx: params.Tx,
 				Ns: idx.Info.Ns,
 			},
-			IdxInfo: idx.Info,
-			Bounds:  idx.Bounds,
+			IdxInfo:      idx.Info,
+			Bounds:       idx.Bounds,
+			ScalarProven: idx.ScalarProven,
 		}
 
 		// A unique index can still be multikey (each array element unique
@@ -1482,6 +1489,7 @@ func buildIndexSeekChain(params *PlanParams, idx *CBOIndex, needFilter, needSort
 			FieldPath:    idx.Info.FieldPaths[0],
 			Reverse:      reverse,
 			FieldReverse: len(idx.Info.Reverse) > 0 && idx.Info.Reverse[0],
+			Sparse:       idx.Info.Sparse,
 		}
 	}
 
@@ -1581,6 +1589,7 @@ func buildIndexScanChain(params *PlanParams, idx *CBOIndex, needFilter bool) Ite
 			FieldPath:    idx.Info.FieldPaths[0],
 			Reverse:      reverse,
 			FieldReverse: len(idx.Info.Reverse) > 0 && idx.Info.Reverse[0],
+			Sparse:       idx.Info.Sparse,
 		}
 	}
 
@@ -2472,7 +2481,13 @@ func padReverseBounds(bs query.Bounds) query.Bounds {
 // ComputeIndexBounds computes combined tuple bounds for an index
 // using pre-computed per-field WIDE bounds from BoundsResult.
 func ComputeIndexBounds(idx *IndexInfo, br *BoundsResult) (query.Bounds, int) {
-	return computeIndexBounds(idx, br.Lookup)
+	return computeIndexBounds(idx, br.Lookup, len(idx.FieldNames))
+}
+
+// ComputeIndexBoundsCapped is ComputeIndexBounds over the first maxFields
+// index fields only (see IndexInfo.SharedFrom).
+func ComputeIndexBoundsCapped(idx *IndexInfo, br *BoundsResult, maxFields int) (query.Bounds, int) {
+	return computeIndexBounds(idx, br.Lookup, maxFields)
 }
 
 // ComputeIndexBoundsTight is the tight-channel variant, built from
@@ -2480,10 +2495,14 @@ func ComputeIndexBounds(idx *IndexInfo, br *BoundsResult) (query.Bounds, int) {
 // EstBounds): feeding it to a seek requires the fan-out-free proof documented
 // on query.TightIndexBounds.
 func ComputeIndexBoundsTight(idx *IndexInfo, br *BoundsResult) (query.Bounds, int) {
-	return computeIndexBounds(idx, br.LookupTight)
+	return computeIndexBounds(idx, br.LookupTight, len(idx.FieldNames))
 }
 
-
+// ComputeIndexBoundsTightCapped is ComputeIndexBoundsTight over the first
+// maxFields index fields only.
+func ComputeIndexBoundsTightCapped(idx *IndexInfo, br *BoundsResult, maxFields int) (query.Bounds, int) {
+	return computeIndexBounds(idx, br.LookupTight, maxFields)
+}
 
 // ComputeSingleFieldBounds is the single-field chain for explicit logical
 // bounds: the stored-space transform when the field is reverse-declared, the
@@ -2496,7 +2515,7 @@ func ComputeSingleFieldBounds(idx *IndexInfo, bs query.Bounds) query.Bounds {
 	return bs
 }
 
-func computeIndexBounds(idx *IndexInfo, lookup func(string) (query.Bounds, bool, bool)) (query.Bounds, int) {
+func computeIndexBounds(idx *IndexInfo, lookup func(string) (query.Bounds, bool, bool), maxFields int) (query.Bounds, int) {
 	type fieldBound struct {
 		bounds query.Bounds
 		fixed  bool
@@ -2504,7 +2523,10 @@ func computeIndexBounds(idx *IndexInfo, lookup func(string) (query.Bounds, bool,
 
 	var chainBuf [4]fieldBound // stack-allocated for typical compound indexes
 	chain := chainBuf[:0]
-	for _, field := range idx.FieldNames {
+	if maxFields > len(idx.FieldNames) {
+		maxFields = len(idx.FieldNames)
+	}
+	for _, field := range idx.FieldNames[:maxFields] {
 		fb, fixed, found := lookup(field)
 		if !found || len(fb) == 0 {
 			break
@@ -2806,7 +2828,11 @@ func coveringFilterFields(idx *CBOIndex, fieldBounds *BoundsResult) []IndexField
 	}
 
 	var filters []IndexFieldFilter
-	for fi := idx.BoundFields; fi < len(idx.Info.FieldNames); fi++ {
+	end := len(idx.Info.FieldNames)
+	if idx.UsableFields > 0 && idx.UsableFields < end {
+		end = idx.UsableFields
+	}
+	for fi := idx.BoundFields; fi < end; fi++ {
 		fieldName := idx.Info.FieldNames[fi]
 		bounds, fixed, found := fieldBounds.Lookup(fieldName)
 		if !found || !fixed || len(bounds) != 1 {

--- a/internal/qplanner/text_plan.go
+++ b/internal/qplanner/text_plan.go
@@ -380,9 +380,10 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 			// tail pad would double-pad the seek, and MergeOverlappingBounds
 			// would collapse distinct point probes (see buildIndexSeekChain).
 			root = &CoverIter{
-				Source:  &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
-				IdxInfo: idx.Info,
-				Bounds:  idx.Bounds,
+				Source:       &CursorSource{Tx: params.Tx, Ns: idx.Info.Ns},
+				IdxInfo:      idx.Info,
+				Bounds:       idx.Bounds,
+				ScalarProven: idx.ScalarProven,
 			}
 			if len(idx.Bounds) > 1 {
 				root = &DocDedupIter{Source: root}
@@ -414,6 +415,7 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 						FieldPath:    idx.Info.FieldPaths[0],
 						Reverse:      reverse,
 						FieldReverse: fieldReverse,
+						Sparse:       idx.Info.Sparse,
 					}
 				}
 			}

--- a/query.go
+++ b/query.go
@@ -1148,13 +1148,21 @@ func (q *collQuery) buildCBOIndexesInto(buf []qplanner.CBOIndex, br *qplanner.Bo
 			return proven
 		}
 
-		cboIdx := q.buildCBOIndex(idx, br, sortFields, false)
+		// Fields sharing an array with an earlier field pair with it only
+		// inside one element (index.go resolveField), so their bounds and
+		// cover filters compound with the earlier fields' only when the index
+		// provably holds no fan-out.
+		maxFields := len(idx.cboInfo.FieldNames)
+		if idx.cboInfo.SharedFrom < maxFields && !scalarProven() {
+			maxFields = idx.cboInfo.SharedFrom
+		}
+		cboIdx := q.buildCBOIndex(idx, br, sortFields, false, maxFields)
 		if br.TightDiffers(idx.cboInfo.FieldNames) {
 			if scalarProven() {
-				cboIdx = q.buildCBOIndex(idx, br, sortFields, true)
+				cboIdx = q.buildCBOIndex(idx, br, sortFields, true, maxFields)
 			} else {
 				// Estimation-only tight bounds; seeks keep the wide Bounds.
-				cboIdx.EstBounds, _ = qplanner.ComputeIndexBoundsTight(idx.cboInfo, br)
+				cboIdx.EstBounds, _ = qplanner.ComputeIndexBoundsTightCapped(idx.cboInfo, br, maxFields)
 			}
 		}
 		// A covering Count on a compound index needs the proof to keep
@@ -1167,6 +1175,15 @@ func (q *collQuery) buildCBOIndexesInto(buf []qplanner.CBOIndex, br *qplanner.Bo
 		if countOnly && len(idx.cboInfo.FieldPaths) > 1 &&
 			cboIdx.PointLookup && len(cboIdx.Bounds) <= 1 &&
 			cboIdx.BoundFields < len(idx.cboInfo.FieldNames) {
+			scalarProven()
+		}
+		// Multi-bound single-field counts (CountEntries' page-batch branch)
+		// and multi-bound unique lookups (CoverIter) need it too: a fan-out
+		// through an array of objects leaves no whole-array key to probe, so
+		// the proof alone spares them a per-entry dedup.
+		if len(cboIdx.Bounds) > 1 && cboIdx.PointLookup &&
+			((countOnly && len(idx.cboInfo.FieldPaths) == 1) ||
+				(idx.cboInfo.Unique && cboIdx.BoundFields == len(idx.cboInfo.FieldNames))) {
 			scalarProven()
 		}
 		// Order-providing gate (Mongo array-sort semantics): an index scan's
@@ -1189,6 +1206,14 @@ func (q *collQuery) buildCBOIndexesInto(buf []qplanner.CBOIndex, br *qplanner.Bo
 		// lazily, only for candidates the gate would demote. When the only cut
 		// on the sort side is a type-bracket edge, the candidate is widened
 		// (widenSortEdges) instead of demoted.
+		// A SPARSE index holds no entry for a null or missing leaf, so over
+		// fan-out data a document surfaces at its least non-null leaf while
+		// the sort key is the least leaf of all (null wins): demote, no edge
+		// widening can restore that.
+		if cboIdx.ExactSort && idx.cboInfo.Sparse && !scalarProven() {
+			cboIdx.ExactSort = false
+			cboIdx.PartialSort = false
+		}
 		if cboIdx.ExactSort && sortRunNeedsScalarProof(&cboIdx, sortFields, br) && !scalarProven() {
 			w, ok := qplanner.CBOIndex{}, false
 			if !countOnly {
@@ -1315,7 +1340,7 @@ func (q *collQuery) widenSortEdges(br *qplanner.BoundsResult, sortFields []query
 // buildCBOIndex builds one candidate's CBOIndex with bounds AND all
 // bounds-derived flags taken consistently from a single channel (wide or
 // tight) — see buildCBOIndexesInto for why mixing channels is forbidden.
-func (q *collQuery) buildCBOIndex(idx *index, br *qplanner.BoundsResult, sortFields []query.SortField, tight bool) qplanner.CBOIndex {
+func (q *collQuery) buildCBOIndex(idx *index, br *qplanner.BoundsResult, sortFields []query.SortField, tight bool, maxFields int) qplanner.CBOIndex {
 	info := idx.cboInfo
 
 	// Compute bounds for this index
@@ -1323,10 +1348,10 @@ func (q *collQuery) buildCBOIndex(idx *index, br *qplanner.BoundsResult, sortFie
 	var chainLen int
 	lookup := br.Lookup
 	if tight {
-		bounds, chainLen = qplanner.ComputeIndexBoundsTight(info, br)
+		bounds, chainLen = qplanner.ComputeIndexBoundsTightCapped(info, br, maxFields)
 		lookup = br.LookupTight
 	} else {
-		bounds, chainLen = qplanner.ComputeIndexBounds(info, br)
+		bounds, chainLen = qplanner.ComputeIndexBoundsCapped(info, br, maxFields)
 	}
 
 	pointLookup := qplanner.AllBoundsFixed(bounds)
@@ -1352,7 +1377,7 @@ func (q *collQuery) buildCBOIndex(idx *index, br *qplanner.BoundsResult, sortFie
 	// disjoint, and IndexIter consumes it from the top on a reverse scan, so the
 	// concatenated runs are globally ordered in that field.
 	equalityPrefix := 0
-	for _, field := range info.FieldNames {
+	for _, field := range info.FieldNames[:maxFields] {
 		bounds, fixed, found := lookup(field)
 		if !found || len(bounds) != 1 || !fixed {
 			break
@@ -1375,6 +1400,7 @@ func (q *collQuery) buildCBOIndex(idx *index, br *qplanner.BoundsResult, sortFie
 		Ns:             idx.ns,
 		PointLookup:    pointLookup,
 		BoundFields:    chainLen,
+		UsableFields:   maxFields,
 		ExactSort:      exactSort,
 		PartialSort:    partialSort,
 		SortMatchStart: sortMatchStart,

--- a/query/bound.go
+++ b/query/bound.go
@@ -244,8 +244,9 @@ func minStartKey(a, b Bound) ([]byte, bool, bool) {
 		return b.Start, true, false
 	}
 	switch bytes.Compare(a.Start, b.Start) {
-	case 0: // a value and an edge can share bytes ([1] is null and the null edge)
-		return a.Start, a.StartInclude, a.startEdge && b.startEdge
+	case 0: // a value and an edge can share bytes ([1] is null and the null edge);
+		// the union starts closed when either side does: (0, …) ∪ [0, 0] = [0, …)
+		return a.Start, a.StartInclude || b.StartInclude, a.startEdge && b.startEdge
 	case -1:
 		return a.Start, a.StartInclude, a.startEdge
 	default:
@@ -261,8 +262,8 @@ func maxEndKey(a, b Bound) ([]byte, bool, bool) {
 		return b.End, true, false
 	}
 	switch bytes.Compare(a.End, b.End) {
-	case 0:
-		return a.End, a.EndInclude, a.endEdge && b.endEdge
+	case 0: // the union ends closed when either side does
+		return a.End, a.EndInclude || b.EndInclude, a.endEdge && b.endEdge
 	case 1:
 		return a.End, a.EndInclude, a.endEdge
 	default:

--- a/query/bound_test.go
+++ b/query/bound_test.go
@@ -1,9 +1,11 @@
 package query
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/any-store/v2/anyenc"
 )
@@ -395,4 +397,33 @@ func TestBounds_ContainsSorted_Randomized(t *testing.T) {
 			}
 		}
 	}
+}
+
+// A union of bounds that meet at one key is closed there when either side
+// is: (0, …) ∪ [0, 0] = [0, …). Sorting orders by Start only, so both
+// input orders must agree.
+func TestSortAndMerge_TiedKeysKeepInclusion(t *testing.T) {
+	zero := anyenc.Tuple(anyenc.MustParseJson(`0`).MarshalTo(nil))
+	ten := anyenc.Tuple(anyenc.MustParseJson(`10`).MarshalTo(nil))
+	openRange := Bound{Start: zero, End: ten, StartInclude: false, EndInclude: false}
+	point := Bound{Start: zero, End: zero, StartInclude: true, EndInclude: true}
+	endPoint := Bound{Start: ten, End: ten, StartInclude: true, EndInclude: true}
+	for _, in := range []Bounds{
+		{openRange, point, endPoint},
+		{point, openRange, endPoint},
+		{endPoint, openRange, point},
+	} {
+		got := slices.Clone(in).SortAndMerge()
+		require.Len(t, got, 1)
+		assert.True(t, got[0].StartInclude, "start must be closed")
+		assert.True(t, got[0].EndInclude, "end must be closed")
+		assert.Equal(t, zero, got[0].Start)
+		assert.Equal(t, ten, got[0].End)
+	}
+
+	// The filter-level shape the differential fuzz found: {a > 0} ∪ {a = 0}.
+	bs := MustParseCondition(`{"$or":[{"$and":[{"a":{"$gt":0}},{"c":false}]},{"a":0}]}`).IndexBounds("a", nil)
+	require.Len(t, bs, 1)
+	assert.True(t, bs[0].StartInclude)
+	assert.True(t, bs.Contains(zero))
 }

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -892,6 +892,11 @@ func parseType(v *anyenc.Value) (f Filter, err error) {
 		return TypeFilter{Type: anyenc.Type(tv)}, err
 	case anyenc.TypeString:
 		bs, _ := v.StringBytes()
+		if string(bs) == "bool" {
+			// Mongo's alias for either boolean; anyenc keeps true and false as
+			// two types, so it is the union of both.
+			return Or{TypeFilter{Type: anyenc.TypeTrue}, TypeFilter{Type: anyenc.TypeFalse}}, nil
+		}
 		tv, ok := stringToType[string(bs)]
 		if !ok {
 			return nil, &ParseError{Op: "$type", Reason: "unexpected type: " + string(bs)}

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -56,6 +56,10 @@ const (
 	// Regexp, never by makeCompFilter. Appended at the end for the same
 	// iota-stability reason as opKnn.
 	opOptions
+
+	// opElemMatch: {"$elemMatch": …}, field-level (> _opVal); appended for the
+	// same iota-stability reason.
+	opElemMatch
 )
 
 var opBytesPrefix = []byte("$")
@@ -500,6 +504,8 @@ func makeCompFilter(op Operator, v *anyenc.Value) (f Filter, err error) {
 		return parseRegexp(v, "")
 	case opSize:
 		return parseSize(v)
+	case opElemMatch:
+		return parseElemMatch(v)
 	case opKnn:
 		// This arm is critical: without it a $knn value would fall through to
 		// makeArrComp, whose default arm panics on an unrecognized op.
@@ -842,6 +848,10 @@ func makeArrComp(op Operator, v *anyenc.Value) (Filter, error) {
 	case opNin:
 		return Nor(makeEqArray(v)), nil
 	case opAll:
+		vals, _ := v.Array()
+		if f, ok, err := parseAllElemMatch(vals); err != nil || ok {
+			return f, err
+		}
 		return And(makeEqArray(v)), nil
 	default:
 		panic(fmt.Errorf("unexpected operator: %v", op))

--- a/query/elem_match.go
+++ b/query/elem_match.go
@@ -1,0 +1,221 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// ElemMatch is {"$elemMatch": …}: the value must be an array with at least
+// one element satisfying Cond as a whole — the one way to bind several
+// predicates to the SAME element, where {"a.b":{"$gt":1,"$lt":3}} may pick
+// two different ones.
+//
+// Two forms, decided by the operand's first key (MongoDB's rule):
+//   - object form — {"$elemMatch": {"b": 1, "c": {"$gt": 2}}}, also
+//     {"$or": …} / {} — Cond is a document condition applied to each
+//     OBJECT element. Engine divergence: Mongo also admits array elements,
+//     matched as objects keyed by position ("0", "1", …); here they never
+//     match, so a path inside Cond cannot silently traverse a nested array.
+//   - value form — {"$elemMatch": {"$gt": 1, "$lt": 3}} — Cond is an
+//     operator set applied to each element as ONE value (ElemFilter): an
+//     element that is itself an array is compared whole, exactly as a
+//     positional leaf is.
+//
+// $text and $knn are rejected inside either form at parse time.
+type ElemMatch struct {
+	Cond      Filter
+	ValueForm bool
+}
+
+func (e ElemMatch) Ok(v *anyenc.Value, buf *syncpool.DocBuffer) bool {
+	if v == nil || v.Type() != anyenc.TypeArray {
+		return false
+	}
+	arr, _ := v.Array()
+	for _, el := range arr {
+		if e.ValueForm {
+			if okElem(e.Cond, el, buf) {
+				return true
+			}
+		} else if el.Type() == anyenc.TypeObject && e.Cond.Ok(el, buf) {
+			return true
+		}
+	}
+	return false
+}
+
+// IndexBounds for the value form are Cond's own bounds on the field: a
+// matching element's value is one of the field's fan-out entries, so the
+// element-level bounds are a sound (wide-channel) superset — except when the
+// field is a positional path, whose leaf is stored whole (no element
+// entries), or when Cond nests another $elemMatch, which looks inside an
+// element the index stores whole; both contribute nothing. The object form
+// contributes nothing on its own field; Key.IndexBounds re-keys its Cond
+// under the sub-fields (elemMatchSubField).
+func (e ElemMatch) IndexBounds(fieldName string, bs Bounds) (bounds Bounds) {
+	if !e.ValueForm || lastSegmentNumeric(fieldName) || ContainsElemMatch(e.Cond) {
+		return bs
+	}
+	return e.Cond.IndexBounds(fieldName, bs)
+}
+
+// elemMatchSubField reports whether the Key holds an object-form $elemMatch
+// — or an $all conjunction of them — whose condition constrains fieldName
+// below the Key's path, and returns that condition with the sub-field name.
+// Sound because the index fans an element's values out under the sub-field,
+// so a matching element's value is an entry there. Not on a positional path:
+// its leaf is stored whole and has no element entries to seek.
+func (e Key) elemMatchSubField(fieldName string) (cond Filter, sub string, ok bool) {
+	path := strings.Join(e.Path, ".")
+	if len(fieldName) <= len(path)+1 || fieldName[len(path)] != '.' ||
+		!strings.HasPrefix(fieldName, path) || lastSegmentNumeric(path) {
+		return nil, "", false
+	}
+	sub = fieldName[len(path)+1:]
+	// A numeric first segment indexes the ARRAY on the index side (the leaf
+	// is stored whole) but names an object key inside the element on the
+	// condition side: nothing to seek.
+	first := sub
+	if i := strings.IndexByte(first, '.'); i >= 0 {
+		first = first[:i]
+	}
+	if _, numeric := anyenc.ParseIndexSegment(first); numeric {
+		return nil, "", false
+	}
+	objectForm := func(f Filter) (Filter, bool) {
+		switch em := f.(type) {
+		case ElemMatch:
+			return em.Cond, !em.ValueForm
+		case *ElemMatch:
+			return em.Cond, !em.ValueForm
+		}
+		return nil, false
+	}
+	if c, ok := objectForm(e.Filter); ok {
+		return c, sub, true
+	}
+	var children []Filter
+	switch ft := e.Filter.(type) {
+	case And:
+		children = ft
+	case *And:
+		children = *ft
+	default:
+		return nil, "", false
+	}
+	if len(children) == 0 {
+		return nil, "", false
+	}
+	conds := make(And, 0, len(children))
+	for _, child := range children {
+		c, ok := objectForm(child)
+		if !ok {
+			return nil, "", false
+		}
+		conds = append(conds, c)
+	}
+	return conds, sub, true
+}
+
+func (e ElemMatch) String() string {
+	return fmt.Sprintf(`{"$elemMatch": %s}`, e.Cond.String())
+}
+
+// lastSegmentNumeric reports whether the dotted field name ends in an array
+// index segment — a positional path, whose leaf the index stores whole.
+func lastSegmentNumeric(fieldName string) bool {
+	last := fieldName
+	if i := strings.LastIndexByte(fieldName, '.'); i >= 0 {
+		last = fieldName[i+1:]
+	}
+	_, numeric := anyenc.ParseIndexSegment(last)
+	return numeric
+}
+
+// parseElemMatch compiles a $elemMatch operand. The first key decides the
+// form: a field-level operator ($gt, $not, $in, …, $elemMatch itself) means
+// the value form; anything else — a field name, {}, or a top-level logical
+// operator like $or — means the object form.
+func parseElemMatch(v *anyenc.Value) (Filter, error) {
+	obj, err := v.Object()
+	if err != nil {
+		return nil, &ParseError{Op: "$elemMatch", Reason: "$elemMatch must be an object"}
+	}
+	valueForm := false
+	first := true
+	obj.Visit(func(key []byte, _ *anyenc.Value) {
+		if !first {
+			return
+		}
+		first = false
+		isOp, op, opErr := isOperator(key)
+		valueForm = opErr == nil && isOp && !isTopLevel(op)
+	})
+	if valueForm {
+		hasOp, cond, err := parseCompObjOp(v)
+		if err != nil {
+			return nil, err
+		}
+		if !hasOp {
+			return nil, &ParseError{Op: "$elemMatch", Reason: "expected an object of operators"}
+		}
+		if ContainsKnn(cond) {
+			return nil, &ParseError{Op: "$knn", Reason: "$knn is not allowed under $elemMatch"}
+		}
+		return ElemMatch{Cond: cond, ValueForm: true}, nil
+	}
+	cond, err := parseAnd(v)
+	if err != nil {
+		return nil, err
+	}
+	if cond == nil {
+		cond = All{} // {"$elemMatch": {}}: any object element
+	}
+	if ContainsSourceFilter(cond) {
+		return nil, &ParseError{Op: "$elemMatch", Reason: "$text and $knn are not allowed under $elemMatch"}
+	}
+	return ElemMatch{Cond: cond}, nil
+}
+
+// parseAllElemMatch handles {"$all": [{"$elemMatch": …}, …]}: every element
+// must be a single-key {"$elemMatch": …} object (Mongo's rule — mixing
+// $elemMatch with plain values is a rejection), and the result is the
+// conjunction of the element matches. ok=false means no element is an
+// $elemMatch object and the caller keeps the plain equality form.
+func parseAllElemMatch(vals []*anyenc.Value) (f Filter, ok bool, err error) {
+	n := 0
+	for _, el := range vals {
+		if isElemMatchObject(el) {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil, false, nil
+	}
+	if n != len(vals) {
+		return nil, false, &ParseError{Op: "$all", Reason: "$all cannot mix $elemMatch with values"}
+	}
+	fs := make(And, 0, len(vals))
+	for i, el := range vals {
+		em, err := parseElemMatch(el.Get("$elemMatch"))
+		if err != nil {
+			return nil, false, atPath(atPath(err, "$elemMatch"), fmt.Sprint(i))
+		}
+		fs = append(fs, em)
+	}
+	if len(fs) == 1 {
+		return fs[0], true, nil
+	}
+	return fs, true, nil
+}
+
+func isElemMatchObject(v *anyenc.Value) bool {
+	obj, err := v.Object()
+	if err != nil || obj.Len() != 1 {
+		return false
+	}
+	return v.Get("$elemMatch") != nil
+}

--- a/query/elem_match_test.go
+++ b/query/elem_match_test.go
@@ -1,0 +1,166 @@
+package query
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+)
+
+func TestElemMatch_Parse(t *testing.T) {
+	t.Run("object form", func(t *testing.T) {
+		for _, js := range []string{
+			`{"a":{"$elemMatch":{"b":1}}}`,
+			`{"a":{"$elemMatch":{"b":{"$gt":1},"c":2}}}`,
+			`{"a":{"$elemMatch":{"$or":[{"b":1},{"c":2}]}}}`,
+			`{"a":{"$elemMatch":{}}}`,
+		} {
+			f, err := ParseCondition(js)
+			require.NoError(t, err, js)
+			em, ok := f.(Key).Filter.(ElemMatch)
+			require.True(t, ok, js)
+			assert.False(t, em.ValueForm, js)
+			assert.NotNil(t, em.Cond, js)
+		}
+	})
+	t.Run("value form", func(t *testing.T) {
+		for _, js := range []string{
+			`{"a":{"$elemMatch":{"$gt":1,"$lt":3}}}`,
+			`{"a":{"$elemMatch":{"$eq":1}}}`,
+			`{"a":{"$elemMatch":{"$not":{"$gt":1}}}}`,
+			`{"a":{"$elemMatch":{"$elemMatch":{"c":1}}}}`,
+			`{"a":{"$elemMatch":{"$in":[1,2]}}}`,
+		} {
+			f, err := ParseCondition(js)
+			require.NoError(t, err, js)
+			em, ok := f.(Key).Filter.(ElemMatch)
+			require.True(t, ok, js)
+			assert.True(t, em.ValueForm, js)
+		}
+	})
+	t.Run("rejections", func(t *testing.T) {
+		for _, tc := range []struct{ js, path, op string }{
+			{`{"a":{"$elemMatch":1}}`, "a.$elemMatch", "$elemMatch"},
+			{`{"a":{"$elemMatch":{"$gt":1,"b":2}}}`, "a.$elemMatch.b", ""},
+			{`{"a":{"$elemMatch":{"b":{"$sizee":1}}}}`, "a.$elemMatch.b.$sizee", "$sizee"},
+			{`{"a":{"$elemMatch":{"$text":{"$search":"x"}}}}`, "a.$elemMatch", "$elemMatch"},
+			{`{"a":{"$all":[{"$elemMatch":{"b":1}},2]}}`, "a.$all", "$all"},
+		} {
+			_, err := ParseCondition(tc.js)
+			require.Error(t, err, tc.js)
+			var pe *ParseError
+			require.True(t, errors.As(err, &pe), tc.js)
+			assert.Equal(t, tc.path, pe.Path, tc.js)
+			if tc.op != "" {
+				assert.Equal(t, tc.op, pe.Op, tc.js)
+			}
+		}
+	})
+	t.Run("all of elemMatch", func(t *testing.T) {
+		f, err := ParseCondition(`{"a":{"$all":[{"$elemMatch":{"b":1}},{"$elemMatch":{"c":2}}]}}`)
+		require.NoError(t, err)
+		and, ok := f.(Key).Filter.(And)
+		require.True(t, ok)
+		assert.Len(t, and, 2)
+		f, err = ParseCondition(`{"a":{"$all":[{"$elemMatch":{"b":1}}]}}`)
+		require.NoError(t, err)
+		_, ok = f.(Key).Filter.(ElemMatch)
+		assert.True(t, ok)
+	})
+}
+
+func TestElemMatch_Ok(t *testing.T) {
+	cases := []struct {
+		filter string
+		doc    string
+		want   bool
+	}{
+		// object form: one element must satisfy every predicate
+		{`{"a":{"$elemMatch":{"b":1,"c":2}}}`, `{"a":[{"b":1,"c":2}]}`, true},
+		{`{"a":{"$elemMatch":{"b":1,"c":2}}}`, `{"a":[{"b":1},{"c":2}]}`, false},
+		{`{"a.b":1,"a.c":2}`, `{"a":[{"b":1},{"c":2}]}`, true}, // the unbound form does match
+		{`{"a":{"$elemMatch":{"b":{"$gt":1,"$lt":3}}}}`, `{"a":[{"b":1},{"b":5}]}`, false},
+		{`{"a.b":{"$gt":1,"$lt":3}}`, `{"a":[{"b":1},{"b":5}]}`, true},
+		{`{"a":{"$elemMatch":{"b":{"$gt":1,"$lt":3}}}}`, `{"a":[{"b":[1,5,2]}]}`, true}, // leaf array inside the element
+		{`{"a":{"$elemMatch":{"b.c":1}}}`, `{"a":[{"b":[{"c":1}]}]}`, true},
+		{`{"a":{"$elemMatch":{"$or":[{"b":1},{"c":2}]}}}`, `{"a":[{"c":2}]}`, true},
+		{`{"a":{"$elemMatch":{}}}`, `{"a":[1,{"x":1}]}`, true},
+		{`{"a":{"$elemMatch":{}}}`, `{"a":[1,[{"x":1}]]}`, false}, // object elements only
+		{`{"a":{"$elemMatch":{"b":{"$exists":false}}}}`, `{"a":[{"c":1}]}`, true},
+		{`{"a":{"$elemMatch":{"b":1}}}`, `{"a":{"b":1}}`, false}, // not an array
+		{`{"a":{"$elemMatch":{"b":1}}}`, `{}`, false},
+		{`{"a":{"$elemMatch":{"b":1}}}`, `{"a":[]}`, false},
+		// value form: each element as one value, no traversal
+		{`{"a":{"$elemMatch":{"$gt":1,"$lt":3}}}`, `{"a":[1,2]}`, true},
+		{`{"a":{"$elemMatch":{"$gt":1,"$lt":3}}}`, `{"a":[1,5]}`, false},
+		{`{"a":{"$elemMatch":{"$gt":1,"$lt":3}}}`, `{"a":[[1,2],[3]]}`, false},
+		{`{"a":{"$elemMatch":{"$eq":[1,2]}}}`, `{"a":[[1,2],[3]]}`, true},
+		{`{"a":{"$elemMatch":{"$elemMatch":{"$eq":2}}}}`, `{"a":[[1,2],[3]]}`, true},
+		{`{"a":{"$elemMatch":{"$ne":1}}}`, `{"a":[1,null]}`, true},
+		{`{"a":{"$elemMatch":{"$type":"object"}}}`, `{"a":[1,{"x":1}]}`, true},
+		{`{"a":{"$elemMatch":{"$type":"number"}}}`, `{"a":[[1],"x"]}`, false},
+		{`{"a":{"$elemMatch":{"$regex":"^x"}}}`, `{"a":["y","xz"]}`, true},
+		{`{"a":{"$elemMatch":{"$in":[1,3]}}}`, `{"a":[2,3]}`, true},
+		{`{"a":{"$elemMatch":{"$exists":true}}}`, `{"a":[null]}`, true},
+		{`{"a":{"$elemMatch":{"$exists":true}}}`, `{"a":[]}`, false},
+		{`{"a":{"$elemMatch":{"$size":2}}}`, `{"a":[[1,2]]}`, true},
+		// through a path: applies to every leaf array; a positional leaf is iterated too
+		{`{"a.b":{"$elemMatch":{"$gt":1}}}`, `{"a":[{"b":[0]},{"b":[0,2]}]}`, true},
+		{`{"a.0":{"$elemMatch":{"$eq":2}}}`, `{"a":[[1,2]]}`, true},
+		// negation
+		{`{"a":{"$not":{"$elemMatch":{"b":1}}}}`, `{"a":[{"b":1}]}`, false},
+		{`{"a":{"$not":{"$elemMatch":{"b":1}}}}`, `{"a":[{"b":2}]}`, true},
+		{`{"a":{"$all":[{"$elemMatch":{"b":1}},{"$elemMatch":{"c":2}}]}}`, `{"a":[{"b":1},{"c":2}]}`, true},
+		{`{"a":{"$all":[{"$elemMatch":{"b":1}},{"$elemMatch":{"c":2}}]}}`, `{"a":[{"b":1}]}`, false},
+	}
+	for _, c := range cases {
+		f, err := ParseCondition(c.filter)
+		require.NoError(t, err, c.filter)
+		assert.Equal(t, c.want, f.Ok(anyenc.MustParseJson(c.doc), nil), "%s on %s", c.filter, c.doc)
+	}
+}
+
+func TestElemMatch_IndexBoundsAndString(t *testing.T) {
+	// value form: the element-level bounds on the field itself
+	f := MustParseCondition(`{"a":{"$elemMatch":{"$gt":1,"$lt":3}}}`)
+	bs := f.IndexBounds("a", nil)
+	require.Len(t, bs, 1)
+	assert.Equal(t, anyenc.Tuple(anyenc.MustParseJson(`1`).MarshalTo(nil)), bs[0].Start) // first conjunct, wide channel
+	assert.Empty(t, f.IndexBounds("a.b", nil))
+	// positional path: the leaf is stored whole, no element bounds
+	assert.Empty(t, MustParseCondition(`{"a.0":{"$elemMatch":{"$gt":1}}}`).IndexBounds("a.0", nil))
+	// a nested $elemMatch looks inside elements the index stores whole
+	assert.Empty(t, MustParseCondition(`{"a":{"$elemMatch":{"$elemMatch":{"$eq":2}}}}`).IndexBounds("a", nil))
+	assert.Empty(t, MustParseCondition(`{"a":{"$elemMatch":{"$not":{"$elemMatch":{"$eq":2}}}}}`).IndexBounds("a", nil))
+	// $all of object forms re-keys like the $and spelling
+	all := MustParseCondition(`{"a":{"$all":[{"$elemMatch":{"b":{"$gt":1}}},{"$elemMatch":{"c":2}}]}}`)
+	and := MustParseCondition(`{"$and":[{"a":{"$elemMatch":{"b":{"$gt":1}}}},{"a":{"$elemMatch":{"c":2}}}]}`)
+	assert.Equal(t, and.IndexBounds("a.b", nil), all.IndexBounds("a.b", nil))
+	assert.Len(t, all.IndexBounds("a.c", nil), 1)
+	tbAll, _ := TightIndexBounds(all, "a.b")
+	tbAnd, _ := TightIndexBounds(and, "a.b")
+	assert.Equal(t, tbAnd, tbAll)
+	assert.True(t, ContainsElemMatch(all))
+	assert.False(t, ContainsElemMatch(MustParseCondition(`{"a.b":1}`)))
+
+	// object form: re-keyed under the sub-field, none on the field itself
+	f = MustParseCondition(`{"a":{"$elemMatch":{"b":{"$gt":1},"c":2}}}`)
+	assert.Empty(t, f.IndexBounds("a", nil))
+	bs = f.IndexBounds("a.b", nil)
+	require.Len(t, bs, 1)
+	assert.Equal(t, anyenc.Tuple(anyenc.MustParseJson(`1`).MarshalTo(nil)), bs[0].Start)
+	assert.Len(t, f.IndexBounds("a.c", nil), 1)
+	assert.Empty(t, f.IndexBounds("a.d", nil))
+	assert.Empty(t, f.IndexBounds("ab", nil))
+	assert.Empty(t, MustParseCondition(`{"a.0":{"$elemMatch":{"b":1}}}`).IndexBounds("a.0.b", nil))
+	tb, empty := TightIndexBounds(f, "a.b")
+	assert.False(t, empty)
+	assert.Len(t, tb, 1)
+
+	assert.Equal(t, `{"a": {"$elemMatch": {"$gt": 1}}}`, MustParseCondition(`{"a":{"$elemMatch":{"$gt":1}}}`).String())
+	assert.True(t, GuaranteesPresence(MustParseCondition(`{"a":{"$elemMatch":{"b":1}}}`), "a"))
+	assert.True(t, ContainsKnn(Key{Path: []string{"a"}, Filter: ElemMatch{Cond: Key{Path: []string{"v"}, Filter: &Knn{}}}}))
+}

--- a/query/errors_test.go
+++ b/query/errors_test.go
@@ -460,7 +460,7 @@ func TestModifierOperators(t *testing.T) {
 func TestOperators(t *testing.T) {
 	ops := Operators()
 	assert.Equal(t, []string{
-		"$all", "$and", "$eq", "$exists", "$gt", "$gte", "$in", "$knn",
+		"$all", "$and", "$elemMatch", "$eq", "$exists", "$gt", "$gte", "$in", "$knn",
 		"$lt", "$lte", "$ne", "$nin", "$nor", "$not", "$options", "$or",
 		"$regex", "$size", "$text", "$type",
 	}, ops)

--- a/query/filter.go
+++ b/query/filter.go
@@ -468,8 +468,42 @@ type Key struct {
 	Filter
 }
 
+// Ok resolves the path to its leaf set. A path that crosses no array of
+// objects has one leaf (anyenc.Value.GetLeaf) and is evaluated by Ok exactly
+// as a Get result is; otherwise the leaves go through LeafFilter semantics.
+//
+// buf.Leaves is a stack: this frame's leaves live above base and are cut
+// back on return, so a Key nested in the inner filter ($elemMatch) appends
+// its own leaves above ours without disturbing the slice we iterate. The
+// frame is cleared before the cut so a pooled buffer does not pin the
+// document's values.
 func (e Key) Ok(v *anyenc.Value, buf *syncpool.DocBuffer) bool {
-	return e.Filter.Ok(v.Get(e.Path...), buf)
+	if leaf, single := v.GetLeaf(e.Path...); single {
+		return e.Filter.Ok(leaf, buf)
+	}
+	if buf == nil {
+		// No per-query scratch (hand-built callers, $pull conditions): a pooled
+		// leaf slice keeps this path alloc-free too.
+		lb := leafBufPool.Get().(*leafBuf)
+		lb.leaves = v.AppendLeaves(lb.leaves[:0], e.Path...)
+		ok := okLeafSet(e.Filter, lb.leaves, nil)
+		clear(lb.leaves)
+		leafBufPool.Put(lb)
+		return ok
+	}
+	base := len(buf.Leaves)
+	buf.Leaves = v.AppendLeaves(buf.Leaves, e.Path...)
+	ok := okLeafSet(e.Filter, buf.Leaves[base:], buf)
+	clear(buf.Leaves[base:])
+	buf.Leaves = buf.Leaves[:base]
+	return ok
+}
+
+func okLeafSet(f Filter, leaves []anyenc.Leaf, buf *syncpool.DocBuffer) bool {
+	if len(leaves) == 1 {
+		return okLeaf(f, leaves[0], buf)
+	}
+	return okLeaves(f, leaves, buf)
 }
 
 func (e Key) IndexBounds(fieldName string, bs Bounds) (bounds Bounds) {
@@ -1158,11 +1192,26 @@ type TypeFilter struct {
 	Type anyenc.Type
 }
 
+// Ok matches the value's own type or, for an array, any element's type (as
+// MongoDB: {"$type":"number"} on ["x",1] matches, {"$type":"array"} matches
+// the array itself). A missing field has no type: {"$type":"null"} needs an
+// explicit null.
 func (e TypeFilter) Ok(v *anyenc.Value, buf *syncpool.DocBuffer) bool {
 	if v == nil {
 		return false
 	}
-	return v.Type() == e.Type
+	if v.Type() == e.Type {
+		return true
+	}
+	if v.Type() == anyenc.TypeArray {
+		arr, _ := v.Array()
+		for _, el := range arr {
+			if el.Type() == e.Type {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (e TypeFilter) IndexBounds(fieldName string, bs Bounds) (bounds Bounds) {

--- a/query/filter.go
+++ b/query/filter.go
@@ -506,9 +506,16 @@ func okLeafSet(f Filter, leaves []anyenc.Leaf, buf *syncpool.DocBuffer) bool {
 	return okLeaves(f, leaves, buf)
 }
 
+// IndexBounds delegates to the inner filter on this path's own field. An
+// object-form $elemMatch additionally constrains the fields BELOW the path:
+// {"a":{"$elemMatch":{"b":{"$gt":1}}}} bounds "a.b" exactly as
+// {"a.b":{"$gt":1}} would (elemMatchSubField).
 func (e Key) IndexBounds(fieldName string, bs Bounds) (bounds Bounds) {
 	if strings.Join(e.Path, ".") == fieldName {
 		return e.Filter.IndexBounds(fieldName, bs)
+	}
+	if cond, sub, ok := e.elemMatchSubField(fieldName); ok {
+		return cond.IndexBounds(sub, bs)
 	}
 	return bs
 }
@@ -1058,6 +1065,10 @@ func FilterTreeAny(f Filter, pred func(Filter) bool) bool {
 		return FilterTreeAny(ft.Filter, pred)
 	case *Key:
 		return FilterTreeAny(ft.Filter, pred)
+	case ElemMatch:
+		return FilterTreeAny(ft.Cond, pred)
+	case *ElemMatch:
+		return FilterTreeAny(ft.Cond, pred)
 	}
 	return false
 }
@@ -1120,6 +1131,18 @@ func ContainsKnn(f Filter) bool {
 // matches nothing.
 func ContainsSourceFilter(f Filter) bool {
 	return FilterTreeAny(f, isSourceLeaf)
+}
+
+// ContainsElemMatch reports whether f contains a $elemMatch anywhere. Index
+// bounds of such a filter are supersets, never the exact value image.
+func ContainsElemMatch(f Filter) bool {
+	return FilterTreeAny(f, func(f Filter) bool {
+		switch f.(type) {
+		case ElemMatch, *ElemMatch:
+			return true
+		}
+		return false
+	})
 }
 
 // presenceNullProbe is an explicit JSON null used by GuaranteesPresence to test

--- a/query/leaves.go
+++ b/query/leaves.go
@@ -1,0 +1,191 @@
+package query
+
+import (
+	"sync"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// leafBuf is the leaf-set scratch Key.Ok borrows when the caller passes no
+// DocBuffer.
+type leafBuf struct {
+	leaves []anyenc.Leaf
+}
+
+var leafBufPool = sync.Pool{New: func() any { return &leafBuf{} }}
+
+// LeafFilter evaluates a filter against the LEAF SET of a dotted path — the
+// values anyenc.Value.AppendLeaves yields when the path crosses an array of
+// objects (a nil Value is a missing leaf). Key.Ok calls it whenever a path
+// resolves to more than one leaf; a single leaf goes through Ok (or OkElem)
+// unchanged.
+//
+// MongoDB quantifies per operator: a positive predicate matches when ANY
+// leaf satisfies it, a negation ($ne, $nin, $not, $nor) when NO leaf
+// satisfies the negated predicate, and sibling operators on one path
+// quantify independently — {"a.b":{"$gt":1,"$lt":3}} may pick its two
+// witnesses from different elements ($elemMatch binds them). Filters that do
+// not implement LeafFilter get the positive rule (okLeaves); the negation
+// forms implement it themselves.
+type LeafFilter interface {
+	OkLeaves(leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool
+}
+
+// ElemFilter evaluates a filter against ONE value with no array iteration:
+// an array value is compared whole. Used for positional leaves ({"a.0":…}
+// on an element that is itself an array) and for the elements of an
+// $elemMatch operator form. Filters that do not implement it are evaluated
+// by Ok, which is right for every filter whose Ok never iterates arrays.
+type ElemFilter interface {
+	OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool
+}
+
+// okLeaf evaluates f on one leaf, honouring Positional.
+func okLeaf(f Filter, l anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	if l.Positional {
+		return okElem(f, l.Value, docBuf)
+	}
+	return f.Ok(l.Value, docBuf)
+}
+
+func okElem(f Filter, v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	if ef, ok := f.(ElemFilter); ok {
+		return ef.OkElem(v, docBuf)
+	}
+	return f.Ok(v, docBuf)
+}
+
+// okLeaves is the positive rule: any leaf satisfies f.
+func okLeaves(f Filter, leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	if lf, ok := f.(LeafFilter); ok {
+		return lf.OkLeaves(leaves, docBuf)
+	}
+	for _, l := range leaves {
+		if okLeaf(f, l, docBuf) {
+			return true
+		}
+	}
+	return false
+}
+
+// OkLeaves: $ne is a negation — no leaf may equal the operand (a leaf array
+// is checked whole and per element by Ok); every other op is positive.
+func (e *Comp) OkLeaves(leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	if e.CompOp == CompOpNe {
+		for _, l := range leaves {
+			if !okLeaf(e, l, docBuf) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, l := range leaves {
+		if okLeaf(e, l, docBuf) {
+			return true
+		}
+	}
+	return false
+}
+
+// OkElem compares the value whole: no element iteration for an array.
+func (e *Comp) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	if e.isOrderingOp() && e.eqIsVector() {
+		return false
+	}
+	if v == nil {
+		return e.comp(encodedNull)
+	}
+	return e.okScalar(v, docBuf)
+}
+
+// OkElem: membership of the value itself.
+func (e In) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	if v == nil {
+		_, ok := e.Values[string(encodedNull)]
+		return ok
+	}
+	if docBuf == nil {
+		docBuf = &syncpool.DocBuffer{}
+	}
+	return e.containsValue(v, docBuf)
+}
+
+// OkElem: the value must be a string.
+func (r Regexp) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	if v == nil || v.Type() != anyenc.TypeString {
+		return false
+	}
+	exp, _ := v.StringBytes()
+	return r.Regexp.Match(exp)
+}
+
+// OkElem: the value's own type.
+func (e TypeFilter) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	return v != nil && v.Type() == e.Type
+}
+
+// OkLeaves quantifies each conjunct independently.
+func (e And) OkLeaves(leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	for _, f := range e {
+		if !okLeaves(f, leaves, docBuf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e And) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	for _, f := range e {
+		if !okElem(f, v, docBuf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e Or) OkLeaves(leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	for _, f := range e {
+		if okLeaves(f, leaves, docBuf) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e Or) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	for _, f := range e {
+		if okElem(f, v, docBuf) {
+			return true
+		}
+	}
+	return false
+}
+
+// OkLeaves: no leaf satisfies any branch.
+func (e Nor) OkLeaves(leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	for _, f := range e {
+		if okLeaves(f, leaves, docBuf) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e Nor) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	for _, f := range e {
+		if okElem(f, v, docBuf) {
+			return false
+		}
+	}
+	return true
+}
+
+// OkLeaves: no leaf satisfies the inner filter.
+func (e Not) OkLeaves(leaves []anyenc.Leaf, docBuf *syncpool.DocBuffer) bool {
+	return !okLeaves(e.Filter, leaves, docBuf)
+}
+
+func (e Not) OkElem(v *anyenc.Value, docBuf *syncpool.DocBuffer) bool {
+	return !okElem(e.Filter, v, docBuf)
+}

--- a/query/leaves_test.go
+++ b/query/leaves_test.go
@@ -1,0 +1,127 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/any-store/v2/anyenc"
+	"github.com/anyproto/any-store/v2/syncpool"
+)
+
+// Dotted paths through arrays of objects: MongoDB matcher semantics
+// (docs/query-filter-contract.md item 14).
+func TestKey_PathThroughArrays(t *testing.T) {
+	cases := []struct {
+		filter string
+		doc    string
+		want   bool
+	}{
+		{`{"a.b":1}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		{`{"a.b":3}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.b":1}`, `{"a":[{"b":[1,2]}]}`, true},          // leaf array, per element
+		{`{"a.b":[1,2]}`, `{"a":[{"b":[1,2]}]}`, true},      // leaf array, whole
+		{`{"a.b":[1,2]}`, `{"a":[{"b":1},{"b":2}]}`, false}, // not a collected array
+		{`{"a.b":1}`, `{"a":[[{"b":1}]]}`, false},           // nested arrays are not traversed
+		{`{"a.b.c":1}`, `{"a":[{"b":[{"c":1}]}]}`, true},    // traversal repeats per level
+		// independent quantification per operator
+		{`{"a.b":{"$gt":1,"$lt":2}}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		{`{"a.b":{"$gt":1,"$lte":1}}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		{`{"a.b":{"$in":[1],"$nin":[2]}}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.b":{"$in":[1],"$nin":[2]}}`, `{"a":[{"b":1},{"b":3}]}`, true},
+		{`{"a.b":{"$all":[1,2]}}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		// negations: no leaf may match
+		{`{"a.b":{"$ne":1}}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.b":{"$ne":3}}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		{`{"a.b":{"$nin":[2,3]}}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.b":{"$not":{"$gt":1}}}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.b":{"$not":{"$gt":5}}}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		{`{"$nor":[{"a.b":1}]}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		// null and missing leaves
+		{`{"a.b":null}`, `{"a":[{"b":1},{"c":2}]}`, true},
+		{`{"a.b":null}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.b":null}`, `{"a":[]}`, true},
+		{`{"a.b":null}`, `{"a":[1,2]}`, true},
+		{`{"a.b":null}`, `{"a":5}`, true},
+		{`{"a.b":{"$ne":null}}`, `{"a":[{"b":1},{"c":2}]}`, false},
+		{`{"a.b":{"$exists":true}}`, `{"a":[{"b":1},{"c":2}]}`, true},
+		{`{"a.b":{"$exists":true}}`, `{"a":[{"c":2}]}`, false},
+		{`{"a.b":{"$exists":false}}`, `{"a":[]}`, true},
+		{`{"a.b":{"$exists":false}}`, `{"a":[{"b":null}]}`, false},
+		{`{"a.b":{"$type":"null"}}`, `{"a":[{"c":1}]}`, false}, // missing is not null-typed
+		{`{"a.b":{"$type":"null"}}`, `{"a":[{"b":null}]}`, true},
+		// other leaf operators quantify over leaves too
+		{`{"a.b":{"$size":2}}`, `{"a":[{"b":[1]},{"b":[1,2]}]}`, true},
+		{`{"a.b":{"$type":"string"}}`, `{"a":[{"b":1},{"b":"x"}]}`, true},
+		{`{"a.b":{"$type":"array"}}`, `{"a":[{"b":1},{"b":[]}]}`, true},
+		{`{"a.b":{"$regex":"^x"}}`, `{"a":[{"b":"y"},{"b":"xz"}]}`, true},
+		// numeric segments: index, and the leaf is compared whole
+		{`{"a.0.b":1}`, `{"a":[{"b":1},{"b":2}]}`, true},
+		{`{"a.1.b":1}`, `{"a":[{"b":1},{"b":2}]}`, false},
+		{`{"a.0":1}`, `{"a":[[1,2]]}`, false},
+		{`{"a.0":[1,2]}`, `{"a":[[1,2]]}`, true},
+		{`{"a.0":{"$type":"number"}}`, `{"a":[[1,2]]}`, false},
+		{`{"a.0":{"$size":2}}`, `{"a":[[1,2]]}`, true},
+		{`{"a.0.b":1}`, `{"a":[[{"b":1}]]}`, true}, // traversal resumes after the index
+		{`{"a.0":1}`, `{"a":{"0":[1,2]}}`, true},   // an object key "0" is an ordinary leaf
+	}
+	for _, c := range cases {
+		f, err := ParseCondition(c.filter)
+		require.NoError(t, err, c.filter)
+		doc := anyenc.MustParseJson(c.doc)
+		assert.Equal(t, c.want, f.Ok(doc, nil), "%s on %s (nil buf)", c.filter, c.doc)
+		buf := &syncpool.DocBuffer{Parser: &anyenc.Parser{}}
+		assert.Equal(t, c.want, f.Ok(doc, buf), "%s on %s", c.filter, c.doc)
+		if rf, ok := f.(RawFilter); ok {
+			// the raw path must agree or decline, never disagree
+			got, handled := rf.OkRaw(doc.MarshalTo(nil), buf)
+			if handled {
+				assert.Equal(t, c.want, got, "raw %s on %s", c.filter, c.doc)
+			}
+		}
+	}
+}
+
+func TestKey_PathThroughArrays_AllocFree(t *testing.T) {
+	doc := anyenc.MustParseJson(`{"a":[{"b":[{"c":1},{"c":2}]},{"b":[{"c":3}]},{"x":1},5]}`)
+	buf := &syncpool.DocBuffer{Parser: &anyenc.Parser{}}
+	for _, js := range []string{
+		`{"a.b.c":3}`,
+		`{"a.b.c":{"$gt":1,"$lt":3}}`,
+		`{"a.b.c":{"$ne":9}}`,
+		`{"a.b.c":{"$in":[3,4]}}`,
+		`{"a.b":{"$elemMatch":{"c":{"$gt":1,"$lt":3}}}}`,
+		`{"a":{"$elemMatch":{"b":{"$elemMatch":{"c":3}}}}}`,
+	} {
+		f := MustParseCondition(js)
+		require.True(t, f.Ok(doc, buf), js)
+		allocs := testing.AllocsPerRun(50, func() { f.Ok(doc, buf) })
+		assert.Zero(t, allocs, js)
+	}
+}
+
+// Without a DocBuffer the leaf set lives on the stack.
+func TestKey_PathThroughArrays_NilBufAllocFree(t *testing.T) {
+	doc := anyenc.MustParseJson(`{"a":[{"b":1},{"b":2},{"b":3}]}`)
+	f := MustParseCondition(`{"a.b":3}`)
+	require.True(t, f.Ok(doc, nil))
+	assert.Zero(t, testing.AllocsPerRun(50, func() { f.Ok(doc, nil) }))
+}
+
+// Nested Keys ($elemMatch conditions) push and pop their own leaves above the
+// enclosing Key's on the shared DocBuffer stack.
+func TestKey_LeafStackNesting(t *testing.T) {
+	doc := anyenc.MustParseJson(`{"a":[{"b":[{"c":1},{"c":5}]},{"b":[{"c":2}]}]}`)
+	buf := &syncpool.DocBuffer{Parser: &anyenc.Parser{}}
+	f := MustParseCondition(`{"a.b":{"$elemMatch":{"c":{"$gt":1,"$lt":3}}}}`)
+	assert.True(t, f.Ok(doc, buf))
+	assert.Empty(t, buf.Leaves)
+	f = MustParseCondition(`{"a.b":{"$elemMatch":{"c":{"$gt":5}}}}`)
+	assert.False(t, f.Ok(doc, buf))
+	assert.Empty(t, buf.Leaves)
+	// the frame is cleared, not just cut: a pooled buffer pins no values
+	for _, l := range buf.Leaves[:cap(buf.Leaves)] {
+		assert.Nil(t, l.Value)
+	}
+}

--- a/query/operators.go
+++ b/query/operators.go
@@ -29,6 +29,8 @@ var operators = map[string]Operator{
 	"$options": opOptions,
 	"$size":    opSize,
 
+	"$elemMatch": opElemMatch,
+
 	"$knn": opKnn,
 }
 

--- a/query/sort.go
+++ b/query/sort.go
@@ -165,58 +165,77 @@ type SortField struct {
 	Reverse bool
 }
 
-func (s *SortField) AppendKey(tuple anyenc.Tuple, v *anyenc.Value) anyenc.Tuple {
-	return s.appendElementKey(tuple, v.Get(s.Path...))
-}
-
-// appendElementKey appends fv's sort key under Mongo array-sort semantics: a
-// non-empty array contributes its MINIMUM element ascending / MAXIMUM element
-// descending — chosen from all elements, independent of any query predicate
-// (MongoDB >= 4.4, SERVER-19402). This is exactly the element an ordered index
-// scan encounters first for the doc (min forward, max reverse — see
-// qplanner.CanonicalKeyDedupIter), so plan choice cannot change the order.
-//
-// An empty array contributes its own whole-array encoding: the index stores an
-// empty array only under that key, so both plans agree; this deliberately
-// diverges from Mongo (which sorts [] before null) — matching that would need
-// a key encoding below TypeNull on disk. A nil/missing value marshals to
-// TypeNull, unchanged.
+// AppendKey appends the document's sort key for this field under Mongo
+// array-sort semantics. The path resolves to its leaf set
+// (anyenc.Value.WalkLeaves) and every non-empty, non-positional array leaf
+// contributes its elements; the key is the MINIMUM candidate ascending /
+// MAXIMUM descending — chosen from all candidates, independent of any query
+// predicate (MongoDB >= 4.4, SERVER-19402). This is exactly the entry an
+// ordered index scan encounters first for the doc (min forward, max reverse
+// — see qplanner.CanonicalKeyDedupIter), so plan choice cannot change the
+// order. A missing leaf is null. An EMPTY array leaf keeps its whole-array
+// key: the index stores an empty array only under that key, so both plans
+// agree; this deliberately diverges from Mongo (which sorts [] before null)
+// — matching that would need a key encoding below TypeNull on disk.
 //
 // Zero-alloc: candidates are marshaled into the tuple's spare tail capacity
 // and the loser is truncated away (copy handles the overlapping move), so the
 // running best lives in the caller's buffer and this method needs no state —
 // a Sort, like a Filter, may be shared by concurrent queries.
+func (s *SortField) AppendKey(tuple anyenc.Tuple, v *anyenc.Value) anyenc.Tuple {
+	if leaf, single := v.GetLeaf(s.Path...); single {
+		return s.appendElementKey(tuple, leaf)
+	}
+	base := len(tuple)
+	v.WalkLeaves(s.Path, func(l anyenc.Leaf) { tuple = s.considerLeaf(tuple, base, l) })
+	return s.finishKey(tuple, base)
+}
+
+// appendElementKey is AppendKey for one already-resolved, non-positional
+// leaf (the raw fast path, whose walk never crosses an array container).
 func (s *SortField) appendElementKey(tuple anyenc.Tuple, fv *anyenc.Value) anyenc.Tuple {
-	if fv != nil && fv.Type() == anyenc.TypeArray {
-		if items, _ := fv.Array(); len(items) > 0 {
-			base := len(tuple)
+	base := len(tuple)
+	tuple = s.considerLeaf(tuple, base, anyenc.Leaf{Value: fv})
+	return s.finishKey(tuple, base)
+}
+
+func (s *SortField) considerLeaf(tuple anyenc.Tuple, base int, l anyenc.Leaf) anyenc.Tuple {
+	if l.Value != nil && l.Value.Type() == anyenc.TypeArray && !l.Positional {
+		if items, _ := l.Value.Array(); len(items) > 0 {
 			for _, item := range items {
-				candOff := len(tuple)
-				tuple = item.MarshalTo(tuple)
-				if candOff == base {
-					continue // first element is the initial best
-				}
-				cand, best := tuple[candOff:], tuple[base:candOff]
-				cmp := bytes.Compare(cand, best)
-				if (!s.Reverse && cmp < 0) || (s.Reverse && cmp > 0) {
-					n := copy(tuple[base:], cand) // overlapping move: new best down
-					tuple = tuple[:base+n]
-				} else {
-					tuple = tuple[:candOff] // loser: drop the tail bytes
-				}
-			}
-			if s.Reverse {
-				for i := base; i < len(tuple); i++ {
-					tuple[i] = ^tuple[i]
-				}
+				tuple = s.consider(tuple, base, item)
 			}
 			return tuple
 		}
 	}
-	if !s.Reverse {
-		return tuple.Append(fv)
+	return s.consider(tuple, base, l.Value)
+}
+
+// consider marshals fv after the running best at tuple[base:] and keeps the
+// better of the two.
+func (s *SortField) consider(tuple anyenc.Tuple, base int, fv *anyenc.Value) anyenc.Tuple {
+	candOff := len(tuple)
+	tuple = fv.MarshalTo(tuple)
+	if candOff == base {
+		return tuple // first candidate is the initial best
 	}
-	return tuple.AppendInverted(fv)
+	cand, best := tuple[candOff:], tuple[base:candOff]
+	cmp := bytes.Compare(cand, best)
+	if (!s.Reverse && cmp < 0) || (s.Reverse && cmp > 0) {
+		n := copy(tuple[base:], cand) // overlapping move: new best down
+		return tuple[:base+n]
+	}
+	return tuple[:candOff] // loser: drop the tail bytes
+}
+
+// finishKey inverts the chosen key for a descending field.
+func (s *SortField) finishKey(tuple anyenc.Tuple, base int) anyenc.Tuple {
+	if s.Reverse {
+		for i := base; i < len(tuple); i++ {
+			tuple[i] = ^tuple[i]
+		}
+	}
+	return tuple
 }
 
 func (s *SortField) Fields() []SortField {

--- a/query/sort_test.go
+++ b/query/sort_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +94,32 @@ func TestSortField_AppendKey_ArrayElements(t *testing.T) {
 		require.NotEmpty(t, got)
 		assert.Equal(t, want, got)
 	})
+}
+
+// Sort keys through arrays of objects: min ascending / max descending over
+// every leaf's elements; a missing leaf is null; a positional leaf is whole.
+func TestSortField_PathThroughArrays(t *testing.T) {
+	key := func(path, doc string, reverse bool) string {
+		s := &SortField{Path: strings.Split(path, "."), Reverse: reverse}
+		k := s.AppendKey(nil, anyenc.MustParseJson(doc))
+		if reverse {
+			for i := range k {
+				k[i] = ^k[i]
+			}
+		}
+		v, err := (&anyenc.Parser{}).Parse(k)
+		require.NoError(t, err)
+		return v.String()
+	}
+	assert.Equal(t, `1`, key("a.b", `{"a":[{"b":3},{"b":1},{"b":2}]}`, false))
+	assert.Equal(t, `3`, key("a.b", `{"a":[{"b":3},{"b":1},{"b":2}]}`, true))
+	assert.Equal(t, `null`, key("a.b", `{"a":[{"b":3},{"c":1}]}`, false))
+	assert.Equal(t, `3`, key("a.b", `{"a":[{"b":3},{"c":1}]}`, true))
+	assert.Equal(t, `null`, key("a.b", `{"a":[]}`, false))
+	assert.Equal(t, `null`, key("a.b", `{"a":[1,2]}`, false))
+	assert.Equal(t, `0`, key("a.b", `{"a":[{"b":[5,0]},{"b":2}]}`, false)) // leaf array elements
+	assert.Equal(t, `[]`, key("a.b", `{"a":[{"b":[]}]}`, false))           // empty leaf array: whole key
+	assert.Equal(t, `[1,2]`, key("a.0", `{"a":[[1,2],[0]]}`, false))       // positional: whole
+	assert.Equal(t, `1`, key("a.0.b", `{"a":[[{"b":1}]]}`, false))
+	assert.Equal(t, `5`, key("a.b.c", `{"a":[{"b":[{"c":9},{"c":5}]},{"b":{"c":7}}]}`, false))
 }

--- a/query/tight_bounds.go
+++ b/query/tight_bounds.go
@@ -40,8 +40,14 @@ import (
 func TightIndexBounds(f Filter, fieldName string) (bounds Bounds, empty bool) {
 	switch t := f.(type) {
 	case Key:
-		if strings.Join(t.Path, ".") == fieldName {
+		path := strings.Join(t.Path, ".")
+		if path == fieldName {
 			return TightIndexBounds(t.Filter, fieldName)
+		}
+		// Object-form $elemMatch re-keyed under its sub-fields, as
+		// Key.IndexBounds does for the wide channel.
+		if cond, sub, ok := t.elemMatchSubField(fieldName); ok {
+			return TightIndexBounds(cond, sub)
 		}
 		return nil, false
 	case And:
@@ -90,6 +96,10 @@ func MayTighten(f Filter) bool {
 		return slices.ContainsFunc(t, MayTighten)
 	case *And:
 		return MayTighten(*t)
+	case ElemMatch:
+		return MayTighten(t.Cond)
+	case *ElemMatch:
+		return MayTighten(t.Cond)
 	default:
 		return false
 	}

--- a/syncpool/syncpool.go
+++ b/syncpool/syncpool.go
@@ -2,6 +2,7 @@ package syncpool
 
 import (
 	"sync"
+	"unsafe"
 
 	"github.com/anyproto/any-store/v2/anyenc"
 )
@@ -29,8 +30,10 @@ type DocBuffer struct {
 	SmallBuf   []byte
 	DocBuf     []byte
 	ScratchBuf []byte
-	Arena      *anyenc.Arena
-	Parser     *anyenc.Parser
+	// Leaves is the scratch for path resolution through arrays (query.Key).
+	Leaves []anyenc.Leaf
+	Arena  *anyenc.Arena
+	Parser *anyenc.Parser
 }
 
 func (sp *SyncPool) GetDocBuf() *DocBuffer {
@@ -44,6 +47,9 @@ func (sp *SyncPool) GetDocBuf() *DocBuffer {
 	return buf
 }
 
+// leafSize is the pooled footprint of one Leaves entry.
+const leafSize = int(unsafe.Sizeof(anyenc.Leaf{}))
+
 func (sp *SyncPool) ReleaseDocBuf(b *DocBuffer) {
 	// Size check excludes reusable scratch buffers inside Parser (decompBuf,
 	// input copy buffer) — those are kept deliberately to avoid re-allocation
@@ -52,7 +58,7 @@ func (sp *SyncPool) ReleaseDocBuf(b *DocBuffer) {
 	// size limit, so one huge document can't pin its high-water mark in the
 	// pool while the buffer keeps passing the size check below.
 	b.Parser.TrimScratch(sp.sizeLimit)
-	if sp.sizeLimit > 0 && cap(b.DocBuf)+cap(b.SmallBuf)+cap(b.ScratchBuf)+b.Arena.ApproxSize()+b.Parser.ApproxSize() > sp.sizeLimit {
+	if sp.sizeLimit > 0 && cap(b.DocBuf)+cap(b.SmallBuf)+cap(b.ScratchBuf)+cap(b.Leaves)*leafSize+b.Arena.ApproxSize()+b.Parser.ApproxSize() > sp.sizeLimit {
 		return
 	}
 	sp.pool.Put(b)

--- a/syncpool/syncpool_test.go
+++ b/syncpool/syncpool_test.go
@@ -1,6 +1,7 @@
 package syncpool
 
 import (
+	"github.com/anyproto/any-store/v2/anyenc"
 	"runtime"
 	"testing"
 
@@ -34,4 +35,13 @@ func TestSyncPools_GetDocBuf(t *testing.T) {
 		assert.Len(t, buf.DocBuf, 5)
 	}
 	// If a fresh buffer was returned (GC cleared the pool), that's acceptable.
+}
+
+func TestReleaseDocBuf_LeavesCountTowardSizeLimit(t *testing.T) {
+	sp := NewSyncPool(1024)
+	b := sp.GetDocBuf()
+	b.Leaves = make([]anyenc.Leaf, 0, 1024)
+	sp.ReleaseDocBuf(b)
+	got := sp.GetDocBuf()
+	assert.Less(t, cap(got.Leaves)*leafSize, 1024, "an oversized Leaves scratch must not be pooled")
 }


### PR DESCRIPTION
Dotted paths traverse arrays of objects with MongoDB field-path semantics: `{"a.b":1}` matches `{"a":[{"b":1}]}` in filters, sorts, index entries and index-driven plans. Adds `$elemMatch`, element-wise `$type` (plus the `"bool"` alias), and `$lookup` local-field traversal.

## Semantics

- A path resolves to a **leaf set** (`anyenc.Value.AppendLeaves`): a non-numeric segment met by an array maps the rest of the path over the object elements; an element that cannot carry the path, and an empty array, yield a missing leaf. Traversal repeats at every array level.
- Per-operator quantification, as in Mongo: positive operators match on any leaf, negations (`$ne`, `$nin`, `$not`, `$nor`) on no leaf, sibling operators independently. `$elemMatch` binds predicates to one element (object and value forms, `$all` of `$elemMatch`).
- A leaf picked by a numeric segment is **positional**: compared whole, stored whole, its whole value is its sort key (`{"a.0":1}` does not match `{"a":[[1,2]]}`).
- One definition feeds every consumer: `Key.Ok`, index entries (`AppendIndexValues`), sort keys and the index-order dedup (`AppendElementValues`). A sparse index holds a document only when every indexed field is present somewhere in it (unchanged), and then writes every key with at least one present field, so `{"a":[{"b":1},{"c":2}]}` under a sparse `(a.b, a.c)` has `(1, null)` and `(null, 2)`.
- Fields of a compound index that run through the same array iterate it together: `(a.b, a.c)` over N elements holds N entries, as Mongo generates them, and a unique index constrains element pairs. Consequently the planner compounds bounds and cover filters across such fields only on a scalar-proven index (`IndexInfo.SharedFrom`); over fan-out data it seeks the first of them and filters the rest.
- Paths that cross no array keep the Get-shaped evaluation (`GetLeaf`), so scalar filters, sort keys and index maintenance are unchanged in cost.

Contract: `docs/query-filter-contract.md` items 14 and 15, including the deliberate divergences from Mongo (null-equality on elements that cannot carry the path, numeric-segment ambiguity, empty-array sort position, the object-form `$elemMatch` ignoring array elements).

## Planner

- Object-form `$elemMatch` re-keys its condition under the sub-fields, so `{"a":{"$elemMatch":{"b":{"$gt":1}}}}` seeks an index on `a.b`; the value form contributes element-level bounds. Both are supersets, never the exact value image, so a `Key` holding a `$elemMatch` always keeps its residual filter (`keyBoundsExact`).
- Fan-out through an array of objects writes scalar entries with no whole-array key, so the array-tag probe can no longer rule multikey out: `CountEntries` and `CoverIter` gate on the sticky scalar-proven flag.
- `CanonicalKeyDedupIter` elects among element candidates, whole-array entries only as a fallback tier, and mirrors the sparse rule.

No index format change or rebuild: no deployed index crosses an array of objects. Release notes: an index whose path crosses an array of objects, or ends in a numeric segment over array values, must be rebuilt (its pre-upgrade entries are orphans otherwise); an index built before the scalar-proven marker stays unproven, so multi-bound `$in` counts and multi-bound unique lookups on it dedup instead of page-batching until it is rebuilt.

Separate fix found by the extended differential fuzz (last commit): a union of bounds meeting at one key kept the first bound's inclusion flag, so `{"$or":[{"a":{"$gt":0}},{"a":0}]}` on an index over `a` lost the `a = 0` rows.

## Verification

- MongoDB 8.0 oracle: a mongosh-generated fixture (36 documents, 443 filters and sorts) replayed on 10 index shapes in `any-store-tests` (`TestMongoArraySemantics`); every remaining difference is pinned with a reason.
- `go test ./...` here and `go test -tags vfs ./...` in `any-store-tests` (strict differential fuzz included) pass. Every commit builds, vets and passes the unit suites standalone.
- Filter-evaluation and insert micro-benchmarks within noise of main after the single-leaf fast paths (interleaved benchstat runs); the full `any-store-tests` harness comparison follows in a comment.

Found on the way, pre-existing and out of scope: on a reverse single-field index `{"$type":"null"}` Count includes documents whose field is missing while Iter filters them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AFXV8rvzkmtuZpk191DDA
