### PR TITLE
chore(cli): bump any-store to v2.1.0

### DIFF
--- a/cmd/any-store-cli2/go.mod
+++ b/cmd/any-store-cli2/go.mod
@@ -3,7 +3,7 @@ module github.com/anyproto/any-store/cmd/any-store-cli2/v2
 go 1.25.0
 
 require (
-	github.com/anyproto/any-store/v2 v2.0.2
+	github.com/anyproto/any-store/v2 v2.1.0
 	github.com/fatih/color v1.19.0
 	github.com/peterh/liner v1.2.2
 	github.com/robertkrimen/otto v0.5.1

--- a/cmd/any-store-cli2/go.sum
+++ b/cmd/any-store-cli2/go.sum
@@ -1,5 +1,5 @@
-github.com/anyproto/any-store/v2 v2.0.2 h1:SFJfgl/1/J9CZk/Ps0Jryx6YNcbIzran7Dv737WAeGU=
-github.com/anyproto/any-store/v2 v2.0.2/go.mod h1:Mw/A48qIY3anKfv4jaiTEvv/JhuMpPEp6VuxHn6lAeM=
+github.com/anyproto/any-store/v2 v2.1.0 h1:PsR+p7lMl6uR+Ej1HjKMq+shv3MBBpIDt5qeqWBSdrw=
+github.com/anyproto/any-store/v2 v2.1.0/go.mod h1:Mw/A48qIY3anKfv4jaiTEvv/JhuMpPEp6VuxHn6lAeM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=


### PR DESCRIPTION
Pins the CLI to any-store v2.1.0 (exact-bounds residual elision for `$regex` and `$type null`, sound `$regex` seek prefix — #184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhnKPWP3AvB5MeNBLodYBX
