### PR TITLE
fix(qplanner): residual filter kept for $regex and $type null; sound $regex seek prefix

### DIFF
--- a/docs/query-filter-contract.md
+++ b/docs/query-filter-contract.md
@@ -129,12 +129,20 @@ build per query and carry no such guarantee.
     `(?flags)`. Inline flag groups in the pattern itself remain legal.
     Duplicate `$options` keys collapse last-wins in the JSON parser (standard
     JSON behavior); the surviving occurrence is validated like any other.
-    Anchored-prefix index bounds (`^literal…`) are suppressed exactly when a
-    flag can widen the match: `i` (case folding) and `m` (any-line anchoring)
-    keep the scan wide — via `$options` or a leading `^(?i)` in the pattern —
-    while `s` only changes what `.` matches and keeps the prefix bounds.
-    Pinned by `TestRegexp` (query/filter_test.go) and the `$options` cases in
-    `TestParseError`.
+    Index bounds seek the prefix range of the pattern's anchored literal
+    head, read off the parsed syntax tree so it means what the engine
+    means: a quantifier binds the literal before it (`^ab*` seeks `a`,
+    `^ab+` seeks `ab`), an escape class is no literal (`^\d` seeks
+    nothing), a top-level alternation has no head, and `i` (case folding)
+    or `m` (any-line anchoring) — via `$options` or an inline flag group —
+    keeps the scan wide, while `s` only changes what `.` matches. The range
+    is the exact match set only when the pattern is that literal and
+    nothing more; any other pattern keeps its residual filter
+    (`query.IndexBoundsExact`). Pinned by `TestRegexp` and
+    `TestRegexp_LiteralPrefix` (query/filter_test.go), the `$options` cases
+    in `TestParseError`, and the oracle runs `TestRegexPrefixBounds_Oracle`
+    and `TestResidualElision_InexactBounds` in the `any-store-tests`
+    repository.
 
 12. **Parse rejections are structured.** Everything `ParseCondition`,
     `ParseModifier`, and the aggregation pipeline parser reject — unknown
@@ -230,7 +238,11 @@ build per query and carry no such guarantee.
     raw fast paths (`OkRaw`, `AppendKeyRaw`) decline at an array container
     and fall back to the parsed document. `$type` matches an array whose
     ELEMENT has the type as well as the array itself (`"array"`), and
-    accepts Mongo's `"bool"` alias.
+    accepts Mongo's `"bool"` alias. `$type: "null"` needs an explicit null:
+    a missing field has no type. Its index bounds cover the null key, which
+    a missing field and an empty array also occupy, so it keeps its
+    residual filter (`query.IndexBoundsExact`); every other `$type` is
+    exactly its type range.
     Deliberate divergences from Mongo, pinned by the MongoDB-fixture replay
     `TestMongoArraySemantics` in the `any-store-tests` repository: (a) the null-equality
     family (`$eq null`, `$in [null]`, and their negations) matches a missing
@@ -267,5 +279,5 @@ build per query and carry no such guarantee.
     object with that value sits in the bounds without matching), so a `Key`
     holding a `$elemMatch` always keeps its residual filter: the planner's
     covering-count, verify-chain and residual-elision paths treat it as
-    uncovered (`keyBoundsExact`). Pinned by `TestElemMatch_Parse`,
+    uncovered (`query.IndexBoundsExact`). Pinned by `TestElemMatch_Parse`,
     `TestElemMatch_Ok` and `TestElemMatch_IndexBoundsAndString`.

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -1734,7 +1734,7 @@ func indexCoversFilter(idx *CBOIndex, filter query.Filter) bool {
 	// Condition 1: every filter field is within the bounded index prefix.
 	// Returns false on any uncovered field or any complex node (Or/Not/Nor).
 	hasFields := false
-	if ok := filterFieldsCoveredBy(filter, boundedFields, &hasFields); !ok || !hasFields {
+	if ok := filterFieldsCoveredBy(filter, boundedFields, idx.Info.Reverse, &hasFields); !ok || !hasFields {
 		return false
 	}
 	// Condition 2: reject when any covered field carries >1 predicate, because
@@ -1764,14 +1764,20 @@ func indexScanCoversFilter(idx *CBOIndex, coverFilters []IndexFieldFilter, filte
 		return false
 	}
 	var fields []string
+	var reverse []bool
 	if len(idx.Bounds) > 0 {
-		fields = append(fields, idx.Info.FieldNames[:min(idx.BoundFields, len(idx.Info.FieldNames))]...)
+		n := min(idx.BoundFields, len(idx.Info.FieldNames))
+		fields = append(fields, idx.Info.FieldNames[:n]...)
+		for i := range n {
+			reverse = append(reverse, fieldReverse(idx.Info.Reverse, i))
+		}
 	}
 	for _, f := range coverFilters {
 		fields = append(fields, idx.Info.FieldNames[f.FieldIdx])
+		reverse = append(reverse, fieldReverse(idx.Info.Reverse, f.FieldIdx))
 	}
 	hasFields := false
-	if ok := filterFieldsCoveredBy(filter, fields, &hasFields); !ok || !hasFields {
+	if ok := filterFieldsCoveredBy(filter, fields, reverse, &hasFields); !ok || !hasFields {
 		return false
 	}
 	for _, field := range fields {
@@ -1854,31 +1860,36 @@ func countInnerPreds(f query.Filter) int {
 }
 
 // keyBoundsExact reports whether a Key's index bounds are the exact value
-// image of its predicate — the premise of every FilterIter-skipping path.
-// The widening predicates ($elemMatch, $type null, a $regex beyond its
-// anchored literal) are enumerated by query.IndexBoundsExact; such a Key
-// always keeps its residual filter.
-func keyBoundsExact(k query.Key) bool {
-	return query.IndexBoundsExact(k.Filter)
+// image of its predicate on a field stored ascending, or inverted when
+// reverse — the premise of every FilterIter-skipping path. The widening
+// predicates are enumerated by query.IndexBoundsExact; such a Key always
+// keeps its residual filter.
+func keyBoundsExact(k query.Key, reverse bool) bool {
+	return query.IndexBoundsExact(k.Filter, reverse)
+}
+
+// fieldReverse reports whether index field i is reverse-flagged; reverse is
+// the index's per-field flags, which may be shorter than its field list.
+func fieldReverse(reverse []bool, i int) bool {
+	return i >= 0 && i < len(reverse) && reverse[i]
 }
 
 // filterFieldsCoveredBy walks the filter tree and checks that every referenced
-// field name is present in idxFields. Zero-allocation.
-func filterFieldsCoveredBy(f query.Filter, idxFields []string, hasFields *bool) bool {
+// field name is present in idxFields, with bounds exact for the field's
+// direction (reverse aligns with idxFields). Zero-allocation.
+func filterFieldsCoveredBy(f query.Filter, idxFields []string, reverse []bool, hasFields *bool) bool {
 	switch ft := f.(type) {
 	case query.Key:
-		if !keyBoundsExact(ft) {
+		name := strings.Join(ft.Path, ".")
+		i := slices.Index(idxFields, name)
+		if i < 0 || !keyBoundsExact(ft, fieldReverse(reverse, i)) {
 			return false
 		}
-		name := strings.Join(ft.Path, ".")
-		if slices.Contains(idxFields, name) {
-			*hasFields = true
-			return true
-		}
-		return false
+		*hasFields = true
+		return true
 	case query.And:
 		for _, sub := range ft {
-			if !filterFieldsCoveredBy(sub, idxFields, hasFields) {
+			if !filterFieldsCoveredBy(sub, idxFields, reverse, hasFields) {
 				return false
 			}
 		}
@@ -1889,7 +1900,7 @@ func filterFieldsCoveredBy(f query.Filter, idxFields []string, hasFields *bool) 
 		// (see query/cond_parse.go:103), so without this case the covering-
 		// count fast path is silently disabled for $and-spelled filters.
 		for _, sub := range *ft {
-			if !filterFieldsCoveredBy(sub, idxFields, hasFields) {
+			if !filterFieldsCoveredBy(sub, idxFields, reverse, hasFields) {
 				return false
 			}
 		}
@@ -1900,23 +1911,30 @@ func filterFieldsCoveredBy(f query.Filter, idxFields []string, hasFields *bool) 
 }
 
 // collectUncoveredFilterFields walks the filter tree and returns field names
-// not present in coveredFields. Returns nil if the filter contains complex
-// nodes (Or, Not, Nor) that can't be reliably field-analyzed.
-func collectUncoveredFilterFields(f query.Filter, coveredFields []string) []string {
+// not present in coveredFields (reverse aligns with it). Returns nil if the
+// filter contains complex nodes (Or, Not, Nor) that can't be reliably
+// field-analyzed, or a covered field whose bounds are not exact.
+func collectUncoveredFilterFields(f query.Filter, coveredFields []string, reverse []bool) []string {
 	switch ft := f.(type) {
 	case query.Key:
-		if !keyBoundsExact(ft) {
-			return nil
-		}
 		name := strings.Join(ft.Path, ".")
-		if slices.Contains(coveredFields, name) {
+		if i := slices.Index(coveredFields, name); i >= 0 {
+			if !keyBoundsExact(ft, fieldReverse(reverse, i)) {
+				return nil
+			}
 			return []string{} // covered
+		}
+		// An uncovered field is verified through its own index, whose
+		// direction is unknown here: a predicate inexact either way
+		// disables the chain.
+		if !keyBoundsExact(ft, true) {
+			return nil
 		}
 		return []string{name}
 	case query.And:
 		var result []string
 		for _, sub := range ft {
-			fields := collectUncoveredFilterFields(sub, coveredFields)
+			fields := collectUncoveredFilterFields(sub, coveredFields, reverse)
 			if fields == nil {
 				return nil
 			}
@@ -1926,7 +1944,7 @@ func collectUncoveredFilterFields(f query.Filter, coveredFields []string) []stri
 	case *query.And:
 		var result []string
 		for _, sub := range *ft {
-			fields := collectUncoveredFilterFields(sub, coveredFields)
+			fields := collectUncoveredFilterFields(sub, coveredFields, reverse)
 			if fields == nil {
 				return nil
 			}
@@ -1944,7 +1962,7 @@ func collectUncoveredFilterFields(f query.Filter, coveredFields []string) []stri
 // index and verifies docIds against it instead of fetching full documents.
 // Returns nil if verification is not possible.
 func buildVerifyChain(params *PlanParams, idx *CBOIndex, root Iterator) Iterator {
-	uncovered := collectUncoveredFilterFields(params.Filter, idx.Info.FieldNames[:idx.BoundFields])
+	uncovered := collectUncoveredFilterFields(params.Filter, idx.Info.FieldNames[:idx.BoundFields], idx.Info.Reverse)
 	if len(uncovered) == 0 {
 		return nil
 	}

--- a/internal/qplanner/planner.go
+++ b/internal/qplanner/planner.go
@@ -1854,13 +1854,12 @@ func countInnerPreds(f query.Filter) int {
 }
 
 // keyBoundsExact reports whether a Key's index bounds are the exact value
-// image of its predicate — the premise of every FilterIter-skipping path. A
-// $elemMatch breaks it: its bounds are element-level (value form) or
-// re-keyed sub-field bounds (object form), and a scalar or an object with
-// that value sits in the same bounds without matching. Such a Key always
-// keeps its residual filter.
+// image of its predicate — the premise of every FilterIter-skipping path.
+// The widening predicates ($elemMatch, $type null, a $regex beyond its
+// anchored literal) are enumerated by query.IndexBoundsExact; such a Key
+// always keeps its residual filter.
 func keyBoundsExact(k query.Key) bool {
-	return !query.ContainsElemMatch(k.Filter)
+	return query.IndexBoundsExact(k.Filter)
 }
 
 // filterFieldsCoveredBy walks the filter tree and checks that every referenced

--- a/internal/qplanner/planner_test.go
+++ b/internal/qplanner/planner_test.go
@@ -348,17 +348,16 @@ func TestBuildPlan_LowSelectivity_FullScan(t *testing.T) {
 }
 
 // TestCoverChecks_InexactBounds pins that a covered field whose bounds are a
-// superset of its predicate ($regex beyond an anchored literal, $type null,
-// $elemMatch) never lets a plan skip the residual filter — through the
-// bound prefix (count fast path) or the ordered-scan elision that also
-// counts IndexFilterIter equality fields.
+// superset of its predicate ($regex beyond an anchored literal, or any
+// $regex on a reverse-flagged field, $type null, $elemMatch) never lets a
+// plan skip the residual filter — through the bound prefix (count fast
+// path) or the ordered-scan elision that also counts IndexFilterIter
+// equality fields.
 func TestCoverChecks_InexactBounds(t *testing.T) {
-	idxAZ := func(cond string) *CBOIndex {
-		return &CBOIndex{
-			Info:        &IndexInfo{Name: "az", FieldNames: []string{"a", "z"}},
-			Bounds:      mustParseBounds("a", cond),
-			BoundFields: 1,
-		}
+	idxAZ := func(cond string, reverse bool) *CBOIndex {
+		info := &IndexInfo{Name: "az", FieldNames: []string{"a", "z"}, Reverse: []bool{reverse, false}}
+		bounds, n := ComputeIndexBounds(info, buildBoundsResult(info, query.MustParseCondition(cond)))
+		return &CBOIndex{Info: info, Bounds: bounds, BoundFields: n}
 	}
 	zEq := []IndexFieldFilter{{FieldIdx: 1, MatchValue: anyenc.AppendAnyValue(nil, 1)}}
 	for _, f := range []string{
@@ -368,19 +367,33 @@ func TestCoverChecks_InexactBounds(t *testing.T) {
 		`{"z":1,"a":{"$elemMatch":{"$gt":1}}}`,
 	} {
 		cond := query.MustParseCondition(f)
-		idx := idxAZ(f)
-		require.NotEmpty(t, idx.Bounds, f)
-		assert.False(t, indexScanCoversFilter(idx, zEq, cond), "residual must stay: %s", f)
-		assert.False(t, indexCoversFilter(idx, cond), "count must keep the filter: %s", f)
+		for _, reverse := range []bool{false, true} {
+			idx := idxAZ(f, reverse)
+			require.NotEmpty(t, idx.Bounds, f)
+			assert.False(t, indexScanCoversFilter(idx, zEq, cond), "residual must stay: %s reverse=%v", f, reverse)
+			assert.False(t, indexCoversFilter(idx, cond), "count must keep the filter: %s reverse=%v", f, reverse)
+		}
 	}
+	// A whole anchored literal is exact ascending only: the reverse transform
+	// pads the prefix-derived bound past the group's neighbours.
+	literal := query.MustParseCondition(`{"z":1,"a":{"$regex":"^ab"}}`)
+	assert.True(t, indexScanCoversFilter(idxAZ(`{"z":1,"a":{"$regex":"^ab"}}`, false), zEq, literal))
+	assert.False(t, indexScanCoversFilter(idxAZ(`{"z":1,"a":{"$regex":"^ab"}}`, true), zEq, literal))
 	for _, f := range []string{
-		`{"z":1,"a":{"$regex":"^ab"}}`,
 		`{"z":1,"a":{"$type":"string"}}`,
 		`{"z":1,"a":{"$gt":1}}`,
+		`{"z":1,"a":null}`,
 	} {
 		cond := query.MustParseCondition(f)
-		assert.True(t, indexScanCoversFilter(idxAZ(f), zEq, cond), "exact bounds elide the residual: %s", f)
+		for _, reverse := range []bool{false, true} {
+			assert.True(t, indexScanCoversFilter(idxAZ(f, reverse), zEq, cond), "exact bounds elide the residual: %s reverse=%v", f, reverse)
+		}
 	}
+	// The verify chain sees the same screen, for covered and uncovered
+	// fields alike.
+	assert.Nil(t, collectUncoveredFilterFields(query.MustParseCondition(`{"a":{"$regex":"^ab"},"b":1}`), []string{"b"}, nil))
+	assert.Equal(t, []string{"b"}, collectUncoveredFilterFields(query.MustParseCondition(`{"a":{"$regex":"^ab"},"b":1}`), []string{"a"}, nil))
+	assert.Nil(t, collectUncoveredFilterFields(query.MustParseCondition(`{"a":{"$regex":"^ab"},"b":1}`), []string{"a"}, []bool{true}))
 }
 
 func TestBuildPlan_UniqueIndex_CoverLookup(t *testing.T) {
@@ -2162,14 +2175,14 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 	t.Run("key_covered", func(t *testing.T) {
 		f := query.MustParseCondition(`{"a": 1}`) // parses to query.Key
 		has := false
-		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, &has)
+		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, nil, &has)
 		assert.True(t, ok)
 		assert.True(t, has)
 	})
 	t.Run("key_not_covered", func(t *testing.T) {
 		f := query.MustParseCondition(`{"z": 1}`)
 		has := false
-		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, &has)
+		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, nil, &has)
 		assert.False(t, ok)
 		assert.False(t, has)
 	})
@@ -2179,7 +2192,7 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 		inner2 := query.MustParseCondition(`{"b": 2}`)
 		f := query.And{inner1, inner2}
 		has := false
-		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, &has)
+		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, nil, &has)
 		assert.True(t, ok)
 		assert.True(t, has)
 	})
@@ -2188,7 +2201,7 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 		inner2 := query.MustParseCondition(`{"z": 2}`)
 		f := query.And{inner1, inner2}
 		has := false
-		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, &has)
+		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, nil, &has)
 		assert.False(t, ok, "And must short-circuit on first uncovered child")
 		// The first child matched before the short-circuit, so `has` is true.
 		// Pin the current behavior so a future refactor can't silently drop it.
@@ -2200,7 +2213,7 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 		// *query.And enjoy the covering-count fast path too.
 		inner := query.And{query.MustParseCondition(`{"a": 1}`)}
 		has := false
-		ok := filterFieldsCoveredBy(&inner, []string{"a"}, &has)
+		ok := filterFieldsCoveredBy(&inner, []string{"a"}, nil, &has)
 		assert.True(t, ok, "pointer-And with covered child should report covered")
 		assert.True(t, has)
 	})
@@ -2208,7 +2221,7 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 		// Pointer-And with an uncovered child must short-circuit to false.
 		inner := query.And{query.MustParseCondition(`{"z": 1}`)}
 		has := false
-		ok := filterFieldsCoveredBy(&inner, []string{"a"}, &has)
+		ok := filterFieldsCoveredBy(&inner, []string{"a"}, nil, &has)
 		assert.False(t, ok)
 	})
 	t.Run("default_unsupported", func(t *testing.T) {
@@ -2218,7 +2231,7 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 			query.MustParseCondition(`{"b": 2}`),
 		}
 		has := false
-		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, &has)
+		ok := filterFieldsCoveredBy(f, []string{"a", "b"}, nil, &has)
 		assert.False(t, ok)
 		assert.False(t, has, "default branch must not set hasFields")
 	})
@@ -2230,12 +2243,12 @@ func TestFilterFieldsCoveredBy(t *testing.T) {
 func TestCollectUncoveredFilterFields(t *testing.T) {
 	t.Run("key_covered", func(t *testing.T) {
 		f := query.MustParseCondition(`{"a": 1}`)
-		got := collectUncoveredFilterFields(f, []string{"a"})
+		got := collectUncoveredFilterFields(f, []string{"a"}, nil)
 		assert.Equal(t, []string{}, got)
 	})
 	t.Run("key_uncovered", func(t *testing.T) {
 		f := query.MustParseCondition(`{"z": 1}`)
-		got := collectUncoveredFilterFields(f, []string{"a"})
+		got := collectUncoveredFilterFields(f, []string{"a"}, nil)
 		assert.Equal(t, []string{"z"}, got)
 	})
 	t.Run("and_mixed", func(t *testing.T) {
@@ -2243,13 +2256,13 @@ func TestCollectUncoveredFilterFields(t *testing.T) {
 			query.MustParseCondition(`{"a": 1}`), // covered
 			query.MustParseCondition(`{"z": 2}`), // uncovered → should be returned
 		}
-		got := collectUncoveredFilterFields(f, []string{"a"})
+		got := collectUncoveredFilterFields(f, []string{"a"}, nil)
 		assert.Equal(t, []string{"z"}, got)
 	})
 	t.Run("and_pointer", func(t *testing.T) {
 		// Pointer variant of And exercises the `*query.And` case.
 		a := query.And{query.MustParseCondition(`{"q": 1}`)}
-		got := collectUncoveredFilterFields(&a, []string{"a"})
+		got := collectUncoveredFilterFields(&a, []string{"a"}, nil)
 		assert.Equal(t, []string{"q"}, got)
 	})
 	t.Run("and_propagates_nil", func(t *testing.T) {
@@ -2262,7 +2275,7 @@ func TestCollectUncoveredFilterFields(t *testing.T) {
 				query.MustParseCondition(`{"c": 1}`),
 			},
 		}
-		got := collectUncoveredFilterFields(f, []string{"a"})
+		got := collectUncoveredFilterFields(f, []string{"a"}, nil)
 		assert.Nil(t, got, "nil must propagate out of And when any child returns nil")
 	})
 	t.Run("and_pointer_propagates_nil", func(t *testing.T) {
@@ -2273,12 +2286,12 @@ func TestCollectUncoveredFilterFields(t *testing.T) {
 				query.MustParseCondition(`{"c": 1}`),
 			},
 		}
-		got := collectUncoveredFilterFields(&inner, []string{"a"})
+		got := collectUncoveredFilterFields(&inner, []string{"a"}, nil)
 		assert.Nil(t, got)
 	})
 	t.Run("default_unsupported", func(t *testing.T) {
 		f := query.Or{query.MustParseCondition(`{"a": 1}`)}
-		got := collectUncoveredFilterFields(f, []string{"a"})
+		got := collectUncoveredFilterFields(f, []string{"a"}, nil)
 		assert.Nil(t, got)
 	})
 }
@@ -4377,7 +4390,7 @@ func TestFilterFieldsCoveredBy_PointerAndBranch(t *testing.T) {
 	// MustParseCondition(`{"$and":[{"a":1}]}`) returns *query.And.
 	f := query.MustParseCondition(`{"$and":[{"a":1}]}`)
 	has := false
-	ok := filterFieldsCoveredBy(f, []string{"a"}, &has)
+	ok := filterFieldsCoveredBy(f, []string{"a"}, nil, &has)
 	// The function should recurse into the underlying And slice exactly like
 	// the value-receiver case and report covered=true.
 	assert.True(t, ok, "pointer-And with covered field should report covered")

--- a/internal/qplanner/planner_test.go
+++ b/internal/qplanner/planner_test.go
@@ -347,6 +347,42 @@ func TestBuildPlan_LowSelectivity_FullScan(t *testing.T) {
 	assert.Equal(t, "FullScan", plan.Name)
 }
 
+// TestCoverChecks_InexactBounds pins that a covered field whose bounds are a
+// superset of its predicate ($regex beyond an anchored literal, $type null,
+// $elemMatch) never lets a plan skip the residual filter — through the
+// bound prefix (count fast path) or the ordered-scan elision that also
+// counts IndexFilterIter equality fields.
+func TestCoverChecks_InexactBounds(t *testing.T) {
+	idxAZ := func(cond string) *CBOIndex {
+		return &CBOIndex{
+			Info:        &IndexInfo{Name: "az", FieldNames: []string{"a", "z"}},
+			Bounds:      mustParseBounds("a", cond),
+			BoundFields: 1,
+		}
+	}
+	zEq := []IndexFieldFilter{{FieldIdx: 1, MatchValue: anyenc.AppendAnyValue(nil, 1)}}
+	for _, f := range []string{
+		`{"z":1,"a":{"$regex":"^ab.*c"}}`,
+		`{"z":1,"a":{"$regex":"^abc$"}}`,
+		`{"z":1,"a":{"$type":"null"}}`,
+		`{"z":1,"a":{"$elemMatch":{"$gt":1}}}`,
+	} {
+		cond := query.MustParseCondition(f)
+		idx := idxAZ(f)
+		require.NotEmpty(t, idx.Bounds, f)
+		assert.False(t, indexScanCoversFilter(idx, zEq, cond), "residual must stay: %s", f)
+		assert.False(t, indexCoversFilter(idx, cond), "count must keep the filter: %s", f)
+	}
+	for _, f := range []string{
+		`{"z":1,"a":{"$regex":"^ab"}}`,
+		`{"z":1,"a":{"$type":"string"}}`,
+		`{"z":1,"a":{"$gt":1}}`,
+	} {
+		cond := query.MustParseCondition(f)
+		assert.True(t, indexScanCoversFilter(idxAZ(f), zEq, cond), "exact bounds elide the residual: %s", f)
+	}
+}
+
 func TestBuildPlan_UniqueIndex_CoverLookup(t *testing.T) {
 	bounds := mustParseBounds("a", `{"a": 42}`)
 	plan := BuildPlan(&PlanParams{

--- a/internal/qplanner/text_plan.go
+++ b/internal/qplanner/text_plan.go
@@ -364,7 +364,7 @@ func buildTextProbePlan(params *PlanParams, cand *textCandidate, rankMode bool) 
 		}
 		hasFields := false
 		countCovered = !needFilter ||
-			(filterFieldsCoveredBy(params.Filter, []string{pk}, &hasFields) && hasFields &&
+			(filterFieldsCoveredBy(params.Filter, []string{pk}, nil, &hasFields) && hasFields &&
 				countFilterFieldPreds(params.Filter, pk) <= 1)
 	default:
 		idx := cand.idx

--- a/query/cond_parse.go
+++ b/query/cond_parse.go
@@ -809,9 +809,9 @@ func parseRegexp(v *anyenc.Value, options string) (Filter, error) {
 			if compiledRegexp, err = regexp.Compile("(?" + options + ")" + pattern); err != nil {
 				return nil, &ParseError{Op: "$regex", Reason: "invalid regular expression: " + err.Error(), Err: err}
 			}
-			return Regexp{Regexp: compiledRegexp, Options: options}, nil
+			return NewRegexp(compiledRegexp, options), nil
 		}
-		return Regexp{Regexp: compiledRegexp}, nil
+		return NewRegexp(compiledRegexp, ""), nil
 	default:
 		return nil, &ParseError{Op: "$regex", Reason: "$regex must be a string, got " + v.String()}
 	}

--- a/query/filter.go
+++ b/query/filter.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/valyala/fastjson"
 
@@ -1147,25 +1148,30 @@ func ContainsElemMatch(f Filter) bool {
 }
 
 // IndexBoundsExact reports whether the index bounds of a Key's inner filter
-// f are the exact key image of its Ok set — the premise of every plan that
-// skips the residual FilterIter for a covered field (indexCoversFilter,
-// indexScanCoversFilter and the verify chain in the planner). IndexBounds
-// is only contracted to be a SUPERSET; three predicates widen it:
+// f are the exact key image of its Ok set on a field stored ascending, or
+// inverted when reverse — the premise of every plan that skips the residual
+// FilterIter for a covered field (indexCoversFilter, indexScanCoversFilter
+// and the verify chain in the planner). IndexBounds is only contracted to
+// be a SUPERSET; these predicates widen it:
 //
 //   - $elemMatch: element-level or re-keyed sub-field bounds — a scalar, or
 //     an object carrying the value, sits inside them without matching;
 //   - $type null: a missing field and an empty array are indexed under the
 //     null key, and Ok rejects both;
 //   - $regex beyond a whole anchored literal: the prefix range admits every
-//     continuation, the pattern only some (^abc$, ^ab.*c, ^a\w).
+//     continuation, the pattern only some (^abc$, ^ab.*c, ^a\w). A whole
+//     literal is exact ascending only: the reverse transform pads a
+//     prefix-derived bound past the group's neighbours (see
+//     qplanner.transformReverseBounds);
+//   - $not, $nor, $exists, $size: no bounds at all against a selective Ok.
 //
 // A Key holding any of them anywhere in f must keep its residual filter.
 // Multi-predicate conjunctions widen too and are screened separately by
 // predicate count.
-func IndexBoundsExact(f Filter) bool {
+func IndexBoundsExact(f Filter, reverse bool) bool {
 	return !FilterTreeAny(f, func(f Filter) bool {
 		switch ft := f.(type) {
-		case ElemMatch, *ElemMatch:
+		case ElemMatch, *ElemMatch, Not, *Not, Nor, *Nor, Exists, *Exists, Size, *Size:
 			return true
 		case TypeFilter:
 			return ft.Type == anyenc.TypeNull
@@ -1173,10 +1179,10 @@ func IndexBoundsExact(f Filter) bool {
 			return ft.Type == anyenc.TypeNull
 		case Regexp:
 			_, complete := ft.literalPrefix()
-			return !complete
+			return !complete || reverse
 		case *Regexp:
 			_, complete := ft.literalPrefix()
-			return !complete
+			return !complete || reverse
 		}
 		return false
 	})
@@ -1309,7 +1315,9 @@ func (e TypeFilter) String() string {
 type Regexp struct {
 	Regexp *regexp.Regexp
 	// Options are the Mongo $options flags ("i", "m", "s") the parser baked
-	// into Regexp as a leading (?flags) group; String renders them back.
+	// into Regexp as a leading (?flags) group; String renders them back. A
+	// Regexp built by hand carries them here only: the seek prefix then
+	// screens i and m itself, since neither survives in the compiled pattern.
 	Options string
 
 	// prefix is the literal every match must start with (the head of an
@@ -1370,6 +1378,9 @@ func (r Regexp) literalPrefix() (prefix string, complete bool) {
 	if r.prefixKnown {
 		return r.prefix, r.prefixComplete
 	}
+	if strings.ContainsAny(r.Options, "im") {
+		return "", false
+	}
 	return literalPrefix(r.Regexp.String())
 }
 
@@ -1412,8 +1423,10 @@ func (r Regexp) IndexBounds(_ string, bs Bounds) (bounds Bounds) {
 // the engine means: a quantifier binds the last literal (^ab* → "a", ^ab+ →
 // "ab"), an
 // escape class is not a literal (^\d → ""), a top-level alternation has no
-// common head (^ab|^xy → ""), and a case-folded literal or a line anchor
-// (i / m flags, inline or via $options) rules the prefix out.
+// common head (^ab|^xy → ""), a case-folded literal or a line anchor
+// (i / m flags, inline or via $options) rules the prefix out, and so does a
+// literal U+FFFD, which stands for any invalid byte. An empty prefix is
+// never complete.
 func literalPrefix(pattern string) (prefix string, complete bool) {
 	re, err := syntax.Parse(pattern, syntax.Perl)
 	if err != nil {
@@ -1441,7 +1454,13 @@ func literalPrefix(pattern string) (prefix string, complete bool) {
 			sb.WriteRune(c)
 		}
 	}
-	return sb.String(), sb.Len() > 0 && i == len(re.Sub)
+	prefix = sb.String()
+	if strings.ContainsRune(prefix, utf8.RuneError) {
+		// The engine decodes every invalid byte as U+FFFD, so this literal
+		// also matches byte strings the UTF-8 form of U+FFFD does not prefix.
+		return "", false
+	}
+	return prefix, i == len(re.Sub)
 }
 
 func (r Regexp) String() string {

--- a/query/filter.go
+++ b/query/filter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"regexp/syntax"
 	"slices"
 	"strconv"
 	"strings"
@@ -1272,12 +1273,24 @@ func (e TypeFilter) String() string {
 type Regexp struct {
 	Regexp *regexp.Regexp
 	// Options are the Mongo $options flags ("i", "m", "s") the parser baked
-	// into Regexp as a leading (?flags) group. i and m make an anchored
-	// ^literal prefix unsound as an index bound (case folding / any-line
-	// anchoring admit keys outside the literal range), so IndexBounds keeps
-	// the scan wide for them; s cannot affect a literal prefix and keeps the
-	// bounds.
+	// into Regexp as a leading (?flags) group; String renders them back.
 	Options string
+
+	// prefix is the literal every match must start with (the head of an
+	// anchored ^literal pattern) and prefixComplete whether the pattern is
+	// that literal and nothing more, so its match set is exactly the
+	// prefix-continuation group. NewRegexp computes them once; a Regexp
+	// built as a bare literal derives them on demand.
+	prefix         string
+	prefixComplete bool
+	prefixKnown    bool
+}
+
+// NewRegexp builds the $regex predicate for a compiled pattern; options are
+// the $options flags the caller folded into it as a leading (?flags) group.
+func NewRegexp(re *regexp.Regexp, options string) Regexp {
+	prefix, complete := literalPrefix(re.String())
+	return Regexp{Regexp: re, Options: options, prefix: prefix, prefixComplete: complete, prefixKnown: true}
 }
 
 func (r Regexp) Ok(v *anyenc.Value, buf *syncpool.DocBuffer) bool {
@@ -1317,13 +1330,20 @@ func (r Regexp) rawPattern() string {
 	return pattern
 }
 
-func (r Regexp) IndexBounds(_ string, bs Bounds) (bounds Bounds) {
-	if strings.ContainsAny(r.Options, "im") {
-		// See Options: a case-folded or any-line-anchored prefix does not
-		// bound the index range.
-		return bs
+func (r Regexp) literalPrefix() (prefix string, complete bool) {
+	if r.prefixKnown {
+		return r.prefix, r.prefixComplete
 	}
-	prefix := extractPrefix(r.rawPattern())
+	return literalPrefix(r.Regexp.String())
+}
+
+// IndexBounds seeks the prefix-continuation group of an anchored literal
+// head: a SOUND superset of the matches (every match starts with the
+// prefix), exact only when the pattern is that literal and nothing more
+// (literalPrefix's complete) — the planner elides the residual filter on
+// that basis alone. No prefix, no bounds.
+func (r Regexp) IndexBounds(_ string, bs Bounds) (bounds Bounds) {
+	prefix, _ := r.literalPrefix()
 	if prefix == "" {
 		return bs
 	}
@@ -1349,54 +1369,43 @@ func (r Regexp) IndexBounds(_ string, bs Bounds) (bounds Bounds) {
 	return bs.Append(bound)
 }
 
-func findPrefix(pattern string) string {
-	var result []rune
-	specialChars := `^$|*+?(){}[]\.`
-	escaped := false
-
-	for i := range len(pattern) {
-		char := pattern[i]
-
-		if escaped {
-			escaped = false
-			result = append(result, rune(char))
-			continue
-		}
-
-		if char == '\\' {
-			escaped = true
-			continue
-		}
-
-		if !isSpecialChar(char, specialChars) {
-			result = append(result, rune(char))
-		} else {
+// literalPrefix returns the literal every match of pattern must begin with
+// — the head of an anchored ^literal… pattern — and whether the pattern is
+// that anchored literal and nothing more, i.e. matches exactly the strings
+// starting with it. Read off the parsed syntax tree so the prefix means what
+// the engine means: a quantifier binds the last literal (^ab* → "a", ^ab+ →
+// "ab"), an
+// escape class is not a literal (^\d → ""), a top-level alternation has no
+// common head (^ab|^xy → ""), and a case-folded literal or a line anchor
+// (i / m flags, inline or via $options) rules the prefix out.
+func literalPrefix(pattern string) (prefix string, complete bool) {
+	re, err := syntax.Parse(pattern, syntax.Perl)
+	if err != nil {
+		return "", false
+	}
+	re = re.Simplify()
+	if re.Op != syntax.OpConcat || len(re.Sub) < 2 || re.Sub[0].Op != syntax.OpBeginText {
+		return "", false
+	}
+	var sb strings.Builder
+	i := 1
+	for ; i < len(re.Sub); i++ {
+		sub := re.Sub[i]
+		if sub.Op == syntax.OpPlus && sub.Sub[0].Op == syntax.OpLiteral && sub.Sub[0].Flags&syntax.FoldCase == 0 {
+			// x+ requires x at least once: it extends the prefix and ends it.
+			for _, c := range sub.Sub[0].Rune {
+				sb.WriteRune(c)
+			}
 			break
 		}
-	}
-	return string(result)
-}
-
-func isSpecialChar(char byte, specialChars string) bool {
-	for i := 0; i < len(specialChars); i++ {
-		if char == specialChars[i] {
-			return true
+		if sub.Op != syntax.OpLiteral || sub.Flags&syntax.FoldCase != 0 {
+			break
+		}
+		for _, c := range sub.Rune {
+			sb.WriteRune(c)
 		}
 	}
-	return false
-}
-
-// extractPrefix returns the literal prefix of an anchored (^…) pattern, "" if
-// none. SOUNDNESS: a pattern under i or m flags must never reach the prefix
-// fast path — Regexp.IndexBounds screens Options before calling, and a flag
-// group inlined in the pattern fails the '^' check here. Do not teach this
-// function to skip a leading (?…) group without consulting the flags.
-func extractPrefix(pattern string) string {
-	if !strings.HasPrefix(pattern, "^") || strings.HasPrefix(pattern, "^(?i)") {
-		return ""
-	}
-	pattern = strings.TrimPrefix(pattern, "^")
-	return findPrefix(pattern)
+	return sb.String(), sb.Len() > 0 && i == len(re.Sub)
 }
 
 func (r Regexp) String() string {

--- a/query/filter.go
+++ b/query/filter.go
@@ -1146,6 +1146,42 @@ func ContainsElemMatch(f Filter) bool {
 	})
 }
 
+// IndexBoundsExact reports whether the index bounds of a Key's inner filter
+// f are the exact key image of its Ok set — the premise of every plan that
+// skips the residual FilterIter for a covered field (indexCoversFilter,
+// indexScanCoversFilter and the verify chain in the planner). IndexBounds
+// is only contracted to be a SUPERSET; three predicates widen it:
+//
+//   - $elemMatch: element-level or re-keyed sub-field bounds — a scalar, or
+//     an object carrying the value, sits inside them without matching;
+//   - $type null: a missing field and an empty array are indexed under the
+//     null key, and Ok rejects both;
+//   - $regex beyond a whole anchored literal: the prefix range admits every
+//     continuation, the pattern only some (^abc$, ^ab.*c, ^a\w).
+//
+// A Key holding any of them anywhere in f must keep its residual filter.
+// Multi-predicate conjunctions widen too and are screened separately by
+// predicate count.
+func IndexBoundsExact(f Filter) bool {
+	return !FilterTreeAny(f, func(f Filter) bool {
+		switch ft := f.(type) {
+		case ElemMatch, *ElemMatch:
+			return true
+		case TypeFilter:
+			return ft.Type == anyenc.TypeNull
+		case *TypeFilter:
+			return ft.Type == anyenc.TypeNull
+		case Regexp:
+			_, complete := ft.literalPrefix()
+			return !complete
+		case *Regexp:
+			_, complete := ft.literalPrefix()
+			return !complete
+		}
+		return false
+	})
+}
+
 // presenceNullProbe is an explicit JSON null used by GuaranteesPresence to test
 // whether a predicate rejects a present-but-null value, as distinct from a
 // missing field (which probes as a nil *anyenc.Value).

--- a/query/filter.go
+++ b/query/filter.go
@@ -1345,13 +1345,10 @@ func (r Regexp) Ok(v *anyenc.Value, buf *syncpool.DocBuffer) bool {
 		return false
 	}
 	if v.Type() == anyenc.TypeArray {
+		// Any string element may match; other elements have no text.
 		vals, _ := v.Array()
 		for _, val := range vals {
-			exp, err := val.StringBytes()
-			if err != nil {
-				return false
-			}
-			if r.Regexp.Match(exp) {
+			if exp, err := val.StringBytes(); err == nil && r.Regexp.Match(exp) {
 				return true
 			}
 		}

--- a/query/filter_test.go
+++ b/query/filter_test.go
@@ -600,6 +600,40 @@ func TestRegexp_LiteralPrefix(t *testing.T) {
 	}
 }
 
+// TestIndexBoundsExact pins which predicates the planner may treat as
+// exactly represented by their index bounds (residual filter elidable).
+func TestIndexBoundsExact(t *testing.T) {
+	for cond, exact := range map[string]bool{
+		`{"a":1}`:                                 true,
+		`{"a":null}`:                              true,
+		`{"a":{"$in":[1,null]}}`:                  true,
+		`{"a":{"$gt":1}}`:                         true,
+		`{"a":{"$ne":1}}`:                         true,
+		`{"a":{"$gte":1,"$lte":2}}`:               true, // widened by count, screened by predicate count
+		`{"a":{"$type":"string"}}`:                true,
+		`{"a":{"$type":"array"}}`:                 true,
+		`{"a":{"$type":"null"}}`:                  false,
+		`{"a":{"$regex":"^ab"}}`:                  true,
+		`{"a":{"$regex":"^ab\\.c"}}`:              true,
+		`{"a":{"$regex":"^abc$"}}`:                false,
+		`{"a":{"$regex":"^ab.*c"}}`:               false,
+		`{"a":{"$regex":"^ab[cz]"}}`:              false,
+		`{"a":{"$regex":"^a\\w"}}`:                false,
+		`{"a":{"$regex":"ab"}}`:                   false,
+		`{"a":{"$regex":"^ab","$options":"i"}}`:   false,
+		`{"a":{"$elemMatch":{"$gt":1}}}`:          false,
+		`{"a":{"$elemMatch":{"b":1}}}`:            false,
+		`{"a":{"$all":[{"$elemMatch":{"b":1}}]}}`: false,
+		`{"a":{"$not":{"$regex":"^ab.*c"}}}`:      false,
+	} {
+		f, err := ParseCondition(cond)
+		require.NoError(t, err, cond)
+		k, ok := f.(Key)
+		require.True(t, ok, cond)
+		assert.Equal(t, exact, IndexBoundsExact(k.Filter), cond)
+	}
+}
+
 func TestSize(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		f, err := ParseCondition(`{"name":{"$size": 2}}`)

--- a/query/filter_test.go
+++ b/query/filter_test.go
@@ -461,6 +461,9 @@ func TestRegexp(t *testing.T) {
 		assert.True(t, f.Ok(anyenc.MustParseJson(`{"name": ["A", "B", "C"]}`), nil))
 		assert.False(t, f.Ok(anyenc.MustParseJson(`{"name": ["baaa"]}`), nil))
 		assert.True(t, f.Ok(anyenc.MustParseJson(`{"name": ["baaa", "a"]}`), nil))
+		// A non-string element is skipped, not a rejection of the array.
+		assert.True(t, f.Ok(anyenc.MustParseJson(`{"name": [1, null, "a"]}`), nil))
+		assert.False(t, f.Ok(anyenc.MustParseJson(`{"name": [1, null]}`), nil))
 	})
 	t.Run("ok - number", func(t *testing.T) {
 		f, err := ParseCondition(`{"name":{"$regex": "^a(?i)"}}`)

--- a/query/filter_test.go
+++ b/query/filter_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"bytes"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -593,6 +594,8 @@ func TestRegexp_LiteralPrefix(t *testing.T) {
 		{`(?i)^ab`, "", false},
 		{`^(?i)ab`, "", false},
 		{`(?m)^ab`, "", false},
+		{`^a\x{FFFD}`, "", false},
+		{`^\x{FFFD}`, "", false},
 	} {
 		prefix, complete := literalPrefix(tc.pattern)
 		assert.Equal(t, tc.prefix, prefix, "prefix of %s", tc.pattern)
@@ -601,37 +604,52 @@ func TestRegexp_LiteralPrefix(t *testing.T) {
 }
 
 // TestIndexBoundsExact pins which predicates the planner may treat as
-// exactly represented by their index bounds (residual filter elidable).
+// exactly represented by their index bounds (residual filter elidable),
+// ascending and on a reverse-flagged field.
 func TestIndexBoundsExact(t *testing.T) {
-	for cond, exact := range map[string]bool{
-		`{"a":1}`:                                 true,
-		`{"a":null}`:                              true,
-		`{"a":{"$in":[1,null]}}`:                  true,
-		`{"a":{"$gt":1}}`:                         true,
-		`{"a":{"$ne":1}}`:                         true,
-		`{"a":{"$gte":1,"$lte":2}}`:               true, // widened by count, screened by predicate count
-		`{"a":{"$type":"string"}}`:                true,
-		`{"a":{"$type":"array"}}`:                 true,
-		`{"a":{"$type":"null"}}`:                  false,
-		`{"a":{"$regex":"^ab"}}`:                  true,
-		`{"a":{"$regex":"^ab\\.c"}}`:              true,
-		`{"a":{"$regex":"^abc$"}}`:                false,
-		`{"a":{"$regex":"^ab.*c"}}`:               false,
-		`{"a":{"$regex":"^ab[cz]"}}`:              false,
-		`{"a":{"$regex":"^a\\w"}}`:                false,
-		`{"a":{"$regex":"ab"}}`:                   false,
-		`{"a":{"$regex":"^ab","$options":"i"}}`:   false,
-		`{"a":{"$elemMatch":{"$gt":1}}}`:          false,
-		`{"a":{"$elemMatch":{"b":1}}}`:            false,
-		`{"a":{"$all":[{"$elemMatch":{"b":1}}]}}`: false,
-		`{"a":{"$not":{"$regex":"^ab.*c"}}}`:      false,
+	for cond, want := range map[string][2]bool{
+		`{"a":1}`:                                 {true, true},
+		`{"a":null}`:                              {true, true},
+		`{"a":{"$in":[1,null]}}`:                  {true, true},
+		`{"a":{"$gt":1}}`:                         {true, true},
+		`{"a":{"$ne":1}}`:                         {true, true},
+		`{"a":{"$gte":1,"$lte":2}}`:               {true, true}, // widened by count, screened by predicate count
+		`{"a":{"$type":"string"}}`:                {true, true},
+		`{"a":{"$type":"array"}}`:                 {true, true},
+		`{"a":{"$type":"null"}}`:                  {false, false},
+		`{"a":{"$regex":"^ab"}}`:                  {true, false},
+		`{"a":{"$regex":"^ab\\.c"}}`:              {true, false},
+		`{"a":{"$regex":"^abc$"}}`:                {false, false},
+		`{"a":{"$regex":"^ab.*c"}}`:               {false, false},
+		`{"a":{"$regex":"^ab[cz]"}}`:              {false, false},
+		`{"a":{"$regex":"^a\\w"}}`:                {false, false},
+		`{"a":{"$regex":"ab"}}`:                   {false, false},
+		`{"a":{"$regex":"^ab","$options":"i"}}`:   {false, false},
+		`{"a":{"$elemMatch":{"$gt":1}}}`:          {false, false},
+		`{"a":{"$elemMatch":{"b":1}}}`:            {false, false},
+		`{"a":{"$all":[{"$elemMatch":{"b":1}}]}}`: {false, false},
+		`{"a":{"$not":{"$gt":1}}}`:                {false, false},
+		`{"a":{"$exists":true}}`:                  {false, false},
+		`{"a":{"$size":2}}`:                       {false, false},
 	} {
 		f, err := ParseCondition(cond)
 		require.NoError(t, err, cond)
 		k, ok := f.(Key)
 		require.True(t, ok, cond)
-		assert.Equal(t, exact, IndexBoundsExact(k.Filter), cond)
+		assert.Equal(t, want[0], IndexBoundsExact(k.Filter, false), "%s ascending", cond)
+		assert.Equal(t, want[1], IndexBoundsExact(k.Filter, true), "%s reverse", cond)
 	}
+}
+
+// A Regexp built by hand carries $options only in the Options field, so the
+// seek prefix must screen i and m from there.
+func TestRegexp_HandBuiltOptions(t *testing.T) {
+	r := Regexp{Regexp: regexp.MustCompile("^ab"), Options: "i"}
+	assert.Empty(t, r.IndexBounds("a", nil))
+	assert.False(t, IndexBoundsExact(r, false))
+	r = Regexp{Regexp: regexp.MustCompile("^ab"), Options: "s"}
+	assert.Len(t, r.IndexBounds("a", nil), 1)
+	assert.True(t, IndexBoundsExact(r, false))
 }
 
 func TestSize(t *testing.T) {

--- a/query/filter_test.go
+++ b/query/filter_test.go
@@ -534,27 +534,70 @@ func TestRegexp(t *testing.T) {
 		assert.Len(t, bounds, 1)
 		assert.Equal(t, `"prefix.test"`, append(bounds[0].Start, 0).String())
 	})
-	t.Run("index: ^prefix\\.test{1}* - return prefix.test", func(t *testing.T) {
+	t.Run("index: unmatched brace is literal, * binds it", func(t *testing.T) {
 		f, err := ParseCondition(`{"name":{"$regex": "^prefix\.test{a-zA-z}*"}}`)
 		require.NoError(t, err)
 		bounds := f.IndexBounds("name", Bounds{})
 		assert.Len(t, bounds, 1)
-		assert.Equal(t, `"prefix.test"`, append(bounds[0].Start, 0).String())
+		assert.Equal(t, `"prefix.test{a-zA-z"`, append(bounds[0].Start, 0).String())
 	})
-	t.Run("index: ^prefix+ - return prefix", func(t *testing.T) {
+	t.Run("index: ^prefix+ - x+ keeps one x", func(t *testing.T) {
 		f, err := ParseCondition(`{"name":{"$regex": "^prefix+"}}`)
 		require.NoError(t, err)
 		bounds := f.IndexBounds("name", Bounds{})
 		assert.Len(t, bounds, 1)
 		assert.Equal(t, `"prefix"`, append(bounds[0].Start, 0).String())
 	})
-	t.Run("index: ^\\.a* - return prefix", func(t *testing.T) {
+	t.Run("index: ^\\.a* - * drops its literal", func(t *testing.T) {
+		// "." alone matches, so the prefix stops before the quantified a.
 		f, err := ParseCondition(`{"name":{"$regex": "^\.a*"}}`)
 		require.NoError(t, err)
 		bounds := f.IndexBounds("name", Bounds{})
 		assert.Len(t, bounds, 1)
-		assert.Equal(t, `".a"`, append(bounds[0].Start, 0).String())
+		assert.Equal(t, `"."`, append(bounds[0].Start, 0).String())
 	})
+}
+
+// TestRegexp_LiteralPrefix pins the seek prefix and its exactness for the
+// pattern shapes the syntax walk must read as the engine does. An
+// under-approximating prefix drops rows the residual filter can never
+// recover; a prefix reported complete lets the planner elide that filter.
+func TestRegexp_LiteralPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		pattern  string
+		prefix   string
+		complete bool
+	}{
+		{`^abc`, "abc", true},
+		{`^a`, "a", true},
+		{`^ab\.c`, "ab.c", true},
+		{`^\Qa.b\E`, "a.b", true},
+		{`^a\x41`, "aA", true},
+		{`^aé`, "aé", true},
+		{`(?s)^ab`, "ab", true},
+		{`^abc$`, "abc", false},
+		{`^ab.*c`, "ab", false},
+		{`^ab[cz]`, "ab", false},
+		{`^a(b|x)`, "a", false},
+		{`^abc(?:d)?`, "abc", false},
+		{`^ab*`, "a", false},
+		{`^ab?`, "a", false},
+		{`^ab+`, "ab", false},
+		{`^ab{0,1}c`, "a", false},
+		{`^ab{2}`, "a", false},
+		{`^a\w{2}$`, "a", false},
+		{`^\d+`, "", false},
+		{`^ab|^xy`, "", false},
+		{`abc`, "", false},
+		{`^`, "", false},
+		{`(?i)^ab`, "", false},
+		{`^(?i)ab`, "", false},
+		{`(?m)^ab`, "", false},
+	} {
+		prefix, complete := literalPrefix(tc.pattern)
+		assert.Equal(t, tc.prefix, prefix, "prefix of %s", tc.pattern)
+		assert.Equal(t, tc.complete, complete, "complete for %s", tc.pattern)
+	}
 }
 
 func TestSize(t *testing.T) {


### PR DESCRIPTION
Fixes SYN-225 and SYN-227, and a third `$regex` seek bug found while planning them.

## The bugs

- **SYN-225** — `$regex` seeks the prefix range of its anchored literal, a superset of the matches for any pattern beyond that literal. The covering check treated every bounded field as exactly represented, so an ordered compound scan whose trailing field is checked on the index key elided the residual filter and `Iter` returned rows the pattern rejects (`^abc$` returned `abcd`). `Count` kept the filter, so the two disagreed.
- **SYN-227** — `$type: "null"` seeks the null key, which a missing field and an empty array also occupy while `Ok` rejects both. On a descending index the reverse transform folds the bare tag onto its successor, `AllBoundsFixed` read the result as a point lookup, and the covering count skipped the filter: `Count` was over by every missing-field document. The same elision shape as SYN-225 also broke `Iter` on a compound index, which the ticket did not record.
- **Unfiled** — the literal-prefix extractor read every escaped character as a literal, let a quantifier keep the literal it binds, and cut a top-level alternation at its left branch. Each is an under-approximating seek that drops matching rows, and the residual filter cannot recover them: `^\d+` seeked `d`, `^ab*` seeked `ab` (dropping `a`), `^ab|^xy` dropped every `xy` row.

## The fix

1. `literalPrefix` reads the seek prefix off the parsed syntax tree (`regexp/syntax`), so it means what the engine means, and reports whether the pattern is nothing but its anchored literal. `^ab+` now seeks `ab`, `^ab*` seeks `a`, `^\d+` and `^ab|^xy` seek nothing; `i` and `m` flags rule the prefix out through the tree rather than a flag screen.
2. `query.IndexBoundsExact` enumerates the widening predicates — `$elemMatch`, `$type: "null"`, a `$regex` beyond its anchored literal, and any `$regex` on a reverse-flagged field (the reverse transform pads a prefix-derived bound past its neighbours), plus the bound-less `$not`/`$nor`/`$exists`/`$size` — and the planner's `keyBoundsExact` delegates to it with the field's direction, so the covering count, the ordered-scan elision, the verify chain and the text-plan pk cover all keep the residual filter for them.
3. `Regexp.Ok` on an array skips non-string elements instead of rejecting the array (`["x", 1, "abc"]` now matches `^abc`, as Mongo does).

Contract: `docs/query-filter-contract.md`, the `$regex` item and the `$type` sentence.

## Verification

- Un-indexed oracle runs in `anyproto/any-store-tests` (companion branch of the same name, merged to its main after this PR): the regex prefix oracle reported 168 divergences on the old extractor, the elision oracles 42 without the screen, none afterwards. The `masKnownOpen` pin on the `$type null` count is gone.
- `go test ./...` and `go vet ./...` here; `TestBug*`, `TestType*`, `TestMongoArraySemantics`, reverse-prefix and exclusive-start oracle suites there.
- Review round (three Opus reviewers) folded in: the descending-index leak above (`^abc` on `{-a, z}` returned `abd`), a literal U+FFFD prefix (matches any invalid byte) yields no seek, a hand-built `Regexp` honors `Options` for its prefix, and the `Ok` array fix. An `AllBoundsFixed` type-edge guard was dropped after the review measured it demoting `$type`/bracket-edge seeks to full scans without adding correctness.
- Behavior change beyond the fixes: an unmatched `{` in a pattern is now a literal in the seek prefix (as RE2 reads it), and non-literal regexes on the elision shape pay one filter evaluation per fetched row, which the correct result requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhnKPWP3AvB5MeNBLodYBX


